### PR TITLE
feat(react): add table handle

### DIFF
--- a/packages/react/src/components/icons/grip-horizontal-icon.tsx
+++ b/packages/react/src/components/icons/grip-horizontal-icon.tsx
@@ -1,0 +1,22 @@
+// lucide "grip-horizontal", inlined since the package has no icon dependency.
+// Sized by the button CSS.
+export function GripHorizontalIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="9" r="1" />
+      <circle cx="19" cy="9" r="1" />
+      <circle cx="5" cy="9" r="1" />
+      <circle cx="12" cy="15" r="1" />
+      <circle cx="19" cy="15" r="1" />
+      <circle cx="5" cy="15" r="1" />
+    </svg>
+  )
+}

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -22,6 +22,7 @@ import { BlockHandle } from './block-handle.tsx'
 import { DropIndicator } from './drop-indicator.tsx'
 import { EditorExtensions } from './editor-extensions.tsx'
 import { SlashMenu } from './slash-menu.tsx'
+import { TableHandle } from './table-handle.tsx'
 import { TagMenu } from './tag-menu.tsx'
 import type {
   EditorHandle,
@@ -204,6 +205,7 @@ export function ProseKitEditor({
         readOnly={readOnly}
       />
       <BlockHandle />
+      {!readOnly && <TableHandle />}
       <DropIndicator />
       <SlashMenu />
       {onTagSearch && <TagMenu onTagSearch={onTagSearch} />}

--- a/packages/react/src/components/slash-menu.tsx
+++ b/packages/react/src/components/slash-menu.tsx
@@ -83,7 +83,7 @@ export function SlashMenu() {
           />
           <SlashMenuItem
             label="Table"
-            onSelect={() => editor.commands.insertTable({ row: 3, col: 3 })}
+            onSelect={() => editor.commands.insertTable({ row: 3, col: 3, header: true })}
           />
           <AutocompleteEmpty className={styles.Item}>No results</AutocompleteEmpty>
         </AutocompletePopup>

--- a/packages/react/src/components/table-handle.module.css
+++ b/packages/react/src/components/table-handle.module.css
@@ -56,6 +56,7 @@
   background: light-dark(#fff, #18181b);
   color: color-mix(in oklab, var(--meowdown-muted) 50%, transparent);
   cursor: grab;
+  outline: none;
   overflow: clip;
   transition: background-color 100ms;
 
@@ -81,6 +82,7 @@
   overscroll-behavior: contain;
   white-space: nowrap;
   user-select: none;
+  outline: none;
   border: 1px solid var(--meowdown-border);
   border-radius: 0.75rem;
   background: light-dark(#fff, #18181b);

--- a/packages/react/src/components/table-handle.module.css
+++ b/packages/react/src/components/table-handle.module.css
@@ -1,0 +1,146 @@
+.Positioner,
+.MenuPositioner {
+  display: block;
+  z-index: 50;
+  width: min-content;
+  height: min-content;
+  overflow: visible;
+  transition: transform 100ms ease-out;
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+}
+
+.ColumnPopup {
+  transform: translateY(50%);
+}
+
+.RowPopup {
+  transform: translateX(50%);
+}
+
+.ColumnPopup,
+.RowPopup {
+  display: flex;
+  box-sizing: border-box;
+  transform-origin: var(--transform-origin);
+  transition:
+    opacity 100ms,
+    scale 100ms;
+
+  &[data-state='closed'] {
+    opacity: 0;
+    scale: 0.95;
+    transition-duration: 150ms;
+  }
+
+  @starting-style {
+    opacity: 0;
+    scale: 0.95;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+}
+
+.Trigger {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  padding: 0;
+  border: 1px solid var(--meowdown-border);
+  border-radius: 0.25rem;
+  background: light-dark(#fff, #18181b);
+  color: color-mix(in oklab, var(--meowdown-muted) 50%, transparent);
+  cursor: grab;
+  overflow: clip;
+  transition: background-color 100ms;
+
+  &:hover {
+    background: light-dark(#f4f4f5, #27272a);
+  }
+
+  svg {
+    display: block;
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+}
+
+.MenuPopup {
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  min-width: 8rem;
+  max-height: 25rem;
+  padding: 0.25rem;
+  overflow: auto;
+  overscroll-behavior: contain;
+  white-space: nowrap;
+  user-select: none;
+  border: 1px solid var(--meowdown-border);
+  border-radius: 0.75rem;
+  background: light-dark(#fff, #18181b);
+  box-shadow:
+    0 10px 15px -3px rgb(0 0 0 / 0.1),
+    0 4px 6px -4px rgb(0 0 0 / 0.1);
+  transform-origin: var(--transform-origin);
+  transition:
+    opacity 100ms,
+    scale 100ms;
+
+  &[data-state='closed'] {
+    opacity: 0;
+    scale: 0.95;
+    transition-duration: 150ms;
+  }
+
+  @starting-style {
+    opacity: 0;
+    scale: 0.95;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+}
+
+.MenuItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  box-sizing: border-box;
+  padding: 0.375rem 0.75rem;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--meowdown-text);
+  white-space: nowrap;
+  cursor: default;
+  user-select: none;
+  outline: none;
+  scroll-margin: 0.25rem;
+
+  &[data-highlighted] {
+    background: light-dark(#f4f4f5, #27272a);
+  }
+
+  &[data-danger] {
+    color: light-dark(#ef4444, #f87171);
+  }
+
+  &[data-disabled='true'] {
+    pointer-events: none;
+    opacity: 0.5;
+  }
+
+  kbd {
+    font-family: var(--meowdown-font-mono);
+    font-size: 0.75rem;
+    color: var(--meowdown-muted);
+    opacity: 0.8;
+  }
+}

--- a/packages/react/src/components/table-handle.module.d.css.ts
+++ b/packages/react/src/components/table-handle.module.d.css.ts
@@ -1,0 +1,13 @@
+// @ts-nocheck
+declare const styles = {
+  'Positioner': '' as string,
+  'MenuPositioner': '' as string,
+  'ColumnPopup': '' as string,
+  'RowPopup': '' as string,
+  'ColumnPopup': '' as string,
+  'RowPopup': '' as string,
+  'Trigger': '' as string,
+  'MenuPopup': '' as string,
+  'MenuItem': '' as string,
+} as const;
+export default styles;

--- a/packages/react/src/components/table-handle.test.tsx
+++ b/packages/react/src/components/table-handle.test.tsx
@@ -1,0 +1,88 @@
+import '../testing/index.ts'
+
+import { createRef, type Ref } from 'react'
+import { describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-react'
+import { page } from 'vitest/browser'
+
+import { hover, unhover } from '../testing/mouse.ts'
+
+import { ProseKitEditor } from './prosekit-editor.tsx'
+import type { EditorHandle } from './types.ts'
+
+const pmRoot = page.locate('.ProseMirror')
+const columnHandle = page.getByTestId('table-handle-column')
+const rowHandle = page.getByTestId('table-handle-row')
+const columnMenu = page.getByTestId('table-handle-column-menu')
+const rowMenu = page.getByTestId('table-handle-row-menu')
+
+const TABLE_MARKDOWN = '| a | b |\n| --- | --- |\n| 1 | 2 |\n'
+
+// The mouse position persists across tests; park it first so a leftover
+// position over the new editor cannot open a handle.
+async function renderEditor(ref?: Ref<EditorHandle>) {
+  await unhover()
+  return await render(<ProseKitEditor ref={ref} initialMarkdown={TABLE_MARKDOWN} />)
+}
+
+// The first body cell ("1") sits in column 0, row 1. Hovering it reveals both
+// the column handle (above column 0) and the row handle (left of that row).
+function firstBodyCell() {
+  return pmRoot.locate('td').first()
+}
+
+describe('TableHandle', () => {
+  it('shows the column and row handles when hovering a cell', async () => {
+    await renderEditor()
+    await expect.element(columnHandle).not.toBeVisible()
+    await expect.element(rowHandle).not.toBeVisible()
+    await hover(firstBodyCell())
+    await expect.element(columnHandle).toBeVisible()
+    await expect.element(rowHandle).toBeVisible()
+  })
+
+  it('inserts a column to the right', async () => {
+    const ref = createRef<EditorHandle>()
+    await renderEditor(ref)
+    await hover(firstBodyCell())
+    await columnHandle.click()
+    await columnMenu.getByTestId('table-insert-right').click()
+    expect(ref.current?.getMarkdown()).toBe('| a |  | b |\n| --- | --- | --- |\n| 1 |  | 2 |\n')
+  })
+
+  it('deletes a column', async () => {
+    const ref = createRef<EditorHandle>()
+    await renderEditor(ref)
+    await hover(firstBodyCell())
+    await columnHandle.click()
+    await columnMenu.getByTestId('table-delete-column').click()
+    expect(ref.current?.getMarkdown()).toBe('| b |\n| --- |\n| 2 |\n')
+  })
+
+  it('inserts a row below', async () => {
+    const ref = createRef<EditorHandle>()
+    await renderEditor(ref)
+    await hover(firstBodyCell())
+    await rowHandle.click()
+    await rowMenu.getByTestId('table-insert-below').click()
+    expect(ref.current?.getMarkdown()).toBe('| a | b |\n| --- | --- |\n| 1 | 2 |\n|  |  |\n')
+  })
+
+  it('deletes a row', async () => {
+    const ref = createRef<EditorHandle>()
+    await renderEditor(ref)
+    await hover(firstBodyCell())
+    await rowHandle.click()
+    await rowMenu.getByTestId('table-delete-row').click()
+    expect(ref.current?.getMarkdown()).toBe('| a | b |\n| --- | --- |\n')
+  })
+
+  it('deletes the whole table', async () => {
+    const ref = createRef<EditorHandle>()
+    await renderEditor(ref)
+    await hover(firstBodyCell())
+    await columnHandle.click()
+    await columnMenu.getByTestId('table-delete-table-column').click()
+    expect(ref.current?.getMarkdown().includes('|')).toBe(false)
+  })
+})

--- a/packages/react/src/components/table-handle.tsx
+++ b/packages/react/src/components/table-handle.tsx
@@ -1,0 +1,195 @@
+import type { EditorExtension } from '@meowdown/core'
+import type { Editor } from '@prosekit/core'
+import { useEditorDerivedValue } from '@prosekit/react'
+import { MenuItem, MenuPopup, MenuPositioner } from '@prosekit/react/menu'
+import {
+  TableHandleColumnMenuRoot,
+  TableHandleColumnMenuTrigger,
+  TableHandleColumnPopup,
+  TableHandleColumnPositioner,
+  TableHandleDragPreview,
+  TableHandleDropIndicator,
+  TableHandleRoot,
+  TableHandleRowMenuRoot,
+  TableHandleRowMenuTrigger,
+  TableHandleRowPopup,
+  TableHandleRowPositioner,
+} from '@prosekit/react/table-handle'
+
+import { GripHorizontalIcon } from './icons/grip-horizontal-icon.tsx'
+import { GripVerticalIcon } from './icons/grip-vertical-icon.tsx'
+import styles from './table-handle.module.css'
+
+function getTableHandleState(editor: Editor<EditorExtension>) {
+  const commands = editor.commands
+  return {
+    addTableColumnBefore: {
+      canExec: commands.addTableColumnBefore.canExec(),
+      command: () => commands.addTableColumnBefore(),
+    },
+    addTableColumnAfter: {
+      canExec: commands.addTableColumnAfter.canExec(),
+      command: () => commands.addTableColumnAfter(),
+    },
+    addTableRowAbove: {
+      canExec: commands.addTableRowAbove.canExec(),
+      command: () => commands.addTableRowAbove(),
+    },
+    addTableRowBelow: {
+      canExec: commands.addTableRowBelow.canExec(),
+      command: () => commands.addTableRowBelow(),
+    },
+    deleteCellSelection: {
+      canExec: commands.deleteCellSelection.canExec(),
+      command: () => commands.deleteCellSelection(),
+    },
+    deleteTableColumn: {
+      canExec: commands.deleteTableColumn.canExec(),
+      command: () => commands.deleteTableColumn(),
+    },
+    deleteTableRow: {
+      canExec: commands.deleteTableRow.canExec(),
+      command: () => commands.deleteTableRow(),
+    },
+    deleteTable: {
+      canExec: commands.deleteTable.canExec(),
+      command: () => commands.deleteTable(),
+    },
+  }
+}
+
+export function TableHandle() {
+  const state = useEditorDerivedValue(getTableHandleState)
+
+  return (
+    <TableHandleRoot>
+      <TableHandleDragPreview />
+      <TableHandleDropIndicator />
+
+      <TableHandleColumnPositioner className={styles.Positioner}>
+        <TableHandleColumnPopup className={styles.ColumnPopup}>
+          <TableHandleColumnMenuRoot>
+            <TableHandleColumnMenuTrigger
+              className={styles.Trigger}
+              data-testid="table-handle-column"
+            >
+              <GripHorizontalIcon />
+            </TableHandleColumnMenuTrigger>
+            <MenuPositioner className={styles.MenuPositioner}>
+              <MenuPopup className={styles.MenuPopup} data-testid="table-handle-column-menu">
+                {state.addTableColumnBefore.canExec && (
+                  <MenuItem
+                    className={styles.MenuItem}
+                    data-testid="table-insert-left"
+                    onSelect={state.addTableColumnBefore.command}
+                  >
+                    <span>Insert Left</span>
+                  </MenuItem>
+                )}
+                {state.addTableColumnAfter.canExec && (
+                  <MenuItem
+                    className={styles.MenuItem}
+                    data-testid="table-insert-right"
+                    onSelect={state.addTableColumnAfter.command}
+                  >
+                    <span>Insert Right</span>
+                  </MenuItem>
+                )}
+                {state.deleteCellSelection.canExec && (
+                  <MenuItem
+                    className={styles.MenuItem}
+                    data-testid="table-clear-column"
+                    onSelect={state.deleteCellSelection.command}
+                  >
+                    <span>Clear Contents</span>
+                    <kbd>Del</kbd>
+                  </MenuItem>
+                )}
+                {state.deleteTableColumn.canExec && (
+                  <MenuItem
+                    className={styles.MenuItem}
+                    data-testid="table-delete-column"
+                    onSelect={state.deleteTableColumn.command}
+                  >
+                    <span>Delete Column</span>
+                  </MenuItem>
+                )}
+                {state.deleteTable.canExec && (
+                  <MenuItem
+                    className={styles.MenuItem}
+                    data-danger=""
+                    data-testid="table-delete-table-column"
+                    onSelect={state.deleteTable.command}
+                  >
+                    <span>Delete Table</span>
+                  </MenuItem>
+                )}
+              </MenuPopup>
+            </MenuPositioner>
+          </TableHandleColumnMenuRoot>
+        </TableHandleColumnPopup>
+      </TableHandleColumnPositioner>
+
+      <TableHandleRowPositioner placement="left" className={styles.Positioner}>
+        <TableHandleRowPopup className={styles.RowPopup}>
+          <TableHandleRowMenuRoot>
+            <TableHandleRowMenuTrigger className={styles.Trigger} data-testid="table-handle-row">
+              <GripVerticalIcon />
+            </TableHandleRowMenuTrigger>
+            <MenuPositioner className={styles.MenuPositioner}>
+              <MenuPopup className={styles.MenuPopup} data-testid="table-handle-row-menu">
+                {state.addTableRowAbove.canExec && (
+                  <MenuItem
+                    className={styles.MenuItem}
+                    data-testid="table-insert-above"
+                    onSelect={state.addTableRowAbove.command}
+                  >
+                    <span>Insert Above</span>
+                  </MenuItem>
+                )}
+                {state.addTableRowBelow.canExec && (
+                  <MenuItem
+                    className={styles.MenuItem}
+                    data-testid="table-insert-below"
+                    onSelect={state.addTableRowBelow.command}
+                  >
+                    <span>Insert Below</span>
+                  </MenuItem>
+                )}
+                {state.deleteCellSelection.canExec && (
+                  <MenuItem
+                    className={styles.MenuItem}
+                    data-testid="table-clear-row"
+                    onSelect={state.deleteCellSelection.command}
+                  >
+                    <span>Clear Contents</span>
+                    <kbd>Del</kbd>
+                  </MenuItem>
+                )}
+                {state.deleteTableRow.canExec && (
+                  <MenuItem
+                    className={styles.MenuItem}
+                    data-testid="table-delete-row"
+                    onSelect={state.deleteTableRow.command}
+                  >
+                    <span>Delete Row</span>
+                  </MenuItem>
+                )}
+                {state.deleteTable.canExec && (
+                  <MenuItem
+                    className={styles.MenuItem}
+                    data-danger=""
+                    data-testid="table-delete-table-row"
+                    onSelect={state.deleteTable.command}
+                  >
+                    <span>Delete Table</span>
+                  </MenuItem>
+                )}
+              </MenuPopup>
+            </MenuPositioner>
+          </TableHandleRowMenuRoot>
+        </TableHandleRowPopup>
+      </TableHandleRowPositioner>
+    </TableHandleRoot>
+  )
+}


### PR DESCRIPTION
Adds a hover-activated table handle to `@meowdown/react` so users can edit table structure with the mouse, mirroring the existing block handle.

## What

- Hover a table cell to reveal a column handle (above the column) and a row handle (left of the row).
- Click a handle to open a menu:
  - Column: Insert Left, Insert Right, Clear Contents, Delete Column, Delete Table.
  - Row: Insert Above, Insert Below, Clear Contents, Delete Row, Delete Table.
- The triggers are draggable, so reordering rows/columns works too (via ProseKit's drag preview + drop indicator).

## How

meowdown already ships editable GFM tables (schema, markdown round-trip, table commands), so this is a thin React wrapper:

- `table-handle.tsx` composes `@prosekit/react/table-handle` + `@prosekit/react/menu`, wiring commands through a `useEditorDerivedValue` helper (same pattern as the ProseKit table example).
- `table-handle.module.css` styles it with `--meowdown-*` variables, matching `block-handle` and `autocomplete-menu`.
- `grip-horizontal-icon.tsx` adds the column grip (row reuses the existing grip-vertical).
- Rendered next to `<BlockHandle />` in `prosekit-editor.tsx`, gated on `!readOnly`. It only appears in rich modes (source mode uses CodeMirror).

The component stays internal (not exported from the package index), consistent with `BlockHandle`.

## Tests

`table-handle.test.tsx` (browser) covers: handles appear on cell hover, insert/delete column, insert/delete row, and delete table.