### PR TITLE
feat(react): stop re-exporting core

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -5,9 +5,10 @@ React components for Meowdown, a hybrid (live-preview) Markdown editor.
 ## Usage
 
 ```tsx
-import { MeowdownEditor, type EditorHandle } from '@meowdown/react'
 import '@meowdown/core/style.css'
 import '@meowdown/react/style.css'
+
+import { MeowdownEditor, type EditorHandle } from '@meowdown/react'
 import { useRef, useCallback } from 'react'
 
 export function App() {
@@ -58,8 +59,6 @@ The Markdown editor component. Renders inside a `div.meowdown` wrapper that fill
 
 Re-exported from `@prosekit/react`. Call it from a component passed as `children` to read the live editor instance.
 
-Engine-level exports such as `checkRoundTrip`, `EDITOR_KEY_BINDINGS`, `MarkMode`, and `TypedEditor` come from [`@meowdown/core`](https://www.npmjs.com/package/@meowdown/core); import them from there directly.
-
 ### `EditorHandle`
 
 Imperative handle for the editor, attached via `handleRef`.
@@ -75,17 +74,6 @@ Imperative handle for the editor, attached via `handleRef`.
 - `editor: TypedEditor | undefined`: escape hatch for the underlying ProseKit editor, `undefined` in source mode. No stability guarantees beyond what `@meowdown/core` exports.
 
 Selection positions are in the mounted editor's coordinate space: ProseMirror document positions in the rich modes, character offsets in source mode. They round-trip within one mode but are not portable across a mode switch.
-
-## Keyboard shortcuts
-
-In the rich modes (`focus` / `show` / `hide`), these toggle inline formatting on the selection (`Mod` = Cmd on macOS, Ctrl elsewhere):
-
-| Key           | Action               |
-| ------------- | -------------------- |
-| `Mod-B`       | toggle bold          |
-| `Mod-I`       | toggle italic        |
-| `Mod-E`       | toggle inline code   |
-| `Mod-Shift-X` | toggle strikethrough |
 
 ## Styling
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -6,6 +6,7 @@ React components for Meowdown, a hybrid (live-preview) Markdown editor.
 
 ```tsx
 import { MeowdownEditor, type EditorHandle } from '@meowdown/react'
+import '@meowdown/core/style.css'
 import '@meowdown/react/style.css'
 import { useRef, useCallback } from 'react'
 
@@ -57,13 +58,7 @@ The Markdown editor component. Renders inside a `div.meowdown` wrapper that fill
 
 Re-exported from `@prosekit/react`. Call it from a component passed as `children` to read the live editor instance.
 
-### `checkRoundTrip`
-
-Re-exported from `@meowdown/core`. `checkRoundTrip(markdown)` returns `'exact' | 'normalizing' | 'lossy'`, for hosts that gate saving markdown files on whether the editor reproduces them faithfully.
-
-### `EDITOR_KEY_BINDINGS`
-
-Re-exported from `@meowdown/core`. A literal (`as const`) object mapping each editor shortcut (e.g. `Mod-b`, `Mod-1`) to its description, for host settings UIs and keybinding-collision checks.
+Engine-level exports such as `checkRoundTrip`, `EDITOR_KEY_BINDINGS`, `MarkMode`, and `TypedEditor` come from [`@meowdown/core`](https://www.npmjs.com/package/@meowdown/core); import them from there directly.
 
 ### `EditorHandle`
 
@@ -94,7 +89,7 @@ In the rich modes (`focus` / `show` / `hide`), these toggle inline formatting on
 
 ## Styling
 
-`@meowdown/react/style.css` includes the default theme from [`@meowdown/core`](https://www.npmjs.com/package/@meowdown/core).
+Import both stylesheets: `@meowdown/core/style.css` (the editor theme and variables) and `@meowdown/react/style.css` (the component layout). The core theme is documented in [`@meowdown/core`](https://www.npmjs.com/package/@meowdown/core).
 
 ## License
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -9,7 +9,5 @@ export type {
   WikilinkSearchHandler,
 } from './components/types.ts'
 
-export type { TypedEditor, MarkMode } from '@meowdown/core'
-export { checkRoundTrip, type RoundTripFidelity, EDITOR_KEY_BINDINGS } from '@meowdown/core'
 export type { SelectionJSON } from '@prosekit/core'
 export { useEditor } from '@prosekit/react'

--- a/packages/react/src/style.css
+++ b/packages/react/src/style.css
@@ -1,5 +1,3 @@
-@import '@meowdown/core/style.css';
-
 .meowdown {
   display: flex;
   flex-direction: column;

--- a/packages/react/src/testing/index.ts
+++ b/packages/react/src/testing/index.ts
@@ -1,3 +1,4 @@
+import '@meowdown/core/style.css'
 import '../style.css'
 
 import './locator.ts'

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@import '@meowdown/core/style.css';
 @import '@meowdown/react/style.css';
 @plugin '@egoist/tailwindcss-icons';
 


### PR DESCRIPTION
`@meowdown/react` re-exported engine-level things from `@meowdown/core` (`checkRoundTrip`, `RoundTripFidelity`, `EDITOR_KEY_BINDINGS`, `MarkMode`, `TypedEditor`) and bundled core's theme into `@meowdown/react/style.css`. Since hosts are expected to depend on both packages directly, the re-exports are redundant duplication.

- Drop the core re-exports from `src/index.ts`. `@meowdown/core` stays a dependency (react's internals use it); it is just no longer re-surfaced. React keeps exporting its own API plus the ProseKit `useEditor` / `SelectionJSON`.
- `@meowdown/react/style.css` no longer `@import`s `@meowdown/core/style.css`; it now contains only the React component layout. Import both stylesheets in an app.
- Trim the duplicated README sections.

**Breaking.** Consumers must import `checkRoundTrip` / `EDITOR_KEY_BINDINGS` / `MarkMode` / `TypedEditor` from `@meowdown/core`, and add `import '@meowdown/core/style.css'`. (A downstream app that currently imports these from `@meowdown/react` will be updated when it bumps to this release.)