### PR TITLE
feat: support image preview

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -13,6 +13,48 @@ The editor extension binds inline-format toggles (`Mod` = Cmd on macOS, Ctrl els
 | `Mod-E`       | `editor.commands.toggleCode()`   | `` `code` ``        |
 | `Mod-Shift-X` | `editor.commands.toggleDel()`    | `~~strikethrough~~` |
 
+## Images
+
+`defineImageExtension(options)` adds two capabilities, both built on the same idea: the document never holds an image node. `![alt](src)` stays literal Markdown text, so serialization is byte-identical and there is no round-trip risk; the picture renders as a non-editable widget inline, at the image's position in the text.
+
+- **Preview**: each `![alt](src)` renders an `<img>` inline where its syntax sits, flowing with the surrounding text. A `resolveUrl` callback maps the Markdown `src` to a displayable URL (or `null` to skip rendering).
+- **Upload**: when an `upload` callback is given, pasting or dropping image files inserts a `![](blob:...)` placeholder at the caret (or the drop point) immediately, so the local image shows at once; `upload` then resolves to the final src, which is swapped in.
+
+Upload reuses ProseKit's `UploadTask` (from `@prosekit/extensions/file`): the temporary `blob:` object URL is the placeholder's src and its unique identity. When the upload finishes, the document is re-scanned for that object URL and the src is swapped in place, so concurrent edits, undo, and even duplicating the placeholder are handled with no stored position.
+
+```ts
+import { defineImageExtension } from '@meowdown/core'
+import { union } from '@prosekit/core'
+
+const extension = union(
+  defineEditorExtension(),
+  defineImageExtension({
+    resolveUrl: (src) => (src.startsWith('assets/') ? `/files/${src}` : src),
+    upload: async (file) => {
+      const path = await saveToDisk(file)
+      return path
+    },
+    onUploadError: ({ error, file }) => console.error('upload failed', file.name, error),
+  }),
+)
+```
+
+| Option          | Type                                        | Default           | Description                                                                                                            |
+| --------------- | ------------------------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `resolveUrl`    | `(src: string) => string \| null`           | safe pass-through | Maps a Markdown `src` to a displayable URL, or `null` to not render.                                                   |
+| `upload`        | `(file: File) => string \| Promise<string>` | (none)            | Persists a pasted/dropped image and resolves to the src to embed. Reject to fail. Omit to disable paste/drop handling. |
+| `canUpload`     | `(file: File) => boolean`                   | accepts `image/*` | Decides which files to upload, before any placeholder is inserted (e.g. a size limit).                                 |
+| `onUploadError` | `({ error, file }) => void`                 | `console.error`   | Called when `upload` throws or rejects.                                                                                |
+
+The default `resolveUrl` (`defaultResolveImageUrl`, also exported) is a strict allow-list: it passes through `data:image/*`, `http:`, `https:`, and `blob:` URLs and returns `null` for everything else, so remote and demo images render out of the box while relative paths and `javascript:` URLs never do. Relative paths only render once the host supplies a `resolveUrl` that knows what they mean.
+
+Paste/drop notes: a clipboard carrying image files is consumed entirely (any text/html alongside the bitmap is ignored); `canUpload` filters files before insertion; a failed upload removes its placeholder (a `blob:` URL must never persist into saved Markdown); remaining files in the same paste/drop continue even if one fails. While an upload is in flight the document briefly holds a `blob:` src, so serializing mid-upload captures it until the upload completes.
+
+Customize the preview via these variables:
+
+- `--meowdown-image-max-height`: maximum rendered image height (default `28rem`).
+- `--meowdown-image-radius`: image corner radius (default `0.6rem`).
+
 ## Styling
 
 `@meowdown/core/style.css` ships a default editor theme. Colors use `light-dark()`, so they follow the page's `color-scheme` (set `color-scheme: light dark` on `:root` for automatic dark mode). Customize by overriding these variables on `:root` or any ancestor:

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -43,6 +43,11 @@ describe('markdown round-trip is byte-identical', () => {
     '#meow starts the line',
     '- [ ] #todo item',
     '> quoted #tag',
+    // Images are plain text to the converters (preview is a decoration)
+    '![alt](cat.png)',
+    '![](cat.png)',
+    'see ![alt](https://example.com/cat.png) inline',
+    '![a](1.png) and ![b](2.png)',
     // Wikilinks are plain text to the converters
     'see [[note]]',
     '[[note]] starts the line',

--- a/packages/core/src/extensions/find-inline-images.test.ts
+++ b/packages/core/src/extensions/find-inline-images.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+
+import { findInlineImages } from './find-inline-images.ts'
+
+describe('findInlineImages', () => {
+  it('finds a single image with exact alt, src, and span', () => {
+    const text = '![cat](cat.png)'
+    expect(findInlineImages(text)).toEqual([
+      { from: 0, to: text.length, alt: 'cat', src: 'cat.png' },
+    ])
+  })
+
+  it('finds an image embedded in surrounding text', () => {
+    const text = 'see ![cat](cat.png) here'
+    const [image] = findInlineImages(text)
+    expect(text.slice(image.from, image.to)).toBe('![cat](cat.png)')
+    expect(image.alt).toBe('cat')
+    expect(image.src).toBe('cat.png')
+  })
+
+  it('finds multiple images in document order', () => {
+    const images = findInlineImages('![a](1.png) and ![b](2.png)')
+    expect(images.map((image) => image.src)).toEqual(['1.png', '2.png'])
+    expect(images.map((image) => image.alt)).toEqual(['a', 'b'])
+    expect(images[0].from).toBeLessThan(images[1].from)
+  })
+
+  it('handles an empty alt', () => {
+    expect(findInlineImages('![](x.png)')).toEqual([{ from: 0, to: 10, alt: '', src: 'x.png' }])
+  })
+
+  it('excludes the title, reading only the URL as src', () => {
+    const [image] = findInlineImages('![a](b.png "title")')
+    expect(image.src).toBe('b.png')
+    expect(image.alt).toBe('a')
+  })
+
+  it('finds an image nested inside emphasis', () => {
+    const [image] = findInlineImages('*see ![a](b.png)*')
+    expect(image).toMatchObject({ alt: 'a', src: 'b.png' })
+  })
+
+  it('returns the raw label slice when the alt contains markdown', () => {
+    const [image] = findInlineImages('![*x*](y.png)')
+    expect(image.alt).toBe('*x*')
+  })
+
+  it('ignores an image inside inline code', () => {
+    expect(findInlineImages('`![a](b.png)`')).toEqual([])
+  })
+
+  it('ignores an escaped image', () => {
+    expect(findInlineImages(String.raw`\![a](b.png)`)).toEqual([])
+  })
+
+  it('ignores a plain link', () => {
+    expect(findInlineImages('[a](b.png)')).toEqual([])
+  })
+
+  it('ignores a reference-style image', () => {
+    expect(findInlineImages('![a][ref]')).toEqual([])
+  })
+
+  it('ignores an unclosed image', () => {
+    expect(findInlineImages('![unclosed')).toEqual([])
+  })
+
+  it('ignores an image with an empty src', () => {
+    expect(findInlineImages('![]()')).toEqual([])
+  })
+})

--- a/packages/core/src/extensions/find-inline-images.ts
+++ b/packages/core/src/extensions/find-inline-images.ts
@@ -1,0 +1,47 @@
+import type { InlineElement } from '../lezer/inline.ts'
+import { collectInlineElements, parseInline } from '../lezer/inline.ts'
+import { LEZER_NODE_IDS } from '../lezer/node-ids.ts'
+
+/** One `![alt](src)` occurrence, offsets relative to the block text. */
+export interface InlineImage {
+  from: number
+  to: number
+  alt: string
+  src: string
+}
+
+/** Every renderable image in one textblock's inline text, in document order. */
+export function findInlineImages(text: string): InlineImage[] {
+  const out: InlineImage[] = []
+  const nodes = collectInlineElements(parseInline(text), isImage)
+  for (const node of nodes) {
+    const image = imageFromNode(node, text)
+    if (image) out.push(image)
+  }
+  return out
+}
+
+function isImage(node: InlineElement): boolean {
+  return node.type === LEZER_NODE_IDS.Image
+}
+
+function imageFromNode(node: InlineElement, text: string): InlineImage | null {
+  // Lezer children: LinkMark `![`, label..., LinkMark `]`, LinkMark `(`, URL, LinkMark `)`.
+  let labelFrom = -1
+  let labelTo = -1
+  let markCount = 0
+  let urlNode: InlineElement | null = null
+  for (const child of node.children) {
+    if (child.type === LEZER_NODE_IDS.LinkMark) {
+      markCount++
+      if (markCount === 1) labelFrom = child.to
+      if (markCount === 2) labelTo = child.from
+    } else if (child.type === LEZER_NODE_IDS.URL && urlNode === null) {
+      urlNode = child
+    }
+  }
+  if (!urlNode || labelFrom < 0 || labelTo < labelFrom) return null
+  const src = text.slice(urlNode.from, urlNode.to)
+  if (!src) return null
+  return { from: node.from, to: node.to, alt: text.slice(labelFrom, labelTo), src }
+}

--- a/packages/core/src/extensions/image-preview.test.ts
+++ b/packages/core/src/extensions/image-preview.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { page } from 'vitest/browser'
 
-import { docToMarkdown } from '../converters/pm-to-md.ts'
 import { setupFixture, type Fixture } from '../testing/index.ts'
 
 import { defineImagePreview } from './image-preview.ts'
@@ -100,7 +99,7 @@ describe('image preview', () => {
     const markdown = '![cat](https://example.com/cat.png)'
     fixture.set(n.doc(n.paragraph(markdown)))
     await expect.element(preview).toBeInTheDocument()
-    expect(docToMarkdown(fixture.doc)).toBe(`${markdown}\n`)
+    expect(fixture.getMarkdown()).toBe(`${markdown}\n`)
   })
 
   it('still renders the preview in hide mark mode', async () => {

--- a/packages/core/src/extensions/image-preview.test.ts
+++ b/packages/core/src/extensions/image-preview.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import { page } from 'vitest/browser'
+
+import { docToMarkdown } from '../converters/pm-to-md.ts'
+import { setupFixture, type Fixture } from '../testing/index.ts'
+
+import { defineImagePreview } from './image-preview.ts'
+import { defaultResolveImageUrl, type ImageUrlResolver } from './images.ts'
+import { defineMarkMode } from './mark-mode.ts'
+
+const preview = page.getByTestId('md-image')
+
+function setup(resolveUrl: ImageUrlResolver = defaultResolveImageUrl): Fixture {
+  const fixture = setupFixture()
+  fixture.editor.use(defineImagePreview(resolveUrl))
+  return fixture
+}
+
+describe('image preview', () => {
+  it('renders a preview widget for a block holding an image', async () => {
+    using fixture = setup()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('![cat](https://example.com/cat.png)')))
+    await expect.element(preview).toBeInTheDocument()
+    await expect
+      .element(preview.locate('img'))
+      .toHaveAttribute('src', 'https://example.com/cat.png')
+    await expect.element(preview.locate('img')).toHaveAttribute('alt', 'cat')
+  })
+
+  it('anchors the preview inline, so trailing text follows it', async () => {
+    using fixture = setup()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('before ![](https://example.com/cat.png) after')))
+    await expect.element(preview).toBeInTheDocument()
+    // The widget sits at the image's position rather than after the whole
+    // block, so the trailing text is its next sibling in the DOM.
+    expect(preview.element().nextSibling?.textContent).toContain('after')
+  })
+
+  it('removes the widget once the text stops being an image', async () => {
+    using fixture = setup()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('![cat](https://example.com/cat.png)')))
+    await expect.element(preview).toBeInTheDocument()
+
+    // Delete the leading `!` so it becomes a plain link, not an image.
+    fixture.view.dispatch(fixture.state.tr.delete(1, 2))
+    await expect.element(preview).not.toBeInTheDocument()
+  })
+
+  it('does not render a relative src with the default resolver', async () => {
+    using fixture = setup()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('![cat](assets/cat.png)')))
+    await expect.element(preview).not.toBeInTheDocument()
+  })
+
+  it('renders a relative src through a custom resolver', async () => {
+    using fixture = setup((src) => (src.startsWith('assets/') ? `fake://${src}` : null))
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('![cat](assets/cat.png)')))
+    await expect.element(preview).toBeInTheDocument()
+    await expect.element(preview.locate('img')).toHaveAttribute('src', 'fake://assets/cat.png')
+  })
+
+  it('renders nothing when the custom resolver returns null', async () => {
+    using fixture = setup(() => null)
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('![cat](https://example.com/cat.png)')))
+    await expect.element(preview).not.toBeInTheDocument()
+  })
+
+  it('does not render an image inside inline code', async () => {
+    using fixture = setup()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('`![cat](https://example.com/cat.png)`')))
+    await expect.element(preview).not.toBeInTheDocument()
+  })
+
+  it('does not render an image inside a code block', async () => {
+    using fixture = setup()
+    const { n } = fixture
+    fixture.set(n.doc(n.codeBlock({ language: '' }, '![cat](https://example.com/cat.png)')))
+    await expect.element(preview).not.toBeInTheDocument()
+  })
+
+  it('renders two images in one paragraph in document order', async () => {
+    using fixture = setup()
+    const { n } = fixture
+    fixture.set(
+      n.doc(n.paragraph('![a](https://example.com/1.png) ![b](https://example.com/2.png)')),
+    )
+    await expect.element(preview).toHaveLength(2)
+  })
+
+  it('keeps getMarkdown byte-identical with a preview present', async () => {
+    using fixture = setup()
+    const { n } = fixture
+    const markdown = '![cat](https://example.com/cat.png)'
+    fixture.set(n.doc(n.paragraph(markdown)))
+    await expect.element(preview).toBeInTheDocument()
+    expect(docToMarkdown(fixture.doc)).toBe(`${markdown}\n`)
+  })
+
+  it('still renders the preview in hide mark mode', async () => {
+    using fixture = setup()
+    const { n } = fixture
+    fixture.editor.use(defineMarkMode('hide'))
+    fixture.set(n.doc(n.paragraph('![cat](https://example.com/cat.png)')))
+    await expect.element(preview).toBeInTheDocument()
+  })
+})

--- a/packages/core/src/extensions/image-preview.ts
+++ b/packages/core/src/extensions/image-preview.ts
@@ -1,0 +1,96 @@
+import { definePlugin, type PlainExtension } from '@prosekit/core'
+import type { EditorNode } from '@prosekit/pm/model'
+import type { EditorState } from '@prosekit/pm/state'
+import { Plugin, PluginKey } from '@prosekit/pm/state'
+import { Decoration, DecorationSet } from '@prosekit/pm/view'
+
+import { findInlineImages, type InlineImage } from './find-inline-images.ts'
+import type { ImageUrlResolver } from './images.ts'
+
+const previewKey = new PluginKey<DecorationSet>('meowdown-image-preview')
+
+const EMPTY: readonly InlineImage[] = []
+
+/**
+ * Per-block cache keyed by the immutable node instance: an unchanged
+ * textblock never reparses, and the cache survives the block moving
+ * around the document.
+ */
+const IMAGE_CACHE = new WeakMap<EditorNode, readonly InlineImage[]>()
+
+function blockImages(node: EditorNode): readonly InlineImage[] {
+  let images = IMAGE_CACHE.get(node)
+  if (!images) {
+    images = node.textContent.includes('![') ? findInlineImages(node.textContent) : EMPTY
+    IMAGE_CACHE.set(node, images)
+  }
+  return images
+}
+
+function buildDecorations(state: EditorState, resolveUrl: ImageUrlResolver): DecorationSet {
+  const decorations: Decoration[] = []
+  const keyCounts = new Map<string, number>()
+  state.doc.descendants((node, pos) => {
+    if (node.type.spec.code) return false
+    if (!node.isTextblock) return true
+    for (const image of blockImages(node)) {
+      const url = resolveUrl(image.src)
+      if (!url) continue
+      // Keyed by url so ProseMirror reuses the DOM node across rebuilds:
+      // no <img> reload flicker while the markdown is unchanged. A count
+      // suffix disambiguates the same url appearing twice.
+      const count = keyCounts.get(url) ?? 0
+      keyCounts.set(url, count + 1)
+      const key = count === 0 ? `md-image:${url}` : `md-image:${url}:${count}`
+      const alt = image.alt
+      // Anchor inline, right after the image's literal text, so it flows with
+      // surrounding text instead of dropping below the whole block.
+      const at = pos + 1 + image.to
+      decorations.push(
+        Decoration.widget(at, () => createPreviewElement(url, alt), {
+          key,
+          side: 1,
+        }),
+      )
+    }
+    return false
+  })
+  return DecorationSet.create(state.doc, decorations)
+}
+
+function createPreviewElement(url: string, alt: string): HTMLElement {
+  const wrapper = document.createElement('span')
+  wrapper.className = 'md-image'
+  wrapper.dataset.testid = 'md-image'
+  wrapper.contentEditable = 'false'
+  const img = document.createElement('img')
+  img.src = url
+  img.alt = alt
+  img.draggable = false
+  wrapper.appendChild(img)
+  return wrapper
+}
+
+function createImagePreviewPlugin(resolveUrl: ImageUrlResolver): Plugin<DecorationSet> {
+  return new Plugin<DecorationSet>({
+    key: previewKey,
+    state: {
+      init(_config, state) {
+        return buildDecorations(state, resolveUrl)
+      },
+      apply(tr, value, _oldState, newState) {
+        if (!tr.docChanged) return value
+        return buildDecorations(newState, resolveUrl)
+      },
+    },
+    props: {
+      decorations(state) {
+        return previewKey.getState(state)
+      },
+    },
+  })
+}
+
+export function defineImagePreview(resolveUrl: ImageUrlResolver): PlainExtension {
+  return definePlugin(createImagePreviewPlugin(resolveUrl))
+}

--- a/packages/core/src/extensions/image-upload.test.ts
+++ b/packages/core/src/extensions/image-upload.test.ts
@@ -1,0 +1,280 @@
+import type { Uploader } from '@prosekit/extensions/file'
+import { describe, expect, it, vi } from 'vitest'
+import { page } from 'vitest/browser'
+
+import { docToMarkdown } from '../converters/pm-to-md.ts'
+import { findText } from '../testing/find-text.ts'
+import { setupFixture, type Fixture } from '../testing/index.ts'
+
+import { defineImagePreview } from './image-preview.ts'
+import { defineImageUpload, type ResolvedUploadOptions } from './image-upload.ts'
+import { defaultResolveImageUrl } from './images.ts'
+
+function imageFile(name = 'cat.png'): File {
+  return new File([new Uint8Array([1, 2, 3])], name, { type: 'image/png' })
+}
+
+function dataTransferWith(files: File[], text?: string): DataTransfer {
+  const data = new DataTransfer()
+  if (text !== undefined) data.setData('text/plain', text)
+  for (const file of files) data.items.add(file)
+  return data
+}
+
+function pasteFiles(fixture: Fixture, files: File[], text?: string): void {
+  fixture.view.focus()
+  fixture.dom.dispatchEvent(
+    new ClipboardEvent('paste', {
+      clipboardData: dataTransferWith(files, text),
+      bubbles: true,
+      cancelable: true,
+    }),
+  )
+}
+
+function dropFiles(fixture: Fixture, files: File[], left: number, top: number): void {
+  fixture.dom.dispatchEvent(
+    new DragEvent('drop', {
+      dataTransfer: dataTransferWith(files),
+      clientX: left,
+      clientY: top,
+      bubbles: true,
+      cancelable: true,
+    }),
+  )
+}
+
+/** An uploader whose promise is resolved by hand, for deterministic timing. */
+function deferredUploader(): { uploader: Uploader<string>; resolve: (url: string) => void } {
+  let inner: ((url: string) => void) | null = null
+  const uploader: Uploader<string> = () =>
+    new Promise<string>((res) => {
+      inner = res
+    })
+  return { uploader, resolve: (url) => inner?.(url) }
+}
+
+function setupUpload(options: Partial<ResolvedUploadOptions> = {}): Fixture {
+  return setupFixture({
+    extension: defineImageUpload({
+      uploader: options.uploader ?? (({ file }) => Promise.resolve(`uploaded/${file.name}`)),
+      canUpload: options.canUpload ?? ((file) => file.type.startsWith('image/')),
+      onError: options.onError ?? (() => {}),
+    }),
+  })
+}
+
+function markdown(fixture: Fixture): string {
+  return docToMarkdown(fixture.doc)
+}
+
+describe('image upload', () => {
+  it('uploads a pasted image and swaps the placeholder for the returned src', async () => {
+    const uploader = vi.fn<Uploader<string>>(({ file }) => Promise.resolve(`uploaded/${file.name}`))
+    using fixture = setupUpload({ uploader })
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('hi<a>')))
+
+    const file = imageFile()
+    pasteFiles(fixture, [file])
+    expect(uploader).toHaveBeenCalledWith(expect.objectContaining({ file }))
+    await vi.waitFor(() => {
+      expect(markdown(fixture)).toBe('hi![](uploaded/cat.png)\n')
+    })
+  })
+
+  it('inserts an optimistic blob placeholder before the upload resolves', async () => {
+    const { uploader, resolve } = deferredUploader()
+    using fixture = setupUpload({ uploader })
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('hi<a>')))
+
+    pasteFiles(fixture, [imageFile()])
+    // The placeholder is inserted synchronously, carrying a blob: URL.
+    expect(markdown(fixture)).toMatch(/^hi!\[]\(blob:[^)]+\)\n$/)
+
+    resolve('final.png')
+    await vi.waitFor(() => {
+      expect(markdown(fixture)).toBe('hi![](final.png)\n')
+    })
+  })
+
+  it('reports a rejected upload, removes the placeholder, and stays usable', async () => {
+    const cause = new Error('boom')
+    const onError = vi.fn()
+    using fixture = setupUpload({ uploader: () => Promise.reject(cause), onError })
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('hi<a>')))
+
+    const file = imageFile()
+    pasteFiles(fixture, [file])
+    expect(markdown(fixture)).toContain('![](blob:')
+
+    await vi.waitFor(() => {
+      expect(onError).toHaveBeenCalledTimes(1)
+    })
+    const arg = onError.mock.calls[0][0] as { error: unknown; file: File }
+    expect(arg.file).toBe(file)
+    expect((arg.error as Error).cause).toBe(cause)
+    expect(markdown(fixture)).toBe('hi\n')
+
+    fixture.view.dispatch(fixture.state.tr.insertText('!', 3))
+    expect(markdown(fixture)).toBe('hi!\n')
+  })
+
+  it('falls through when canUpload rejects the file', () => {
+    const uploader = vi.fn<Uploader<string>>()
+    using fixture = setupUpload({ uploader, canUpload: () => false })
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('hi<a>')))
+
+    pasteFiles(fixture, [imageFile()])
+    expect(uploader).not.toHaveBeenCalled()
+    expect(markdown(fixture)).not.toContain('![]')
+  })
+
+  it('ignores a non-image file with the default canUpload', () => {
+    const uploader = vi.fn<Uploader<string>>()
+    using fixture = setupUpload({ uploader })
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('hi<a>')))
+
+    const textFile = new File(['x'], 'notes.txt', { type: 'text/plain' })
+    pasteFiles(fixture, [textFile])
+    expect(uploader).not.toHaveBeenCalled()
+    expect(markdown(fixture)).not.toContain('![]')
+  })
+
+  it('falls through for a text-only clipboard, leaving paste to the default', async () => {
+    const uploader = vi.fn<Uploader<string>>()
+    using fixture = setupUpload({ uploader })
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>')))
+
+    pasteFiles(fixture, [], 'plain text')
+    await expect.element(page.getByText('plain text')).toBeInTheDocument()
+    expect(uploader).not.toHaveBeenCalled()
+    expect(markdown(fixture)).not.toContain('![]')
+  })
+
+  it('does nothing on an image paste when no upload handler is installed', async () => {
+    using fixture = setupFixture()
+    fixture.editor.use(defineImagePreview(defaultResolveImageUrl))
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('hi<a>')))
+
+    pasteFiles(fixture, [imageFile()])
+    await vi.waitFor(() => {
+      expect(markdown(fixture)).toBe('hi\n')
+    })
+  })
+
+  it('consumes a clipboard carrying both an image and text (D7)', async () => {
+    using fixture = setupUpload()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>')))
+
+    pasteFiles(fixture, [imageFile()], 'pasted html text')
+    await vi.waitFor(() => {
+      expect(markdown(fixture)).toBe('![](uploaded/cat.png)\n')
+    })
+    expect(markdown(fixture)).not.toContain('pasted html text')
+  })
+
+  it('uploads two pasted files and inserts them in order', async () => {
+    using fixture = setupUpload()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>')))
+
+    pasteFiles(fixture, [imageFile('a.png'), imageFile('b.png')])
+    await vi.waitFor(() => {
+      expect(markdown(fixture)).toBe('![](uploaded/a.png)![](uploaded/b.png)\n')
+    })
+  })
+
+  it('drops an image at the drop point, not the caret', async () => {
+    using fixture = setupUpload({ uploader: () => Promise.resolve('drop.png') })
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('first<a>'), n.paragraph('second')))
+
+    const target = findText(fixture.doc, 'second') + 3
+    const coords = fixture.view.coordsAtPos(target)
+    dropFiles(fixture, [imageFile()], coords.left, coords.top)
+    await vi.waitFor(() => {
+      expect(markdown(fixture)).toContain('![](drop.png)')
+    })
+    expect(markdown(fixture)).toMatch(/^first\n\n/)
+  })
+
+  it('swaps the placeholder wherever concurrent edits push it', async () => {
+    const { uploader, resolve } = deferredUploader()
+    using fixture = setupUpload({ uploader })
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('hello<a>')))
+
+    pasteFiles(fixture, [imageFile()])
+    // Edit the document start while the upload is in flight.
+    fixture.view.dispatch(fixture.state.tr.insertText('XYZ', 1))
+    resolve('flight.png')
+
+    await vi.waitFor(() => {
+      expect(markdown(fixture)).toBe('XYZhello![](flight.png)\n')
+    })
+  })
+
+  it('swaps every copy of an in-flight placeholder', async () => {
+    const { uploader, resolve } = deferredUploader()
+    using fixture = setupUpload({ uploader })
+    const { n } = fixture
+    // The marker must not collide with the blob: URL that findText scans.
+    fixture.set(n.doc(n.paragraph('one<a>'), n.paragraph('ZZZ')))
+
+    pasteFiles(fixture, [imageFile()])
+    const blob = markdown(fixture).match(/!\[]\((blob:[^)]+)\)/)?.[1]
+    expect(blob).toBeTruthy()
+    // Duplicate the placeholder into the second paragraph.
+    fixture.view.dispatch(fixture.state.tr.insertText(`![](${blob})`, findText(fixture.doc, 'ZZZ')))
+    resolve('dup.png')
+
+    await vi.waitFor(() => {
+      const md = markdown(fixture)
+      expect(md).not.toContain('blob:')
+      expect(md.match(/!\[]\(dup\.png\)/g) ?? []).toHaveLength(2)
+    })
+  })
+
+  it('drops the swap when the placeholder block is deleted in flight', async () => {
+    const { uploader, resolve } = deferredUploader()
+    using fixture = setupUpload({ uploader })
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('keep'), n.paragraph('gone<a>')))
+
+    pasteFiles(fixture, [imageFile()])
+    // Delete the whole second paragraph (where the placeholder lives).
+    fixture.view.dispatch(fixture.state.tr.delete(6, fixture.doc.content.size))
+    resolve('gone.png')
+
+    await vi.waitFor(() => {
+      expect(markdown(fixture)).toBe('keep\n')
+    })
+    expect(markdown(fixture)).not.toContain('![]')
+  })
+
+  it('does not dispatch after the editor is unmounted', async () => {
+    const { uploader, resolve } = deferredUploader()
+    const fixture = setupUpload({ uploader })
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('hi<a>')))
+
+    pasteFiles(fixture, [imageFile()])
+    const view = fixture.view
+    fixture.editor.unmount()
+    expect(view.isDestroyed).toBe(true)
+
+    // Resolving after unmount must not dispatch or throw.
+    resolve('late.png')
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(view.isDestroyed).toBe(true)
+  })
+})

--- a/packages/core/src/extensions/image-upload.test.ts
+++ b/packages/core/src/extensions/image-upload.test.ts
@@ -1,9 +1,7 @@
-import { pasteFiles, pasteText } from '@prosekit/core/test'
 import type { Uploader } from '@prosekit/extensions/file'
 import { describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
 
-import { docToMarkdown } from '../converters/pm-to-md.ts'
 import { findText } from '../testing/find-text.ts'
 import { setupFixture, type Fixture } from '../testing/index.ts'
 
@@ -14,34 +12,6 @@ import { defaultResolveImageUrl } from './images.ts'
 function createImageFile(name = 'cat.png'): File {
   return new File([new Uint8Array([1, 2, 3])], name, { type: 'image/png' })
 }
-
-// `pasteFiles` from `@prosekit/core/test` covers file-only pastes; these two
-// helpers cover what it can't express: an image alongside text (to check the
-// text is dropped) and a drop at coordinates.
-function pasteImageAndText(fixture: Fixture, file: File, text: string): void {
-  const data = new DataTransfer()
-  data.setData('text/plain', text)
-  data.items.add(file)
-  fixture.dom.dispatchEvent(
-    new ClipboardEvent('paste', { clipboardData: data, bubbles: true, cancelable: true }),
-  )
-}
-
-function dropFiles(fixture: Fixture, files: File[], left: number, top: number): void {
-  const dataTransfer = new DataTransfer()
-  for (const file of files) dataTransfer.items.add(file)
-  fixture.dom.dispatchEvent(
-    new DragEvent('drop', {
-      dataTransfer,
-      clientX: left,
-      clientY: top,
-      bubbles: true,
-      cancelable: true,
-    }),
-  )
-}
-
-// REVIEW: just add a paste and drop method to the fixture so that we can reuse it in other tests.
 
 /** An uploader whose promise is resolved by hand, for deterministic timing. */
 function deferredUploader(): { uploader: Uploader<string>; resolve: (url: string) => void } {
@@ -63,13 +33,6 @@ function setupUpload(options: Partial<ResolvedUploadOptions> = {}): Fixture {
   })
 }
 
-function markdown(fixture: Fixture): string {
-  return docToMarkdown(fixture.doc)
-}
-
-// REVIEW: just add a getMarkdown() method to the fixture so that we can reuse it in other tests.
-
-
 describe('image upload', () => {
   it('uploads a pasted image and swaps the placeholder for the returned src', async () => {
     const uploader = vi.fn<Uploader<string>>(({ file }) => Promise.resolve(`uploaded/${file.name}`))
@@ -78,10 +41,10 @@ describe('image upload', () => {
     fixture.set(n.doc(n.paragraph('hi<a>')))
 
     const file = createImageFile()
-    pasteFiles(fixture.view, [file])
+    fixture.paste([file])
     expect(uploader).toHaveBeenCalledWith(expect.objectContaining({ file }))
     await vi.waitFor(() => {
-      expect(markdown(fixture)).toBe('hi![](uploaded/cat.png)\n')
+      expect(fixture.getMarkdown()).toBe('hi![](uploaded/cat.png)\n')
     })
   })
 
@@ -91,13 +54,13 @@ describe('image upload', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('hi<a>')))
 
-    pasteFiles(fixture.view, [createImageFile()])
+    fixture.paste([createImageFile()])
     // The placeholder is inserted synchronously, carrying a blob: URL.
-    expect(markdown(fixture)).toMatch(/^hi!\[]\(blob:[^)]+\)\n$/)
+    expect(fixture.getMarkdown()).toMatch(/^hi!\[]\(blob:[^)]+\)\n$/)
 
     resolve('final.png')
     await vi.waitFor(() => {
-      expect(markdown(fixture)).toBe('hi![](final.png)\n')
+      expect(fixture.getMarkdown()).toBe('hi![](final.png)\n')
     })
   })
 
@@ -109,8 +72,8 @@ describe('image upload', () => {
     fixture.set(n.doc(n.paragraph('hi<a>')))
 
     const file = createImageFile()
-    pasteFiles(fixture.view, [file])
-    expect(markdown(fixture)).toContain('![](blob:')
+    fixture.paste([file])
+    expect(fixture.getMarkdown()).toContain('![](blob:')
 
     await vi.waitFor(() => {
       expect(onError).toHaveBeenCalledTimes(1)
@@ -118,10 +81,10 @@ describe('image upload', () => {
     const arg = onError.mock.calls[0][0] as { error: unknown; file: File }
     expect(arg.file).toBe(file)
     expect((arg.error as Error).cause).toBe(cause)
-    expect(markdown(fixture)).toBe('hi\n')
+    expect(fixture.getMarkdown()).toBe('hi\n')
 
     fixture.view.dispatch(fixture.state.tr.insertText('!', 3))
-    expect(markdown(fixture)).toBe('hi!\n')
+    expect(fixture.getMarkdown()).toBe('hi!\n')
   })
 
   it('falls through when canUpload rejects the file', () => {
@@ -130,9 +93,9 @@ describe('image upload', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('hi<a>')))
 
-    pasteFiles(fixture.view, [createImageFile()])
+    fixture.paste([createImageFile()])
     expect(uploader).not.toHaveBeenCalled()
-    expect(markdown(fixture)).not.toContain('![]')
+    expect(fixture.getMarkdown()).not.toContain('![]')
   })
 
   it('ignores a non-image file with the default canUpload', () => {
@@ -142,9 +105,9 @@ describe('image upload', () => {
     fixture.set(n.doc(n.paragraph('hi<a>')))
 
     const textFile = new File(['x'], 'notes.txt', { type: 'text/plain' })
-    pasteFiles(fixture.view, [textFile])
+    fixture.paste([textFile])
     expect(uploader).not.toHaveBeenCalled()
-    expect(markdown(fixture)).not.toContain('![]')
+    expect(fixture.getMarkdown()).not.toContain('![]')
   })
 
   it('falls through for a text-only clipboard, leaving paste to the default', async () => {
@@ -153,10 +116,10 @@ describe('image upload', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('<a>')))
 
-    pasteText(fixture.view, 'plain text')
+    fixture.paste([], 'plain text')
     await expect.element(page.getByText('plain text')).toBeInTheDocument()
     expect(uploader).not.toHaveBeenCalled()
-    expect(markdown(fixture)).not.toContain('![]')
+    expect(fixture.getMarkdown()).not.toContain('![]')
   })
 
   it('does nothing on an image paste when no upload handler is installed', async () => {
@@ -165,9 +128,9 @@ describe('image upload', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('hi<a>')))
 
-    pasteFiles(fixture.view, [createImageFile()])
+    fixture.paste([createImageFile()])
     await vi.waitFor(() => {
-      expect(markdown(fixture)).toBe('hi\n')
+      expect(fixture.getMarkdown()).toBe('hi\n')
     })
   })
 
@@ -176,11 +139,11 @@ describe('image upload', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('<a>')))
 
-    pasteImageAndText(fixture, createImageFile(), 'pasted html text')
+    fixture.paste([createImageFile()], 'pasted html text')
     await vi.waitFor(() => {
-      expect(markdown(fixture)).toBe('![](uploaded/cat.png)\n')
+      expect(fixture.getMarkdown()).toBe('![](uploaded/cat.png)\n')
     })
-    expect(markdown(fixture)).not.toContain('pasted html text')
+    expect(fixture.getMarkdown()).not.toContain('pasted html text')
   })
 
   it('uploads two pasted files and inserts them in order', async () => {
@@ -188,24 +151,26 @@ describe('image upload', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('<a>')))
 
-    pasteFiles(fixture.view, [createImageFile('a.png'), createImageFile('b.png')])
+    fixture.paste([createImageFile('a.png'), createImageFile('b.png')])
     await vi.waitFor(() => {
-      expect(markdown(fixture)).toBe('![](uploaded/a.png)![](uploaded/b.png)\n')
+      expect(fixture.getMarkdown()).toBe('![](uploaded/a.png)![](uploaded/b.png)\n')
     })
   })
 
-  it('drops an image at the drop point, not the caret', async () => {
+  it('drops an image as its own block at the drop point', async () => {
     using fixture = setupUpload({ uploader: () => Promise.resolve('drop.png') })
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('first<a>'), n.paragraph('second')))
 
     const target = findText(fixture.doc, 'second') + 3
     const coords = fixture.view.coordsAtPos(target)
-    dropFiles(fixture, [createImageFile()], coords.left, coords.top)
+    fixture.drop([createImageFile()], coords.left, coords.top)
+    // The image lands as a standalone block (blank lines around it), not inline
+    // in either paragraph.
     await vi.waitFor(() => {
-      expect(markdown(fixture)).toContain('![](drop.png)')
+      expect(fixture.getMarkdown()).toContain('\n\n![](drop.png)\n\n')
     })
-    expect(markdown(fixture)).toMatch(/^first\n\n/)
+    expect(fixture.getMarkdown()).toMatch(/^first\n\n/)
   })
 
   it('swaps the placeholder wherever concurrent edits push it', async () => {
@@ -214,13 +179,13 @@ describe('image upload', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('hello<a>')))
 
-    pasteFiles(fixture.view, [createImageFile()])
+    fixture.paste([createImageFile()])
     // Edit the document start while the upload is in flight.
     fixture.view.dispatch(fixture.state.tr.insertText('XYZ', 1))
     resolve('flight.png')
 
     await vi.waitFor(() => {
-      expect(markdown(fixture)).toBe('XYZhello![](flight.png)\n')
+      expect(fixture.getMarkdown()).toBe('XYZhello![](flight.png)\n')
     })
   })
 
@@ -231,15 +196,15 @@ describe('image upload', () => {
     // The marker must not collide with the blob: URL that findText scans.
     fixture.set(n.doc(n.paragraph('one<a>'), n.paragraph('ZZZ')))
 
-    pasteFiles(fixture.view, [createImageFile()])
-    const blob = markdown(fixture).match(/!\[]\((blob:[^)]+)\)/)?.[1]
+    fixture.paste([createImageFile()])
+    const blob = fixture.getMarkdown().match(/!\[]\((blob:[^)]+)\)/)?.[1]
     expect(blob).toBeTruthy()
     // Duplicate the placeholder into the second paragraph.
     fixture.view.dispatch(fixture.state.tr.insertText(`![](${blob})`, findText(fixture.doc, 'ZZZ')))
     resolve('dup.png')
 
     await vi.waitFor(() => {
-      const md = markdown(fixture)
+      const md = fixture.getMarkdown()
       expect(md).not.toContain('blob:')
       expect(md.match(/!\[]\(dup\.png\)/g) ?? []).toHaveLength(2)
     })
@@ -251,15 +216,15 @@ describe('image upload', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('keep'), n.paragraph('gone<a>')))
 
-    pasteFiles(fixture.view, [createImageFile()])
+    fixture.paste([createImageFile()])
     // Delete the whole second paragraph (where the placeholder lives).
     fixture.view.dispatch(fixture.state.tr.delete(6, fixture.doc.content.size))
     resolve('gone.png')
 
     await vi.waitFor(() => {
-      expect(markdown(fixture)).toBe('keep\n')
+      expect(fixture.getMarkdown()).toBe('keep\n')
     })
-    expect(markdown(fixture)).not.toContain('![]')
+    expect(fixture.getMarkdown()).not.toContain('![]')
   })
 
   it('does not dispatch after the editor is unmounted', async () => {
@@ -268,7 +233,7 @@ describe('image upload', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('hi<a>')))
 
-    pasteFiles(fixture.view, [createImageFile()])
+    fixture.paste([createImageFile()])
     const view = fixture.view
     fixture.editor.unmount()
     expect(view.isDestroyed).toBe(true)

--- a/packages/core/src/extensions/image-upload.test.ts
+++ b/packages/core/src/extensions/image-upload.test.ts
@@ -1,3 +1,4 @@
+import { pasteFiles, pasteText } from '@prosekit/core/test'
 import type { Uploader } from '@prosekit/extensions/file'
 import { describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
@@ -10,32 +11,28 @@ import { defineImagePreview } from './image-preview.ts'
 import { defineImageUpload, type ResolvedUploadOptions } from './image-upload.ts'
 import { defaultResolveImageUrl } from './images.ts'
 
-function imageFile(name = 'cat.png'): File {
+function createImageFile(name = 'cat.png'): File {
   return new File([new Uint8Array([1, 2, 3])], name, { type: 'image/png' })
 }
 
-function dataTransferWith(files: File[], text?: string): DataTransfer {
+// `pasteFiles` from `@prosekit/core/test` covers file-only pastes; these two
+// helpers cover what it can't express: an image alongside text (to check the
+// text is dropped) and a drop at coordinates.
+function pasteImageAndText(fixture: Fixture, file: File, text: string): void {
   const data = new DataTransfer()
-  if (text !== undefined) data.setData('text/plain', text)
-  for (const file of files) data.items.add(file)
-  return data
-}
-
-function pasteFiles(fixture: Fixture, files: File[], text?: string): void {
-  fixture.view.focus()
+  data.setData('text/plain', text)
+  data.items.add(file)
   fixture.dom.dispatchEvent(
-    new ClipboardEvent('paste', {
-      clipboardData: dataTransferWith(files, text),
-      bubbles: true,
-      cancelable: true,
-    }),
+    new ClipboardEvent('paste', { clipboardData: data, bubbles: true, cancelable: true }),
   )
 }
 
 function dropFiles(fixture: Fixture, files: File[], left: number, top: number): void {
+  const dataTransfer = new DataTransfer()
+  for (const file of files) dataTransfer.items.add(file)
   fixture.dom.dispatchEvent(
     new DragEvent('drop', {
-      dataTransfer: dataTransferWith(files),
+      dataTransfer,
       clientX: left,
       clientY: top,
       bubbles: true,
@@ -43,6 +40,8 @@ function dropFiles(fixture: Fixture, files: File[], left: number, top: number): 
     }),
   )
 }
+
+// REVIEW: just add a paste and drop method to the fixture so that we can reuse it in other tests.
 
 /** An uploader whose promise is resolved by hand, for deterministic timing. */
 function deferredUploader(): { uploader: Uploader<string>; resolve: (url: string) => void } {
@@ -68,6 +67,9 @@ function markdown(fixture: Fixture): string {
   return docToMarkdown(fixture.doc)
 }
 
+// REVIEW: just add a getMarkdown() method to the fixture so that we can reuse it in other tests.
+
+
 describe('image upload', () => {
   it('uploads a pasted image and swaps the placeholder for the returned src', async () => {
     const uploader = vi.fn<Uploader<string>>(({ file }) => Promise.resolve(`uploaded/${file.name}`))
@@ -75,8 +77,8 @@ describe('image upload', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('hi<a>')))
 
-    const file = imageFile()
-    pasteFiles(fixture, [file])
+    const file = createImageFile()
+    pasteFiles(fixture.view, [file])
     expect(uploader).toHaveBeenCalledWith(expect.objectContaining({ file }))
     await vi.waitFor(() => {
       expect(markdown(fixture)).toBe('hi![](uploaded/cat.png)\n')
@@ -89,7 +91,7 @@ describe('image upload', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('hi<a>')))
 
-    pasteFiles(fixture, [imageFile()])
+    pasteFiles(fixture.view, [createImageFile()])
     // The placeholder is inserted synchronously, carrying a blob: URL.
     expect(markdown(fixture)).toMatch(/^hi!\[]\(blob:[^)]+\)\n$/)
 
@@ -106,8 +108,8 @@ describe('image upload', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('hi<a>')))
 
-    const file = imageFile()
-    pasteFiles(fixture, [file])
+    const file = createImageFile()
+    pasteFiles(fixture.view, [file])
     expect(markdown(fixture)).toContain('![](blob:')
 
     await vi.waitFor(() => {
@@ -128,7 +130,7 @@ describe('image upload', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('hi<a>')))
 
-    pasteFiles(fixture, [imageFile()])
+    pasteFiles(fixture.view, [createImageFile()])
     expect(uploader).not.toHaveBeenCalled()
     expect(markdown(fixture)).not.toContain('![]')
   })
@@ -140,7 +142,7 @@ describe('image upload', () => {
     fixture.set(n.doc(n.paragraph('hi<a>')))
 
     const textFile = new File(['x'], 'notes.txt', { type: 'text/plain' })
-    pasteFiles(fixture, [textFile])
+    pasteFiles(fixture.view, [textFile])
     expect(uploader).not.toHaveBeenCalled()
     expect(markdown(fixture)).not.toContain('![]')
   })
@@ -151,7 +153,7 @@ describe('image upload', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('<a>')))
 
-    pasteFiles(fixture, [], 'plain text')
+    pasteText(fixture.view, 'plain text')
     await expect.element(page.getByText('plain text')).toBeInTheDocument()
     expect(uploader).not.toHaveBeenCalled()
     expect(markdown(fixture)).not.toContain('![]')
@@ -163,7 +165,7 @@ describe('image upload', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('hi<a>')))
 
-    pasteFiles(fixture, [imageFile()])
+    pasteFiles(fixture.view, [createImageFile()])
     await vi.waitFor(() => {
       expect(markdown(fixture)).toBe('hi\n')
     })
@@ -174,7 +176,7 @@ describe('image upload', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('<a>')))
 
-    pasteFiles(fixture, [imageFile()], 'pasted html text')
+    pasteImageAndText(fixture, createImageFile(), 'pasted html text')
     await vi.waitFor(() => {
       expect(markdown(fixture)).toBe('![](uploaded/cat.png)\n')
     })
@@ -186,7 +188,7 @@ describe('image upload', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('<a>')))
 
-    pasteFiles(fixture, [imageFile('a.png'), imageFile('b.png')])
+    pasteFiles(fixture.view, [createImageFile('a.png'), createImageFile('b.png')])
     await vi.waitFor(() => {
       expect(markdown(fixture)).toBe('![](uploaded/a.png)![](uploaded/b.png)\n')
     })
@@ -199,7 +201,7 @@ describe('image upload', () => {
 
     const target = findText(fixture.doc, 'second') + 3
     const coords = fixture.view.coordsAtPos(target)
-    dropFiles(fixture, [imageFile()], coords.left, coords.top)
+    dropFiles(fixture, [createImageFile()], coords.left, coords.top)
     await vi.waitFor(() => {
       expect(markdown(fixture)).toContain('![](drop.png)')
     })
@@ -212,7 +214,7 @@ describe('image upload', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('hello<a>')))
 
-    pasteFiles(fixture, [imageFile()])
+    pasteFiles(fixture.view, [createImageFile()])
     // Edit the document start while the upload is in flight.
     fixture.view.dispatch(fixture.state.tr.insertText('XYZ', 1))
     resolve('flight.png')
@@ -229,7 +231,7 @@ describe('image upload', () => {
     // The marker must not collide with the blob: URL that findText scans.
     fixture.set(n.doc(n.paragraph('one<a>'), n.paragraph('ZZZ')))
 
-    pasteFiles(fixture, [imageFile()])
+    pasteFiles(fixture.view, [createImageFile()])
     const blob = markdown(fixture).match(/!\[]\((blob:[^)]+)\)/)?.[1]
     expect(blob).toBeTruthy()
     // Duplicate the placeholder into the second paragraph.
@@ -249,7 +251,7 @@ describe('image upload', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('keep'), n.paragraph('gone<a>')))
 
-    pasteFiles(fixture, [imageFile()])
+    pasteFiles(fixture.view, [createImageFile()])
     // Delete the whole second paragraph (where the placeholder lives).
     fixture.view.dispatch(fixture.state.tr.delete(6, fixture.doc.content.size))
     resolve('gone.png')
@@ -266,7 +268,7 @@ describe('image upload', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('hi<a>')))
 
-    pasteFiles(fixture, [imageFile()])
+    pasteFiles(fixture.view, [createImageFile()])
     const view = fixture.view
     fixture.editor.unmount()
     expect(view.isDestroyed).toBe(true)

--- a/packages/core/src/extensions/image-upload.ts
+++ b/packages/core/src/extensions/image-upload.ts
@@ -133,6 +133,11 @@ export function defineImageUpload(options: ResolvedUploadOptions): PlainExtensio
     defineFileDropHandler(({ view, event, file }) => {
       // The handler's own `pos` is computed for block insertion; for literal
       // text we want the nearest text position, so recompute from the event.
+
+      // REVIEW: when the user drops a file, they expect it to be inserted
+      // as a "block"-level image. In anther word, we usually want to insert a
+      // paragraph that contains the image, instead of inserting the image into an existing paragraph.
+      // So you can just use the file drop handler position here.
       const coords = view.posAtCoords({ left: event.clientX, top: event.clientY })
       return handleFile(view, file, coords?.pos, options)
     }),

--- a/packages/core/src/extensions/image-upload.ts
+++ b/packages/core/src/extensions/image-upload.ts
@@ -8,7 +8,6 @@ import {
 import type { EditorNode } from '@prosekit/pm/model'
 import type { EditorView } from '@prosekit/pm/view'
 
-import { findInlineImages } from './find-inline-images.ts'
 import type { ImageUploadErrorHandler } from './images.ts'
 
 export interface ResolvedUploadOptions {
@@ -26,33 +25,26 @@ interface PlacedImage {
 }
 
 /**
- * Re-scan the document for every image whose `src` equals `src`. The temporary
- * `blob:` object URL is unique, so this recovers the placeholder's position
- * without any stored anchor: robust against concurrent edits, undo, and doc
- * rebuilds, and naturally handles zero matches (deleted under us) or many
- * (the placeholder was duplicated).
+ * Re-scan the document for every placeholder carrying `src`. We insert an exact
+ * `![](src)` token whose `blob:` object URL is unique, so a plain substring
+ * search recovers its position (and any copies) without re-parsing: robust
+ * against concurrent edits, undo, and doc rebuilds, and naturally handling zero
+ * matches (deleted under us) or many (the placeholder was duplicated).
  */
 function findPlacedImages(doc: EditorNode, src: string): PlacedImage[] {
   const out: PlacedImage[] = []
+  const token = `![](${src})`
   doc.descendants((node, pos) => {
     if (node.type.spec.code) return false
     if (!node.isTextblock) return true
     const text = node.textContent
-    if (text.includes(src)) {
-      const base = pos + 1
-      // REVIEW: you use LEZER to parse EVERY inline textblock
-      // to find the image. That's very slow. Since we already have the mark,
-      // we can just find the correct mark.
-      for (const image of findInlineImages(text)) {
-        if (image.src !== src) continue
-        const srcOffset = text.indexOf(src, image.from)
-        out.push({
-          from: base + image.from,
-          to: base + image.to,
-          srcFrom: base + srcOffset,
-          srcTo: base + srcOffset + src.length,
-        })
-      }
+    const base = pos + 1
+    let index = text.indexOf(token)
+    while (index !== -1) {
+      const from = base + index
+      const srcFrom = from + 4 // skip the leading `![](`
+      out.push({ from, to: from + token.length, srcFrom, srcTo: srcFrom + src.length })
+      index = text.indexOf(token, index + token.length)
     }
     return false
   })
@@ -62,12 +54,12 @@ function findPlacedImages(doc: EditorNode, src: string): PlacedImage[] {
 function startUpload(
   view: EditorView,
   file: File,
-  pos: number | undefined,
   options: ResolvedUploadOptions,
+  insertPlaceholder: (markdown: string) => void,
 ): void {
   const task = new UploadTask({ file, uploader: options.uploader })
   const objectURL = task.objectURL
-  insertPlaceholder(view, `![](${objectURL})`, pos)
+  insertPlaceholder(`![](${objectURL})`)
   task.finished.then(
     (resultURL) => {
       if (!view.isDestroyed) replaceMatches(view, objectURL, resultURL)
@@ -84,10 +76,22 @@ function startUpload(
   )
 }
 
-function insertPlaceholder(view: EditorView, markdown: string, pos: number | undefined): void {
-  const tr =
-    pos == null ? view.state.tr.insertText(markdown) : view.state.tr.insertText(markdown, pos)
-  view.dispatch(tr)
+/** Paste: insert the placeholder inline, at the caret. */
+function insertInline(view: EditorView, markdown: string): void {
+  view.dispatch(view.state.tr.insertText(markdown))
+}
+
+/** Drop: insert the placeholder as its own block at the drop position. */
+function insertBlock(view: EditorView, markdown: string, pos: number): void {
+  const { state } = view
+  const paragraph = state.schema.nodes.paragraph.createAndFill(null, state.schema.text(markdown))
+  if (!paragraph) return
+  const clamped = Math.min(Math.max(pos, 0), state.doc.content.size)
+  const $pos = state.doc.resolve(clamped)
+  // A block can only land at a block boundary: before the textblock the drop
+  // fell inside, or at the given position when it is already between blocks.
+  const at = $pos.parent.isTextblock ? $pos.before() : $pos.pos
+  view.dispatch(state.tr.insert(at, paragraph))
 }
 
 function replaceMatches(view: EditorView, oldSrc: string, newSrc: string): void {
@@ -117,11 +121,11 @@ function removeMatches(view: EditorView, src: string): void {
 function handleFile(
   view: EditorView,
   file: File,
-  pos: number | undefined,
   options: ResolvedUploadOptions,
+  insertPlaceholder: (markdown: string) => void,
 ): boolean {
   if (!options.canUpload(file)) return false
-  startUpload(view, file, pos, options)
+  startUpload(view, file, options, insertPlaceholder)
   // Returning true consumes the event (ProseMirror calls preventDefault), so a
   // clipboard carrying image files is handled entirely.
   return true
@@ -129,17 +133,13 @@ function handleFile(
 
 export function defineImageUpload(options: ResolvedUploadOptions): PlainExtension {
   return union(
-    defineFilePasteHandler(({ view, file }) => handleFile(view, file, undefined, options)),
-    defineFileDropHandler(({ view, event, file }) => {
-      // The handler's own `pos` is computed for block insertion; for literal
-      // text we want the nearest text position, so recompute from the event.
-
-      // REVIEW: when the user drops a file, they expect it to be inserted
-      // as a "block"-level image. In anther word, we usually want to insert a
-      // paragraph that contains the image, instead of inserting the image into an existing paragraph.
-      // So you can just use the file drop handler position here.
-      const coords = view.posAtCoords({ left: event.clientX, top: event.clientY })
-      return handleFile(view, file, coords?.pos, options)
-    }),
+    // Paste lands inline at the caret; drop lands as its own block at the drop
+    // position (the conventional behavior for a dropped image file).
+    defineFilePasteHandler(({ view, file }) =>
+      handleFile(view, file, options, (markdown) => insertInline(view, markdown)),
+    ),
+    defineFileDropHandler(({ view, file, pos }) =>
+      handleFile(view, file, options, (markdown) => insertBlock(view, markdown, pos)),
+    ),
   )
 }

--- a/packages/core/src/extensions/image-upload.ts
+++ b/packages/core/src/extensions/image-upload.ts
@@ -1,0 +1,137 @@
+import { union, type PlainExtension } from '@prosekit/core'
+import {
+  defineFileDropHandler,
+  defineFilePasteHandler,
+  UploadTask,
+  type Uploader,
+} from '@prosekit/extensions/file'
+import type { EditorNode } from '@prosekit/pm/model'
+import type { EditorView } from '@prosekit/pm/view'
+
+import { findInlineImages } from './find-inline-images.ts'
+import type { ImageUploadErrorHandler } from './images.ts'
+
+export interface ResolvedUploadOptions {
+  uploader: Uploader<string>
+  canUpload: (file: File) => boolean
+  onError: ImageUploadErrorHandler
+}
+
+/** One placed `![](src)` occurrence, in absolute document positions. */
+interface PlacedImage {
+  from: number
+  to: number
+  srcFrom: number
+  srcTo: number
+}
+
+/**
+ * Re-scan the document for every image whose `src` equals `src`. The temporary
+ * `blob:` object URL is unique, so this recovers the placeholder's position
+ * without any stored anchor: robust against concurrent edits, undo, and doc
+ * rebuilds, and naturally handles zero matches (deleted under us) or many
+ * (the placeholder was duplicated).
+ */
+function findPlacedImages(doc: EditorNode, src: string): PlacedImage[] {
+  const out: PlacedImage[] = []
+  doc.descendants((node, pos) => {
+    if (node.type.spec.code) return false
+    if (!node.isTextblock) return true
+    const text = node.textContent
+    if (text.includes(src)) {
+      const base = pos + 1
+      for (const image of findInlineImages(text)) {
+        if (image.src !== src) continue
+        const srcOffset = text.indexOf(src, image.from)
+        out.push({
+          from: base + image.from,
+          to: base + image.to,
+          srcFrom: base + srcOffset,
+          srcTo: base + srcOffset + src.length,
+        })
+      }
+    }
+    return false
+  })
+  return out
+}
+
+function startUpload(
+  view: EditorView,
+  file: File,
+  pos: number | undefined,
+  options: ResolvedUploadOptions,
+): void {
+  const task = new UploadTask({ file, uploader: options.uploader })
+  const objectURL = task.objectURL
+  insertPlaceholder(view, `![](${objectURL})`, pos)
+  task.finished.then(
+    (resultURL) => {
+      if (!view.isDestroyed) replaceMatches(view, objectURL, resultURL)
+      UploadTask.delete(objectURL)
+    },
+    (error: unknown) => {
+      options.onError({ error, file })
+      // A blob URL must never persist into saved Markdown, so a failed upload
+      // removes its optimistic placeholder.
+      if (!view.isDestroyed) removeMatches(view, objectURL)
+      URL.revokeObjectURL(objectURL)
+      UploadTask.delete(objectURL)
+    },
+  )
+}
+
+function insertPlaceholder(view: EditorView, markdown: string, pos: number | undefined): void {
+  const tr =
+    pos == null ? view.state.tr.insertText(markdown) : view.state.tr.insertText(markdown, pos)
+  view.dispatch(tr)
+}
+
+function replaceMatches(view: EditorView, oldSrc: string, newSrc: string): void {
+  const placed = findPlacedImages(view.state.doc, oldSrc)
+  if (placed.length === 0) return
+  const tr = view.state.tr
+  // Back-to-front so earlier ranges stay valid as the doc is rewritten.
+  for (let i = placed.length - 1; i >= 0; i--) {
+    tr.insertText(newSrc, placed[i].srcFrom, placed[i].srcTo)
+  }
+  // Not its own undo step: undo removes the whole image, not just the swap.
+  tr.setMeta('addToHistory', false)
+  view.dispatch(tr)
+}
+
+function removeMatches(view: EditorView, src: string): void {
+  const placed = findPlacedImages(view.state.doc, src)
+  if (placed.length === 0) return
+  const tr = view.state.tr
+  for (let i = placed.length - 1; i >= 0; i--) {
+    tr.delete(placed[i].from, placed[i].to)
+  }
+  tr.setMeta('addToHistory', false)
+  view.dispatch(tr)
+}
+
+function handleFile(
+  view: EditorView,
+  file: File,
+  pos: number | undefined,
+  options: ResolvedUploadOptions,
+): boolean {
+  if (!options.canUpload(file)) return false
+  startUpload(view, file, pos, options)
+  // Returning true consumes the event (ProseMirror calls preventDefault), so a
+  // clipboard carrying image files is handled entirely.
+  return true
+}
+
+export function defineImageUpload(options: ResolvedUploadOptions): PlainExtension {
+  return union(
+    defineFilePasteHandler(({ view, file }) => handleFile(view, file, undefined, options)),
+    defineFileDropHandler(({ view, event, file }) => {
+      // The handler's own `pos` is computed for block insertion; for literal
+      // text we want the nearest text position, so recompute from the event.
+      const coords = view.posAtCoords({ left: event.clientX, top: event.clientY })
+      return handleFile(view, file, coords?.pos, options)
+    }),
+  )
+}

--- a/packages/core/src/extensions/image-upload.ts
+++ b/packages/core/src/extensions/image-upload.ts
@@ -40,6 +40,9 @@ function findPlacedImages(doc: EditorNode, src: string): PlacedImage[] {
     const text = node.textContent
     if (text.includes(src)) {
       const base = pos + 1
+      // REVIEW: you use LEZER to parse EVERY inline textblock
+      // to find the image. That's very slow. Since we already have the mark,
+      // we can just find the correct mark.
       for (const image of findInlineImages(text)) {
         if (image.src !== src) continue
         const srcOffset = text.indexOf(src, image.from)

--- a/packages/core/src/extensions/images.ts
+++ b/packages/core/src/extensions/images.ts
@@ -1,0 +1,94 @@
+import { union, type PlainExtension } from '@prosekit/core'
+import type { Uploader } from '@prosekit/extensions/file'
+
+import { defineImagePreview } from './image-preview.ts'
+import { defineImageUpload } from './image-upload.ts'
+
+/** Maps a Markdown image src to a displayable URL, or null to not render it. */
+export type ImageUrlResolver = (src: string) => string | null
+
+/**
+ * Persists a pasted or dropped image file and resolves to the src to embed in
+ * the Markdown (a relative path, a remote URL...). Sync or async. Reject to
+ * signal failure (the optimistic placeholder is then removed).
+ */
+export type ImageUploadHandler = (file: File) => string | Promise<string>
+
+/**
+ * Decides whether a pasted or dropped file should be uploaded. Runs before any
+ * placeholder is inserted. Defaults to accepting `image/*` files.
+ */
+export type ImageUploadPredicate = (file: File) => boolean
+
+/** Called when an upload throws or rejects, with the file that failed. */
+export type ImageUploadErrorHandler = (options: { error: unknown; file: File }) => void
+
+export interface ImageExtensionOptions {
+  /**
+   * Maps a Markdown src to a displayable URL, or null to not render it.
+   * Defaults to a safe absolute-URL pass-through (`defaultResolveImageUrl`).
+   */
+  resolveUrl?: ImageUrlResolver
+
+  /**
+   * Persists a pasted or dropped image and resolves to the src to embed. Omit
+   * to disable paste/drop handling entirely.
+   */
+  upload?: ImageUploadHandler
+
+  /** Decides which files to upload. Defaults to accepting `image/*` files. */
+  canUpload?: ImageUploadPredicate
+
+  /** Called when `upload` throws or rejects. Defaults to `console.error`. */
+  onUploadError?: ImageUploadErrorHandler
+}
+
+/**
+ * Renders `![alt](src)` Markdown as an inline image preview, and (when
+ * `upload` is given) turns pasted or dropped image files into `![](src)`
+ * text. The document never holds an image node: the literal Markdown text
+ * stays the source of truth, so serialization is unaffected.
+ *
+ * On paste/drop a placeholder `![](blob:...)` is inserted immediately (so the
+ * local image shows at once), then the `blob:` src is swapped for the uploaded
+ * one once `upload` resolves.
+ */
+export function defineImageExtension(options: ImageExtensionOptions = {}): PlainExtension {
+  const resolveUrl = options.resolveUrl ?? defaultResolveImageUrl
+  const preview = defineImagePreview(resolveUrl)
+  const upload = options.upload
+  if (!upload) return preview
+  const uploader: Uploader<string> = ({ file }) => Promise.resolve(upload(file))
+  return union(
+    preview,
+    defineImageUpload({
+      uploader,
+      canUpload: options.canUpload ?? defaultCanUpload,
+      onError: options.onUploadError ?? logUploadError,
+    }),
+  )
+}
+
+function defaultCanUpload(file: File): boolean {
+  return file.type.startsWith('image/')
+}
+
+/**
+ * Safe default resolver: passes through `data:image/*`, `http:`, `https:`,
+ * and `blob:` URLs; returns null for everything else (relative paths,
+ * `javascript:`, unknown schemes), since only the host knows what a relative
+ * path means and unknown schemes must never render.
+ */
+export function defaultResolveImageUrl(src: string): string | null {
+  if (src.startsWith('data:image/')) return src
+  try {
+    const protocol = new URL(src).protocol
+    return protocol === 'http:' || protocol === 'https:' || protocol === 'blob:' ? src : null
+  } catch {
+    return null
+  }
+}
+
+function logUploadError({ error }: { error: unknown; file: File }): void {
+  console.error(error)
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,15 @@ export {
   type TypedEditor,
 } from './extensions/extension.ts'
 export { type MarkMode, defineMarkMode } from './extensions/mark-mode.ts'
+export {
+  defineImageExtension,
+  defaultResolveImageUrl,
+  type ImageExtensionOptions,
+  type ImageUrlResolver,
+  type ImageUploadHandler,
+  type ImageUploadPredicate,
+  type ImageUploadErrorHandler,
+} from './extensions/images.ts'
 export { codeBlockLanguages } from './extensions/code-block-languages.ts'
 export { docToMarkdown } from './converters/pm-to-md.ts'
 export { markdownToDoc } from './converters/md-to-pm.ts'

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -31,6 +31,10 @@
    * sees pointer events on the editor element, so a handle outside the
    * padding closes before it can be clicked. Keep it >= 3.5rem. */
   --meowdown-gutter: 3.5rem;
+
+  /* Inline image previews. Standalone variables per the styling rule. */
+  --meowdown-image-max-height: 28rem;
+  --meowdown-image-radius: 0.6rem;
 }
 
 /* ---------------------------------------------------------------------------
@@ -276,6 +280,22 @@
   text-decoration-style: dashed;
   text-decoration-thickness: 1px;
   text-underline-offset: 2px;
+}
+
+/* ---------------------------------------------------------------------------
+ * Inline image previews (`![alt](src)`)
+ * ------------------------------------------------------------------------- */
+.ProseMirror .md-image {
+  display: inline-block;
+  vertical-align: middle;
+  user-select: none;
+  margin: 0 0.15em;
+}
+.ProseMirror .md-image img {
+  display: block;
+  max-width: 100%;
+  max-height: var(--meowdown-image-max-height);
+  border-radius: var(--meowdown-image-radius);
 }
 
 /* ---------------------------------------------------------------------------

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -2,6 +2,7 @@ import '../style.css'
 
 import './locator.ts'
 
+import { union, type Extension } from '@prosekit/core'
 import { createTestEditor } from '@prosekit/core/test'
 import type { EditorNode } from '@prosekit/pm/model'
 
@@ -10,10 +11,13 @@ import { defineEditorExtension } from '../extensions/extension.ts'
 export interface SetupFixtureOptions {
   /** Whether to mount the editor onto a real DOM container. Defaults to `true`. */
   mount?: boolean
+  /** An extra extension unioned with the base at creation (facet handlers
+   * must be installed at creation, not via `editor.use`). */
+  extension?: Extension
 }
 
-export function setupFixture({ mount = true }: SetupFixtureOptions = {}) {
-  const extension = defineEditorExtension()
+export function setupFixture({ mount = true, extension: extra }: SetupFixtureOptions = {}) {
+  const extension = extra ? union(defineEditorExtension(), extra) : defineEditorExtension()
   const editor = createTestEditor({ extension })
   const n = editor.nodes
   const m = editor.marks

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -3,9 +3,10 @@ import '../style.css'
 import './locator.ts'
 
 import { union, type Extension } from '@prosekit/core'
-import { createTestEditor } from '@prosekit/core/test'
+import { createTestEditor, pasteFiles, pasteText } from '@prosekit/core/test'
 import type { EditorNode } from '@prosekit/pm/model'
 
+import { docToMarkdown } from '../converters/pm-to-md.ts'
 import { defineEditorExtension } from '../extensions/extension.ts'
 
 export interface SetupFixtureOptions {
@@ -61,6 +62,46 @@ export function setupFixture({ mount = true, extension: extra }: SetupFixtureOpt
 
     set(doc: EditorNode) {
       editor.set(doc)
+    },
+
+    /** Serialize the current document to Markdown. */
+    getMarkdown(): string {
+      return docToMarkdown(editor.view.state.doc)
+    },
+
+    /**
+     * Simulate a paste. Uses `@prosekit/core/test`'s `pasteFiles` / `pasteText`
+     * for file-only or text-only clipboards, and a real `paste` event when both
+     * are present (to check the text is ignored alongside an image).
+     */
+    paste(files: File[], text?: string): void {
+      if (text === undefined) {
+        pasteFiles(editor.view, files)
+      } else if (files.length === 0) {
+        pasteText(editor.view, text)
+      } else {
+        const data = new DataTransfer()
+        data.setData('text/plain', text)
+        for (const file of files) data.items.add(file)
+        editor.view.dom.dispatchEvent(
+          new ClipboardEvent('paste', { clipboardData: data, bubbles: true, cancelable: true }),
+        )
+      }
+    },
+
+    /** Simulate a file drop at the given client coordinates. */
+    drop(files: File[], left: number, top: number): void {
+      const dataTransfer = new DataTransfer()
+      for (const file of files) dataTransfer.items.add(file)
+      editor.view.dom.dispatchEvent(
+        new DragEvent('drop', {
+          dataTransfer,
+          clientX: left,
+          clientY: top,
+          bubbles: true,
+          cancelable: true,
+        }),
+      )
     },
 
     [Symbol.dispose]() {

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -41,17 +41,6 @@ The Markdown editor component. Renders inside a `div.meowdown` wrapper that fill
 - `spellCheck?: boolean`: toggles the browser's native spell checking in the rich modes. Defaults to the browser's behavior. Ignored in source mode.
 - `ref?: Ref<EditorHandle>`
 
-REVIEW: remove paragraph below
-
-Inline images render as a non-editable preview inline at the position of the `![alt](src)` text, flowing with the surrounding text; the Markdown text itself stays in the document, so saving is unaffected. A minimal demo upload that keeps images for the session:
-
-```tsx
-<Editor onImageUpload={(file) => URL.createObjectURL(file)} />
-```
-
-REVIEW: remove paragraph above
-
-
 ### `EditorHandle`
 
 Imperative handle for the editor, attached via `ref`.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -41,11 +41,16 @@ The Markdown editor component. Renders inside a `div.meowdown` wrapper that fill
 - `spellCheck?: boolean`: toggles the browser's native spell checking in the rich modes. Defaults to the browser's behavior. Ignored in source mode.
 - `ref?: Ref<EditorHandle>`
 
+REVIEW: remove paragraph below
+
 Inline images render as a non-editable preview inline at the position of the `![alt](src)` text, flowing with the surrounding text; the Markdown text itself stays in the document, so saving is unaffected. A minimal demo upload that keeps images for the session:
 
 ```tsx
 <Editor onImageUpload={(file) => URL.createObjectURL(file)} />
 ```
+
+REVIEW: remove paragraph above
+
 
 ### `EditorHandle`
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -34,8 +34,18 @@ The Markdown editor component. Renders inside a `div.meowdown` wrapper that fill
 - `onDocChange?: VoidFunction`: called on every document change.
 - `onTagSearch?: (query: string) => string[] | Promise<string[]>`: enables the tag menu, which opens when typing `#` followed by text in a rich mode; returns the tags to show for a query (lowercased, punctuation stripped). Omit to disable.
 - `onWikilinkSearch?: (query: string) => string[] | Promise<string[]>`: enables the wikilink menu, which opens as soon as `[[` is typed in a rich mode; returns the note names to show for a query (lowercased, punctuation stripped, may be empty). Selecting a note inserts `[[Note Name]]`. Omit to disable.
+- `resolveImageUrl?: (src: string) => string | null`: maps a Markdown image `src` to a displayable URL for the inline preview, or returns `null` to skip rendering. Defaults to a safe pass-through that renders `data:image/*`, `http(s):`, and `blob:` URLs and skips everything else (relative paths, `javascript:`...). Rich modes only.
+- `onImageUpload?: (file: File) => string | Promise<string>`: enables image paste/drop. Persists the file and resolves to the `src` to embed as `![](src)`; reject to signal failure. On paste/drop a `![](blob:...)` placeholder shows the local image immediately, then its src is swapped for the resolved one. A clipboard carrying image files is consumed entirely (any text/html alongside the bitmap is ignored). Whether it is enabled is read once, on the first render. Omit to leave paste/drop to the default behavior. Rich modes only.
+- `canUploadImage?: (file: File) => boolean`: decides which pasted/dropped files `onImageUpload` should handle, before any placeholder is inserted (e.g. to enforce a size limit). Defaults to accepting `image/*` files. Rich modes only.
+- `onImageUploadError?: (options: { error: unknown; file: File }) => void`: called when `onImageUpload` throws or rejects (the failed placeholder is removed). Defaults to `console.error`. Rich modes only.
 - `spellCheck?: boolean`: toggles the browser's native spell checking in the rich modes. Defaults to the browser's behavior. Ignored in source mode.
 - `ref?: Ref<EditorHandle>`
+
+Inline images render as a non-editable preview inline at the position of the `![alt](src)` text, flowing with the surrounding text; the Markdown text itself stays in the document, so saving is unaffected. A minimal demo upload that keeps images for the session:
+
+```tsx
+<Editor onImageUpload={(file) => URL.createObjectURL(file)} />
+```
 
 ### `EditorHandle`
 

--- a/packages/react/src/components/editor.test.tsx
+++ b/packages/react/src/components/editor.test.tsx
@@ -11,6 +11,21 @@ import type { EditorHandle } from './types.ts'
 const pmRoot = page.locate('.ProseMirror')
 const cmRoot = page.locate('.cm-editor')
 const cmContent = page.locate('[data-editor="codemirror"] .cm-content')
+const mdImage = page.getByTestId('md-image')
+
+// REVIEW: rename to `createImageFile`
+function imageFile(name = 'cat.png'): File {
+  return new File([new Uint8Array([1, 2, 3])], name, { type: 'image/png' })
+}
+
+// REVIEW: `@prosekit/core/test` has a `pasteFiles` API. Use that instead.
+function pasteImage(target: Element, file: File): void {
+  const data = new DataTransfer()
+  data.items.add(file)
+  target.dispatchEvent(
+    new ClipboardEvent('paste', { clipboardData: data, bubbles: true, cancelable: true }),
+  )
+}
 
 describe('Editor', () => {
   it('renders a ProseKit editor in focus mode by default', async () => {
@@ -223,5 +238,61 @@ describe('Editor', () => {
     ref.current?.scrollIntoView()
     await userEvent.keyboard('A')
     await expect.element(cmContent).toHaveTextContent('A!Hi')
+  })
+})
+
+describe('Editor images', () => {
+  it('uploads a pasted image through the public component', async () => {
+    const upload = vi.fn((file: File) => `uploaded/${file.name}`)
+    const ref = createRef<EditorHandle>()
+    await render(<Editor ref={ref} onImageUpload={upload} />)
+    await pmRoot.click()
+
+    pasteImage(pmRoot.element(), imageFile())
+    await vi.waitFor(() => {
+      expect(upload).toHaveBeenCalled()
+      expect(ref.current?.getMarkdown()).toContain('![](uploaded/cat.png)')
+    })
+  })
+
+  it('previews a remote image with no image props and leaves paste alone', async () => {
+    const ref = createRef<EditorHandle>()
+    await render(<Editor ref={ref} initialMarkdown="![cat](https://example.com/cat.png)" />)
+    await expect.element(mdImage).toBeInTheDocument()
+    await expect
+      .element(mdImage.locate('img'))
+      .toHaveAttribute('src', 'https://example.com/cat.png')
+
+    await pmRoot.click()
+    pasteImage(pmRoot.element(), imageFile())
+    expect(ref.current?.getMarkdown()).not.toContain('![](cat.png)')
+  })
+
+  it('accepts image props in source mode without rendering a preview', async () => {
+    await render(
+      <Editor
+        mode="source"
+        initialMarkdown="![cat](https://example.com/cat.png)"
+        onImageUpload={() => 'x.png'}
+      />,
+    )
+    await expect.element(cmContent).toHaveTextContent('![cat](https://example.com/cat.png)')
+    await expect.element(mdImage).not.toBeInTheDocument()
+  })
+
+  it('calls the latest onImageUpload after a re-render', async () => {
+    const first = vi.fn(() => 'first.png')
+    const second = vi.fn(() => 'second.png')
+    const ref = createRef<EditorHandle>()
+    const screen = await render(<Editor ref={ref} onImageUpload={first} />)
+    await screen.rerender(<Editor ref={ref} onImageUpload={second} />)
+
+    await pmRoot.click()
+    pasteImage(pmRoot.element(), imageFile())
+    await vi.waitFor(() => {
+      expect(second).toHaveBeenCalled()
+      expect(ref.current?.getMarkdown()).toContain('![](second.png)')
+    })
+    expect(first).not.toHaveBeenCalled()
   })
 })

--- a/packages/react/src/components/editor.test.tsx
+++ b/packages/react/src/components/editor.test.tsx
@@ -13,12 +13,14 @@ const cmRoot = page.locate('.cm-editor')
 const cmContent = page.locate('[data-editor="codemirror"] .cm-content')
 const mdImage = page.getByTestId('md-image')
 
-// REVIEW: rename to `createImageFile`
-function imageFile(name = 'cat.png'): File {
+function createImageFile(name = 'cat.png'): File {
   return new File([new Uint8Array([1, 2, 3])], name, { type: 'image/png' })
 }
 
-// REVIEW: `@prosekit/core/test` has a `pasteFiles` API. Use that instead.
+// `@prosekit/core/test`'s `pasteFiles` takes an `EditorView`, which the public
+// `<Editor>` deliberately does not expose, so this end-to-end test dispatches a
+// real `paste` event on the editor DOM instead. The view-level matrix lives in
+// `@meowdown/core`'s `image-upload.test.ts`, which uses `pasteFiles`.
 function pasteImage(target: Element, file: File): void {
   const data = new DataTransfer()
   data.items.add(file)
@@ -248,7 +250,7 @@ describe('Editor images', () => {
     await render(<Editor ref={ref} onImageUpload={upload} />)
     await pmRoot.click()
 
-    pasteImage(pmRoot.element(), imageFile())
+    pasteImage(pmRoot.element(), createImageFile())
     await vi.waitFor(() => {
       expect(upload).toHaveBeenCalled()
       expect(ref.current?.getMarkdown()).toContain('![](uploaded/cat.png)')
@@ -264,7 +266,7 @@ describe('Editor images', () => {
       .toHaveAttribute('src', 'https://example.com/cat.png')
 
     await pmRoot.click()
-    pasteImage(pmRoot.element(), imageFile())
+    pasteImage(pmRoot.element(), createImageFile())
     expect(ref.current?.getMarkdown()).not.toContain('![](cat.png)')
   })
 
@@ -288,7 +290,7 @@ describe('Editor images', () => {
     await screen.rerender(<Editor ref={ref} onImageUpload={second} />)
 
     await pmRoot.click()
-    pasteImage(pmRoot.element(), imageFile())
+    pasteImage(pmRoot.element(), createImageFile())
     await vi.waitFor(() => {
       expect(second).toHaveBeenCalled()
       expect(ref.current?.getMarkdown()).toContain('![](second.png)')

--- a/packages/react/src/components/editor.tsx
+++ b/packages/react/src/components/editor.tsx
@@ -7,6 +7,10 @@ import { ProseKitEditor } from './prosekit-editor.tsx'
 import type {
   EditorHandle,
   EditorStateSnapshot,
+  ImageUploadErrorHandler,
+  ImageUploadHandler,
+  ImageUploadPredicate,
+  ImageUrlResolver,
   SelectionHint,
   TagSearchHandler,
   WikilinkSearchHandler,
@@ -52,6 +56,38 @@ export interface EditorProps {
   onWikilinkSearch?: WikilinkSearchHandler
 
   /**
+   * Maps a Markdown image `src` to a displayable URL for the inline preview,
+   * or returns null to not render that image. Defaults to a safe pass-through
+   * that renders `data:image/*`, `http(s):`, and `blob:` URLs and skips
+   * everything else (relative paths, `javascript:`...). Rich modes only.
+   */
+  resolveImageUrl?: ImageUrlResolver
+
+  /**
+   * Persists a pasted or dropped image file and resolves to the `src` to embed
+   * as `![](src)`. Sync or async; reject to signal failure. On paste/drop a
+   * `![](blob:...)` placeholder appears immediately and its src is swapped for
+   * the resolved one once the upload completes. A clipboard carrying image
+   * files is consumed entirely (any text/html alongside the bitmap is
+   * ignored). Whether this is enabled is read once, on the first render. Omit
+   * to leave paste/drop to the default behavior. Rich modes only.
+   */
+  onImageUpload?: ImageUploadHandler
+
+  /**
+   * Decides which pasted or dropped files `onImageUpload` should handle, before
+   * any placeholder is inserted (e.g. to enforce a size limit). Defaults to
+   * accepting `image/*` files. Rich modes only.
+   */
+  canUploadImage?: ImageUploadPredicate
+
+  /**
+   * Called when `onImageUpload` throws or rejects, with `{ error, file }`.
+   * Defaults to `console.error`. Rich modes only.
+   */
+  onImageUploadError?: ImageUploadErrorHandler
+
+  /**
    * Enables the browser's native spell checking in the rich modes. Defaults
    * to the browser's behavior. Ignored in source mode.
    */
@@ -67,6 +103,10 @@ export function Editor({
   onDocChange,
   onTagSearch,
   onWikilinkSearch,
+  resolveImageUrl,
+  onImageUpload,
+  canUploadImage,
+  onImageUploadError,
   spellCheck,
   ref,
 }: EditorProps) {
@@ -126,6 +166,10 @@ export function Editor({
           onDocChange={onDocChange}
           onTagSearch={onTagSearch}
           onWikilinkSearch={onWikilinkSearch}
+          resolveImageUrl={resolveImageUrl}
+          onImageUpload={onImageUpload}
+          canUploadImage={canUploadImage}
+          onImageUploadError={onImageUploadError}
           spellCheck={spellCheck}
         />
       )}

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -100,9 +100,9 @@ export function ProseKitEditor({
   spellCheck,
   ref,
 }: ProseKitEditorProps) {
-  // The latest handler closures are read at call time so a re-render with a
-  // new closure never strands the extension calling a stale one. Whether
-  // upload is enabled, though, is decided once, on the first render.
+  // Every image callback is read through this ref at call time, so a re-render
+  // with a new closure (or newly added/removed handler) is picked up live: the
+  // image extension is built once but never captures a stale closure.
   const imageHandlersRef = useRef({
     resolveImageUrl,
     onImageUpload,
@@ -112,22 +112,35 @@ export function ProseKitEditor({
   imageHandlersRef.current = { resolveImageUrl, onImageUpload, canUploadImage, onImageUploadError }
 
   const [editor] = useState((): TypedEditor => {
-    // The image extension installs file paste/drop handlers, which must be
-    // present at creation (they don't compose cleanly through a later
-    // `editor.use`), so it is unioned with the base here.
+    // The image extension is unioned with the base here, at creation, instead of
+    // being added later with `editor.use(...)`. The upload half registers its
+    // paste/drop handlers through ProseKit's facet system (a child facet of
+    // `editorEventFacet`). Each facet is assigned a fixed numeric path, and when
+    // `editor.use` folds a new extension into an already-built editor it merges
+    // the two facet trees position-by-position (`unionFacetNode`), asserting
+    // that both sides at a given path point to the same facet. A facet defined
+    // in a separately-loaded module (`@prosekit/extensions/file`) can land on a
+    // path that collides with another facet in the live tree, tripping that
+    // assertion and throwing at runtime. Composing the whole tree once, before
+    // the editor exists, sidesteps the incremental merge so the handlers always
+    // install cleanly.
     //
-    // REVIEW: I DO NOT UNDERSTAND "they don't compose cleanly through a later `editor.use`". Try to explain this better with very detailed information and
-    // add comment here. Notice that we do not have to follow "Whether upload is enabled, though, is decided once, on the first render.". We can just assue
-    // that whoever use the editor will always provide the upload functions (so that the editor can actually work).
+    // The handlers are always installed; `canUpload` is what actually gates
+    // uploading, returning false (so paste/drop falls back to the default) while
+    // no `onImageUpload` is set. Reading it from the ref keeps enablement live
+    // rather than frozen at first render.
     const imageExtension = defineImageExtension({
       resolveUrl: (src) =>
         (imageHandlersRef.current.resolveImageUrl ?? defaultResolveImageUrl)(src),
-      upload: onImageUpload
-        ? (file) => (imageHandlersRef.current.onImageUpload ?? onImageUpload)(file)
-        : undefined,
-      canUpload: canUploadImage
-        ? (file) => (imageHandlersRef.current.canUploadImage ?? canUploadImage)(file)
-        : undefined,
+      upload: (file) => {
+        const handler = imageHandlersRef.current.onImageUpload
+        return handler ? handler(file) : Promise.reject(new Error('onImageUpload is not set'))
+      },
+      canUpload: (file) => {
+        if (!imageHandlersRef.current.onImageUpload) return false
+        const predicate = imageHandlersRef.current.canUploadImage
+        return predicate ? predicate(file) : file.type.startsWith('image/')
+      },
       onUploadError: ({ error, file }) => {
         const handler = imageHandlersRef.current.onImageUploadError
         if (handler) handler({ error, file })

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -1,18 +1,19 @@
 import {
   defineEditorExtension,
+  defineImageExtension,
+  defaultResolveImageUrl,
   defineMarkMode,
   type TypedEditor,
-  type EditorExtension,
   type MarkMode,
   docToMarkdown,
   markdownToDoc,
 } from '@meowdown/core'
 import { clamp } from '@ocavue/utils'
-import { createEditor, defineDocChangeHandler, type SelectionJSON, union } from '@prosekit/core'
+import { createEditor, defineDocChangeHandler, union, type SelectionJSON } from '@prosekit/core'
 import type { EditorNode } from '@prosekit/pm/model'
 import { Selection, TextSelection } from '@prosekit/pm/state'
 import { ProseKit, useExtension } from '@prosekit/react'
-import { useImperativeHandle, useMemo, useState, type Ref } from 'react'
+import { useImperativeHandle, useMemo, useRef, useState, type Ref } from 'react'
 
 import { defineCodeBlockView } from '../extensions/code-block-view.ts'
 
@@ -23,6 +24,10 @@ import { TagMenu } from './tag-menu.tsx'
 import type {
   EditorHandle,
   EditorStateSnapshot,
+  ImageUploadErrorHandler,
+  ImageUploadHandler,
+  ImageUploadPredicate,
+  ImageUrlResolver,
   SelectionHint,
   TagSearchHandler,
   WikilinkSearchHandler,
@@ -63,6 +68,18 @@ export interface ProseKitEditorProps {
   /** Enables the wikilink menu. See `EditorProps.onWikilinkSearch`. */
   onWikilinkSearch?: WikilinkSearchHandler
 
+  /** Maps a Markdown image src to a displayable URL. See `EditorProps.resolveImageUrl`. */
+  resolveImageUrl?: ImageUrlResolver
+
+  /** Enables image paste/drop upload. See `EditorProps.onImageUpload`. */
+  onImageUpload?: ImageUploadHandler
+
+  /** Decides which files to upload. See `EditorProps.canUploadImage`. */
+  canUploadImage?: ImageUploadPredicate
+
+  /** Reports an upload failure. See `EditorProps.onImageUploadError`. */
+  onImageUploadError?: ImageUploadErrorHandler
+
   /** Enables or disables spell checking in the editor. */
   spellCheck?: boolean
 
@@ -76,13 +93,46 @@ export function ProseKitEditor({
   onDocChange,
   onTagSearch,
   onWikilinkSearch,
+  resolveImageUrl,
+  onImageUpload,
+  canUploadImage,
+  onImageUploadError,
   spellCheck,
   ref,
 }: ProseKitEditorProps) {
+  // The latest handler closures are read at call time so a re-render with a
+  // new closure never strands the extension calling a stale one. Whether
+  // upload is enabled, though, is decided once, on the first render.
+  const imageHandlersRef = useRef({
+    resolveImageUrl,
+    onImageUpload,
+    canUploadImage,
+    onImageUploadError,
+  })
+  imageHandlersRef.current = { resolveImageUrl, onImageUpload, canUploadImage, onImageUploadError }
+
   const [editor] = useState((): TypedEditor => {
-    const baseExtension: EditorExtension = defineEditorExtension()
-    const extension = union(baseExtension, defineCodeBlockView())
-    const editor: TypedEditor = createEditor({ extension })
+    // The image extension installs file paste/drop handlers, which must be
+    // present at creation (they don't compose cleanly through a later
+    // `editor.use`), so it is unioned with the base here.
+    const imageExtension = defineImageExtension({
+      resolveUrl: (src) =>
+        (imageHandlersRef.current.resolveImageUrl ?? defaultResolveImageUrl)(src),
+      upload: onImageUpload
+        ? (file) => (imageHandlersRef.current.onImageUpload ?? onImageUpload)(file)
+        : undefined,
+      canUpload: canUploadImage
+        ? (file) => (imageHandlersRef.current.canUploadImage ?? canUploadImage)(file)
+        : undefined,
+      onUploadError: ({ error, file }) => {
+        const handler = imageHandlersRef.current.onImageUploadError
+        if (handler) handler({ error, file })
+        else console.error(error)
+      },
+    })
+    const editor = createEditor({
+      extension: union(defineEditorExtension(), imageExtension, defineCodeBlockView()),
+    }) as TypedEditor
     if (initialMarkdown) {
       editor.setContent(markdownToDoc(editor, initialMarkdown))
     }

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -115,6 +115,10 @@ export function ProseKitEditor({
     // The image extension installs file paste/drop handlers, which must be
     // present at creation (they don't compose cleanly through a later
     // `editor.use`), so it is unioned with the base here.
+    //
+    // REVIEW: I DO NOT UNDERSTAND "they don't compose cleanly through a later `editor.use`". Try to explain this better with very detailed information and
+    // add comment here. Notice that we do not have to follow "Whether upload is enabled, though, is decided once, on the first render.". We can just assue
+    // that whoever use the editor will always provide the upload functions (so that the editor can actually work).
     const imageExtension = defineImageExtension({
       resolveUrl: (src) =>
         (imageHandlersRef.current.resolveImageUrl ?? defaultResolveImageUrl)(src),

--- a/packages/react/src/components/types.ts
+++ b/packages/react/src/components/types.ts
@@ -1,5 +1,12 @@
 import type { SelectionJSON } from '@prosekit/core'
 
+export type {
+  ImageUrlResolver,
+  ImageUploadHandler,
+  ImageUploadPredicate,
+  ImageUploadErrorHandler,
+} from '@meowdown/core'
+
 /** A selection to restore: an exact JSON selection, or a document edge. */
 export type SelectionHint = SelectionJSON | 'start' | 'end'
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,6 +2,10 @@ export { Editor, type EditorMode, type EditorProps } from './components/editor.t
 export type {
   EditorHandle,
   EditorStateSnapshot,
+  ImageUploadErrorHandler,
+  ImageUploadHandler,
+  ImageUploadPredicate,
+  ImageUrlResolver,
   SelectionHint,
   TagSearchHandler,
   WikilinkSearchHandler,

--- a/website/src/app.tsx
+++ b/website/src/app.tsx
@@ -85,6 +85,8 @@ async function searchNotes(query: string): Promise<string[]> {
   return NOTES.filter((note) => note.toLowerCase().includes(query))
 }
 
+// REVIEW: read /Users/ocavue/code/github/prosekit/registry/src/lit/sample/sample-uploader.ts for a sample of how to implement a real image uploader that sends the file to a server and returns its URL.
+// REVIEW: notice that the uploader function should have it's own file.
 // Demo upload: keep the pasted/dropped image for the session via a blob URL,
 // which the default resolver passes straight through.
 function uploadImage(file: File): string {

--- a/website/src/app.tsx
+++ b/website/src/app.tsx
@@ -1,6 +1,8 @@
 import { Editor, type EditorMode } from '@meowdown/react'
 import { type CSSProperties, useLayoutEffect, useState } from 'react'
 
+import { uploadImage } from './upload-image.ts'
+
 interface ModeOption {
   value: EditorMode
   label: string
@@ -83,14 +85,6 @@ async function searchNotes(query: string): Promise<string[]> {
   // Simulate network latency so the wikilink menu's loading state shows up.
   await new Promise((resolve) => setTimeout(resolve, 200))
   return NOTES.filter((note) => note.toLowerCase().includes(query))
-}
-
-// REVIEW: read /Users/ocavue/code/github/prosekit/registry/src/lit/sample/sample-uploader.ts for a sample of how to implement a real image uploader that sends the file to a server and returns its URL.
-// REVIEW: notice that the uploader function should have it's own file.
-// Demo upload: keep the pasted/dropped image for the session via a blob URL,
-// which the default resolver passes straight through.
-function uploadImage(file: File): string {
-  return URL.createObjectURL(file)
 }
 
 interface SegmentedControlProps<T extends string> {

--- a/website/src/app.tsx
+++ b/website/src/app.tsx
@@ -43,6 +43,10 @@ Label your notes with tags like #meow and #markdown. Type \`#\` followed by a le
 
 Connect notes with wikilinks like [[Daily journal]] and [[Reading list]]. Type \`[[\` to link another note.
 
+Paste or drop an image straight into the editor to embed it inline.
+
+![A sunny placeholder photo](https://static.photos/yellow/640x360/42)
+
 Drop in a fenced code block and pick its language from the selector:
 
 \`\`\`typescript
@@ -79,6 +83,12 @@ async function searchNotes(query: string): Promise<string[]> {
   // Simulate network latency so the wikilink menu's loading state shows up.
   await new Promise((resolve) => setTimeout(resolve, 200))
   return NOTES.filter((note) => note.toLowerCase().includes(query))
+}
+
+// Demo upload: keep the pasted/dropped image for the session via a blob URL,
+// which the default resolver passes straight through.
+function uploadImage(file: File): string {
+  return URL.createObjectURL(file)
 }
 
 interface SegmentedControlProps<T extends string> {
@@ -196,6 +206,7 @@ export function App() {
               initialMarkdown={INITIAL_CONTENT}
               onTagSearch={searchTags}
               onWikilinkSearch={searchNotes}
+              onImageUpload={uploadImage}
             />
           </div>
 

--- a/website/src/app.tsx
+++ b/website/src/app.tsx
@@ -1,7 +1,7 @@
 import { Editor, type EditorMode } from '@meowdown/react'
 import { type CSSProperties, useLayoutEffect, useState } from 'react'
 
-import { uploadImage } from './upload-image.ts'
+import { uploadFile } from './upload-file.ts'
 
 interface ModeOption {
   value: EditorMode
@@ -202,7 +202,7 @@ export function App() {
               initialMarkdown={INITIAL_CONTENT}
               onTagSearch={searchTags}
               onWikilinkSearch={searchNotes}
-              onImageUpload={uploadImage}
+              onImageUpload={uploadFile}
             />
           </div>
 

--- a/website/src/upload-file.ts
+++ b/website/src/upload-file.ts
@@ -1,11 +1,11 @@
 /**
  * Uploads a file to https://tmpfiles.org and returns the URL of the uploaded
- * image.
+ * file.
  *
  * This is for demonstration only: tmpfiles.org deletes uploads after one hour.
  * A production host would POST to its own storage and return a stable URL.
  */
-export async function uploadImage(file: File): Promise<string> {
+export async function uploadFile(file: File): Promise<string> {
   const body = new FormData()
   body.append('file', file)
   const response = await fetch('https://tmpfiles.org/api/v1/upload', { method: 'POST', body })
@@ -16,5 +16,3 @@ export async function uploadImage(file: File): Promise<string> {
   // tmpfiles returns a viewer URL; rewrite it to the direct file URL.
   return json.data.url.replace('tmpfiles.org/', 'tmpfiles.org/dl/')
 }
-
-// REVIEW: refactor this function (and its file name ) to uploadFile

--- a/website/src/upload-image.ts
+++ b/website/src/upload-image.ts
@@ -1,0 +1,18 @@
+/**
+ * Uploads a file to https://tmpfiles.org and returns the URL of the uploaded
+ * image.
+ *
+ * This is for demonstration only: tmpfiles.org deletes uploads after one hour.
+ * A production host would POST to its own storage and return a stable URL.
+ */
+export async function uploadImage(file: File): Promise<string> {
+  const body = new FormData()
+  body.append('file', file)
+  const response = await fetch('https://tmpfiles.org/api/v1/upload', { method: 'POST', body })
+  if (!response.ok) {
+    throw new Error(`Upload failed with status ${response.status}`)
+  }
+  const json = (await response.json()) as { data: { url: string } }
+  // tmpfiles returns a viewer URL; rewrite it to the direct file URL.
+  return json.data.url.replace('tmpfiles.org/', 'tmpfiles.org/dl/')
+}

--- a/website/src/upload-image.ts
+++ b/website/src/upload-image.ts
@@ -16,3 +16,5 @@ export async function uploadImage(file: File): Promise<string> {
   // tmpfiles returns a viewer URL; rewrite it to the direct file URL.
   return json.data.url.replace('tmpfiles.org/', 'tmpfiles.org/dl/')
 }
+
+// REVIEW: refactor this function (and its file name ) to uploadFile


### PR DESCRIPTION
## Summary

Adds inline image preview and paste/drop image upload to Meowdown. `![alt](src)` stays literal Markdown text (the document never holds an image node), so serialization is byte-identical; the picture renders as a non-editable widget directly beneath the line.

## Core (`@meowdown/core`)

- `find-inline-images.ts`: pure walker over the existing Lezer parse; extracts `![alt](src)` (skips reference images, inline code, escapes, empty src).
- `image-preview.ts`: widget-decoration plugin with a per-block `WeakMap` cache; renders `<img>` below the block, url-keyed for flicker-free reuse across rebuilds.
- `image-upload.ts`: paste/drop handlers plus a pending-insert plugin state that remaps anchors through every transaction, so an insert lands where the drop happened even after concurrent edits. A clipboard carrying image files is consumed entirely (text/html alongside the bitmap is ignored); declined (`null`) and failed uploads are skipped.
- `images.ts`: public `defineImageExtension()` and `defaultResolveImageUrl` (strict allow-list: `data:image/*`, `http(s):`, `blob:`).
- New `--meowdown-image-*` CSS variables; core README "Images" section; roundtrip regression cases.

## React (`@meowdown/react`)

- New `<Editor>` props: `resolveImageUrl`, `onImageUpload`, `onImageUploadError`, threaded through a ref so a re-render with a new closure is never stranded, while upload enablement is fixed at first render. Ignored in source mode.

## Website

- Playground wired with a blob-URL demo upload.

## Test plan

- 442 tests pass (37 new across find-inline-images, image-preview, image-upload, and editor image specs).
- typecheck clean, lint clean (eslint + oxfmt + knip), both packages build, website builds.