### PR TITLE
feat(core): GFM task list conversion + tight list serialization

### DIFF
--- a/packages/core/src/converters/md-to-pm.test.ts
+++ b/packages/core/src/converters/md-to-pm.test.ts
@@ -107,6 +107,70 @@ describe('markdownToDoc', () => {
     })
   })
 
+  it('converts a task list item, keeping its text', () => {
+    expect(markdownToDoc(editor, '- [ ] todo').toJSON()).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'list',
+          attrs: {
+            kind: 'task',
+            order: null,
+            checked: false,
+            collapsed: false,
+          },
+          content: [{ type: 'paragraph', content: [{ type: 'text', text: 'todo' }] }],
+        },
+      ],
+    })
+  })
+
+  it('marks a checked task list item', () => {
+    expect(markdownToDoc(editor, '- [x] done').toJSON()).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'list',
+          attrs: {
+            kind: 'task',
+            order: null,
+            checked: true,
+            collapsed: false,
+          },
+          content: [{ type: 'paragraph', content: [{ type: 'text', text: 'done' }] }],
+        },
+      ],
+    })
+  })
+
+  it('mixes task and plain items in one bullet list', () => {
+    const doc = markdownToDoc(editor, '- [x] done\n- plain').toJSON() as {
+      content: Array<{ attrs: { kind: string; checked: boolean } }>
+    }
+    expect(doc.content.map((item) => item.attrs.kind)).toEqual(['task', 'bullet'])
+    expect(doc.content.map((item) => item.attrs.checked)).toEqual([true, false])
+  })
+
+  it('keeps a task marker in an ordered list as literal text', () => {
+    // The flat-list schema has a single `kind`, so an ordered item cannot
+    // also be a task; the marker stays in the text and round-trips verbatim.
+    expect(markdownToDoc(editor, '1. [x] done').toJSON()).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'list',
+          attrs: {
+            kind: 'ordered',
+            order: 1,
+            checked: false,
+            collapsed: false,
+          },
+          content: [{ type: 'paragraph', content: [{ type: 'text', text: '[x] done' }] }],
+        },
+      ],
+    })
+  })
+
   it('converts a fenced code block with language', () => {
     expect(markdownToDoc(editor, '```js\nconsole.log(1)\n```').toJSON()).toEqual({
       type: 'doc',

--- a/packages/core/src/converters/md-to-pm.ts
+++ b/packages/core/src/converters/md-to-pm.ts
@@ -70,6 +70,12 @@ function convertBlock(editor: TypedEditor, cursor: TreeCursor, text: string): Pr
       return [editor.nodes.horizontalRule()]
     case LEZER_NODE_IDS.Table:
       return [convertTable(editor, cursor, text)]
+    case LEZER_NODE_IDS.Task:
+      // Reached only for tasks inside ordered lists (bullet lists convert
+      // the Task in `convertListItem`). The flat-list schema has a single
+      // `kind`, so an ordered item cannot also be a task - keep the
+      // `[x]` marker as literal paragraph text so it round-trips verbatim.
+      return [convertParagraph(editor, cursor, text)]
     default:
       return []
   }
@@ -172,22 +178,60 @@ function convertListItem(
   order: number,
 ): ProseMirrorNode {
   const content: ProseMirrorNode[] = []
+  let taskChecked: boolean | null = null
   if (cursor.firstChild()) {
     do {
       if (cursor.type.id === LEZER_NODE_IDS.ListMark) continue
+      if (kind === 'bullet' && cursor.type.id === LEZER_NODE_IDS.Task) {
+        const task = convertTask(editor, cursor, text)
+        taskChecked = task.checked
+        content.push(task.paragraph)
+        continue
+      }
       content.push(...convertBlock(editor, cursor, text))
     } while (cursor.nextSibling())
     cursor.parent()
   }
   return editor.nodes.list(
     {
-      kind,
+      kind: taskChecked === null ? kind : 'task',
       order: kind === 'ordered' ? order : null,
-      checked: false,
+      checked: taskChecked ?? false,
       collapsed: false,
     },
     content,
   )
+}
+
+interface ConvertedTask {
+  checked: boolean
+  paragraph: ProseMirrorNode
+}
+
+/**
+ * Convert a GFM `Task` leaf (`[ ] text` / `[x] text`, after the list mark)
+ * into its checked state plus a paragraph holding the text. Only the single
+ * space separating the `TaskMarker` from the text is dropped - it is
+ * re-emitted by `docToMarkdown`'s `- [ ] ` marker, keeping any extra
+ * whitespace byte-identical through a round-trip.
+ */
+function convertTask(editor: TypedEditor, cursor: TreeCursor, text: string): ConvertedTask {
+  let checked = false
+  let contentStart = cursor.from
+  const contentEnd = cursor.to
+  if (cursor.firstChild()) {
+    if (cursor.type.id === LEZER_NODE_IDS.TaskMarker) {
+      checked = text.slice(cursor.from, cursor.to).toLowerCase().includes('x')
+      contentStart = cursor.to
+    }
+    cursor.parent()
+  }
+  let content = text.slice(contentStart, contentEnd)
+  if (content.startsWith(' ')) content = content.slice(1)
+  return {
+    checked,
+    paragraph: content === '' ? editor.nodes.paragraph() : editor.nodes.paragraph(content),
+  }
 }
 
 function convertCodeBlock(editor: TypedEditor, cursor: TreeCursor, text: string): ProseMirrorNode {

--- a/packages/core/src/converters/pm-to-md.test.ts
+++ b/packages/core/src/converters/pm-to-md.test.ts
@@ -53,24 +53,62 @@ describe('docToMarkdown', () => {
     expect(docToMarkdown(node)).toBe('> quoted text\n')
   })
 
-  it('serializes a bullet list', () => {
+  it('serializes a bullet list tight', () => {
     const item = (text: string): NodeJSON => ({
       type: 'list',
       attrs: { kind: 'bullet', order: null, checked: false, collapsed: false },
       content: [paragraph(text)],
     })
     const node = docFromJSON(wrapInDoc(item('one'), item('two')))
-    expect(docToMarkdown(node)).toBe('- one\n\n- two\n')
+    expect(docToMarkdown(node)).toBe('- one\n- two\n')
   })
 
-  it('serializes an ordered list with start number', () => {
+  it('serializes an ordered list tight, with start number', () => {
     const item = (text: string, order: number): NodeJSON => ({
       type: 'list',
       attrs: { kind: 'ordered', order, checked: false, collapsed: false },
       content: [paragraph(text)],
     })
     const node = docFromJSON(wrapInDoc(item('five', 5), item('six', 5)))
-    expect(docToMarkdown(node)).toBe('5. five\n\n5. six\n')
+    expect(docToMarkdown(node)).toBe('5. five\n5. six\n')
+  })
+
+  it('serializes task list items with GFM markers', () => {
+    const item = (text: string, checked: boolean): NodeJSON => ({
+      type: 'list',
+      attrs: { kind: 'task', order: null, checked, collapsed: false },
+      content: [paragraph(text)],
+    })
+    const node = docFromJSON(wrapInDoc(item('todo', false), item('done', true)))
+    expect(docToMarkdown(node)).toBe('- [ ] todo\n- [x] done\n')
+  })
+
+  it('serializes a list loose when an item holds two blocks', () => {
+    const node = docFromJSON(
+      wrapInDoc(
+        {
+          type: 'list',
+          attrs: { kind: 'bullet', order: null, checked: false, collapsed: false },
+          content: [paragraph('first'), paragraph('second')],
+        },
+        {
+          type: 'list',
+          attrs: { kind: 'bullet', order: null, checked: false, collapsed: false },
+          content: [paragraph('third')],
+        },
+      ),
+    )
+    expect(docToMarkdown(node)).toBe('- first\n\n  second\n\n- third\n')
+  })
+
+  it('keeps a blank line between a tight list and the next block', () => {
+    const item: NodeJSON = {
+      type: 'list',
+      attrs: { kind: 'bullet', order: null, checked: false, collapsed: false },
+      content: [paragraph('item')],
+    }
+    const node = docFromJSON(wrapInDoc(item, paragraph('after')))
+    expect(docToMarkdown(node)).toBe('- item\n\nafter\n')
   })
 
   it('serializes a fenced code block with language', () => {

--- a/packages/core/src/converters/pm-to-md.ts
+++ b/packages/core/src/converters/pm-to-md.ts
@@ -87,6 +87,16 @@ class MdOut {
   }
 
   /**
+   * Cancel the blank line deferred by the last `closeBlock`, so the next
+   * write starts directly on the following line. Used between the blocks of
+   * a tight list, where markdown separates items (and an item's paragraph
+   * from its nested list) with a single newline.
+   */
+  suppressBlank(): void {
+    this.deferredBlankPrefix = null
+  }
+
+  /**
    * Run `fn` with `linePrefix` extended by `continuation`.
    * If `firstLine` is given, it replaces the prefix on the NEXT line only -
    * used for list items where the marker (`- `) only appears on line 1.
@@ -114,7 +124,11 @@ class MdOut {
   private emitDeferredBlankLine(): void {
     const prefix = this.deferredBlankPrefix
     if (prefix === null) return
-    this.parts.push(prefix, '\n')
+    // Trim the prefix so blank lines carry no trailing whitespace: a list's
+    // "  " continuation becomes an empty line (the following indent is what
+    // keeps the item together), while a blockquote's "> " stays ">" - the
+    // bare marker is required to hold the quote across the blank line.
+    this.parts.push(prefix.trimEnd(), '\n')
     this.deferredBlankPrefix = null
   }
 }
@@ -144,7 +158,7 @@ function emit(node: ProseMirrorNode, out: MdOut): void {
       out.closeBlock()
       return
     case 'list':
-      emitList(node, out)
+      emitList(node, out, isTightItem(node))
       return
     case 'codeBlock':
       emitCodeBlock(node, out)
@@ -162,9 +176,61 @@ function emit(node: ProseMirrorNode, out: MdOut): void {
   }
 }
 
-function emitBlockChildren(node: ProseMirrorNode, out: MdOut): void {
+/**
+ * Emit block-level children. Consecutive `list` children form one markdown
+ * list ("run") whose tightness is decided once for the whole run, matching
+ * CommonMark's list-wide loose/tight semantics.
+ *
+ * `tightItem` is true when `node` is a list item inside a tight run: its
+ * blocks (a paragraph followed by nested lists) are then separated by single
+ * newlines instead of blank lines.
+ */
+function emitBlockChildren(node: ProseMirrorNode, out: MdOut, tightItem = false): void {
   const count = node.childCount
-  for (let i = 0; i < count; i++) emit(node.child(i), out)
+  let index = 0
+  while (index < count) {
+    const child = node.child(index)
+    if (child.type.name !== 'list') {
+      if (tightItem && index > 0) out.suppressBlank()
+      emit(child, out)
+      index++
+      continue
+    }
+    let runEnd = index + 1
+    while (runEnd < count && node.child(runEnd).type.name === 'list') runEnd++
+    const tightRun = isTightRun(node, index, runEnd)
+    for (let item = index; item < runEnd; item++) {
+      const isRunStart = item === index
+      if (isRunStart ? tightItem && index > 0 : tightRun) out.suppressBlank()
+      emitList(node.child(item), out, tightRun)
+    }
+    index = runEnd
+  }
+}
+
+/**
+ * A run of sibling `list` nodes serializes tight iff every item is "simple":
+ * at most one leading paragraph, then only nested lists. Any other shape
+ * (multiple paragraphs, a blockquote, a code block, …) needs blank-line
+ * separation inside the item, which per CommonMark makes the whole list
+ * loose.
+ */
+function isTightRun(parent: ProseMirrorNode, from: number, to: number): boolean {
+  for (let i = from; i < to; i++) {
+    if (!isTightItem(parent.child(i))) return false
+  }
+  return true
+}
+
+function isTightItem(item: ProseMirrorNode): boolean {
+  const count = item.childCount
+  for (let i = 0; i < count; i++) {
+    const child = item.child(i)
+    if (child.type.name === 'list') continue
+    if (child.type.name === 'paragraph' && i === 0) continue
+    return false
+  }
+  return true
 }
 
 /**
@@ -186,7 +252,7 @@ function emitInlineChildren(node: ProseMirrorNode, out: MdOut): void {
 // List
 // ─────────────────────────────────────────────────────────────────────
 
-function emitList(node: ProseMirrorNode, out: MdOut): void {
+function emitList(node: ProseMirrorNode, out: MdOut, tight: boolean): void {
   // prosekit's `list` node is a SINGLE item; sibling `list` nodes form the
   // larger markdown list.
   const attrs = node.attrs as {
@@ -203,8 +269,10 @@ function emitList(node: ProseMirrorNode, out: MdOut): void {
           : '- [ ] '
         : '- ' // bullet | toggle
 
-  const continuation = ' '.repeat(marker.length)
-  out.withPrefix(continuation, marker, () => emitBlockChildren(node, out))
+  // For a task item the `[ ] ` checkbox is list-item CONTENT in GFM terms,
+  // not part of the marker, so continuation lines align to the `- ` width.
+  const continuation = ' '.repeat(attrs.kind === 'task' ? 2 : marker.length)
+  out.withPrefix(continuation, marker, () => emitBlockChildren(node, out, tight))
   out.closeBlock()
 }
 

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -1,0 +1,60 @@
+import { createEditor } from '@prosekit/core'
+import { describe, expect, it } from 'vitest'
+
+import { defineEditorExtension } from '../extensions/extension.ts'
+
+import { markdownToDoc } from './md-to-pm.ts'
+import { docToMarkdown } from './pm-to-md.ts'
+
+const editor = createEditor({ extension: defineEditorExtension() })
+
+function roundtrip(markdown: string): string {
+  return docToMarkdown(markdownToDoc(editor, markdown))
+}
+
+/**
+ * Byte-identity guard: `docToMarkdown(markdownToDoc(md))` must reproduce the
+ * input exactly, modulo the single trailing newline `docToMarkdown` always
+ * appends. Each case here is markdown that editor consumers (which treat
+ * markdown files as the source of truth) expect to survive a load/save cycle
+ * without a spurious diff.
+ */
+describe('markdown round-trip is byte-identical', () => {
+  const cases = [
+    // Task lists (GFM `Task` / `TaskMarker`)
+    '- [ ] todo',
+    '- [x] done',
+    '- [ ] todo\n- [x] done\n- [ ] another',
+    '- [x] done\n- plain item\n- [ ] todo',
+    '- [ ] parent\n  - [x] child',
+    '- [ ]  double-spaced text',
+    // Task marker inside an ordered list has no `task` list kind to map to;
+    // the marker survives as literal paragraph text instead.
+    '1. [x] done',
+    // Tight lists stay tight
+    '- a\n- b',
+    '- parent\n  - child',
+    '1. one\n1. two',
+    // A genuinely loose item (two blocks) keeps its blank line
+    '- a\n\n  second paragraph',
+  ]
+
+  for (const markdown of cases) {
+    it(`preserves ${JSON.stringify(markdown)}`, () => {
+      expect(roundtrip(markdown)).toBe(`${markdown}\n`)
+    })
+  }
+})
+
+describe('markdown round-trip normalizations', () => {
+  it('normalizes loose single-paragraph lists to tight', () => {
+    // Tightness is not stored in the document, so a loose list whose items
+    // could be tight comes back tight. This is the one list normalization
+    // docToMarkdown performs.
+    expect(roundtrip('- a\n\n- b')).toBe('- a\n- b\n')
+  })
+
+  it('normalizes an uppercase task marker to lowercase', () => {
+    expect(roundtrip('- [X] done')).toBe('- [x] done\n')
+  })
+})


### PR DESCRIPTION
## Problems

Two converter bugs found while integrating meowdown into a markdown-source-of-truth app:

1. **Task-list content loss (severe).** `markdownToDoc(editor, '- [ ] todo')` produced a `list` node with kind `"bullet"`, `checked: false`, and an **empty** paragraph — the text `todo` was gone, and `docToMarkdown` then serialized the document as just `"\n"`. The Lezer GFM parser emits `Task`/`TaskMarker` nodes that `convertBlock` had no case for, so the whole leaf fell through the `default` and was dropped.

2. **Loose-list normalization.** `docToMarkdown` serialized every list loose (blank line between items), so `- a\n- b` round-tripped as `- a\n\n- b\n` — a spurious diff on every save for tight-list input.

## Fixes

- **md→pm:** bullet items containing a `Task` leaf now become flat-list nodes with `kind: "task"` and `checked` read from the `TaskMarker` (the schema already supports this; `pm-to-md` already had the `- [ ] `/`- [x] ` serialization path waiting). Only the single space after the marker is dropped, so extra whitespace survives round-trips. Ordered-list task markers (`1. [x] done`) have no flat-list kind to map to, so the marker stays as literal paragraph text and round-trips verbatim.
- **pm→md:** a run of sibling `list` nodes serializes **tight** when every item is "simple" (one leading paragraph, then only nested lists), matching CommonMark's list-wide tightness; anything else stays loose. Blank separator lines inside lists no longer carry trailing continuation-indent whitespace, and task items align nested content to the `- ` width (the `[ ]` is item content in GFM terms, not marker).

Tightness is not stored in the document, so a loose list whose items are all simple normalizes to tight on the way out — pinned as a documented normalization in the new round-trip suite, alongside `[X]` → `[x]`.

## Tests

New `roundtrip.test.ts` asserts `docToMarkdown(markdownToDoc(md)) === md + '\n'` byte-identically for task lists (unchecked/checked/mixed/nested/ordered-literal), tight bullet/ordered/nested lists, and a genuinely loose two-block item; plus doc-shape tests in `md-to-pm.test.ts` and serializer tests in `pm-to-md.test.ts`. Full suite: 104 tests, typecheck, oxfmt, eslint, knip all green.

## Release

Commits are conventional (`feat` + `fix`); with `bump-minor-pre-major` release-please should cut **0.3.0** for `@meowdown/core` (and `@meowdown/react` via the node-workspace plugin) once this merges. If squash-merging, the PR title above keeps the `feat` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
