### PR TITLE
fix(core): keep empty table cells on markdown round-trip

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,7 @@
     "@ocavue/tsconfig": "^0.7.1",
     "@tsdown/css": "^0.22.2",
     "@vitest/browser-playwright": "^4.1.8",
+    "dedent": "^1.7.2",
     "diffable-html-snapshot": "^0.2.0",
     "tsdown": "^0.22.2",
     "vitest": "^4.1.8"

--- a/packages/core/src/converters/check-roundtrip.test.ts
+++ b/packages/core/src/converters/check-roundtrip.test.ts
@@ -1,9 +1,31 @@
+import dedent from 'dedent'
 import { describe, expect, it } from 'vitest'
 
 import { checkRoundTrip } from './check-roundtrip.ts'
 
 describe('checkRoundTrip', () => {
-  it.each(['hello world', '# Hello\n\nWorld', '- a\n- b'])('reports exact for %j', (markdown) => {
+  it.each([
+    'hello world',
+    dedent`
+      # Hello
+
+      World
+    `,
+    dedent`
+      - a
+      - b
+    `,
+    dedent`
+      |  |  |  |
+      | --- | --- | --- |
+      |  |  |  |
+    `,
+    dedent`
+      | a |  | c |
+      | --- | --- | --- |
+      |  | b |  |
+    `,
+  ])('reports exact for %j', (markdown) => {
     expect(checkRoundTrip(markdown)).toBe('exact')
   })
 
@@ -15,9 +37,15 @@ describe('checkRoundTrip', () => {
   })
 
   it.each([
-    'Hello\n=====', // setext heading
+    dedent`
+      Hello
+      =====
+    `, // setext heading
     '<div class="x">hi</div>', // raw HTML block
-    '* a\n* b', // bullet markers normalize to `-`
+    dedent`
+      * a
+      * b
+    `, // bullet markers normalize to `-`
   ])('reports lossy for %j', (markdown) => {
     expect(checkRoundTrip(markdown)).toBe('lossy')
   })

--- a/packages/core/src/converters/md-to-pm.test.ts
+++ b/packages/core/src/converters/md-to-pm.test.ts
@@ -1,4 +1,5 @@
 import { createEditor } from '@prosekit/core'
+import dedent from 'dedent'
 import { describe, expect, it } from 'vitest'
 
 import { defineEditorExtension } from '../extensions/extension.ts'
@@ -7,6 +8,21 @@ import { markdownToDoc } from './md-to-pm.ts'
 import { sampleContent, sampleContentMarkdown } from './sample-content.ts'
 
 const editor = createEditor({ extension: defineEditorExtension() })
+
+function tableShape(markdown: string): Array<Array<{ type: string; text: string }>> {
+  const table = markdownToDoc(editor, markdown).child(0)
+  const rows: Array<Array<{ type: string; text: string }>> = []
+  for (let r = 0; r < table.childCount; r++) {
+    const row = table.child(r)
+    const cells: Array<{ type: string; text: string }> = []
+    for (let c = 0; c < row.childCount; c++) {
+      const cell = row.child(c)
+      cells.push({ type: cell.type.name, text: cell.textContent })
+    }
+    rows.push(cells)
+  }
+  return rows
+}
 
 describe('markdownToDoc', () => {
   it('converts a heading', () => {
@@ -52,7 +68,11 @@ describe('markdownToDoc', () => {
   })
 
   it('flattens a bullet list', () => {
-    expect(markdownToDoc(editor, '- one\n- two').toJSON()).toEqual({
+    const md = dedent`
+      - one
+      - two
+    `
+    expect(markdownToDoc(editor, md).toJSON()).toEqual({
       type: 'doc',
       content: [
         {
@@ -80,7 +100,11 @@ describe('markdownToDoc', () => {
   })
 
   it('keeps the start number of an ordered list', () => {
-    expect(markdownToDoc(editor, '5. five\n6. six').toJSON()).toEqual({
+    const md = dedent`
+      5. five
+      6. six
+    `
+    expect(markdownToDoc(editor, md).toJSON()).toEqual({
       type: 'doc',
       content: [
         {
@@ -144,7 +168,11 @@ describe('markdownToDoc', () => {
   })
 
   it('mixes task and plain items in one bullet list', () => {
-    const doc = markdownToDoc(editor, '- [x] done\n- plain').toJSON() as {
+    const md = dedent`
+      - [x] done
+      - plain
+    `
+    const doc = markdownToDoc(editor, md).toJSON() as {
       content: Array<{ attrs: { kind: string; checked: boolean } }>
     }
     expect(doc.content.map((item) => item.attrs.kind)).toEqual(['task', 'bullet'])
@@ -192,7 +220,11 @@ describe('markdownToDoc', () => {
   })
 
   it('converts a GFM table with a header row', () => {
-    const md = '| a | b |\n|---|---|\n| 1 | 2 |\n'
+    const md = dedent`
+      | a | b |
+      |---|---|
+      | 1 | 2 |
+    `
     expect(markdownToDoc(editor, md).toJSON()).toEqual({
       type: 'doc',
       content: [
@@ -253,6 +285,66 @@ describe('markdownToDoc', () => {
         },
       ],
     })
+  })
+
+  it('keeps empty cells when the whole table is empty', () => {
+    const md = dedent`
+      |     |     |     |
+      | --- | --- | --- |
+      |     |     |     |
+    `
+    expect(tableShape(md)).toEqual([
+      [
+        { type: 'tableHeaderCell', text: '' },
+        { type: 'tableHeaderCell', text: '' },
+        { type: 'tableHeaderCell', text: '' },
+      ],
+      [
+        { type: 'tableCell', text: '' },
+        { type: 'tableCell', text: '' },
+        { type: 'tableCell', text: '' },
+      ],
+    ])
+  })
+
+  it('places cells in the correct columns when some are empty', () => {
+    const md = dedent`
+      | a   |     | c   |
+      | --- | --- | --- |
+      |     | b   |     |
+    `
+    expect(tableShape(md)).toEqual([
+      [
+        { type: 'tableHeaderCell', text: 'a' },
+        { type: 'tableHeaderCell', text: '' },
+        { type: 'tableHeaderCell', text: 'c' },
+      ],
+      [
+        { type: 'tableCell', text: '' },
+        { type: 'tableCell', text: 'b' },
+        { type: 'tableCell', text: '' },
+      ],
+    ])
+  })
+
+  it('pads a short row to the header column count', () => {
+    const md = dedent`
+      | a   | b   | c   |
+      | --- | --- | --- |
+      | 1   |
+    `
+    expect(tableShape(md)).toEqual([
+      [
+        { type: 'tableHeaderCell', text: 'a' },
+        { type: 'tableHeaderCell', text: 'b' },
+        { type: 'tableHeaderCell', text: 'c' },
+      ],
+      [
+        { type: 'tableCell', text: '1' },
+        { type: 'tableCell', text: '' },
+        { type: 'tableCell', text: '' },
+      ],
+    ])
   })
 
   it('round-trips the full sample document', () => {

--- a/packages/core/src/converters/md-to-pm.ts
+++ b/packages/core/src/converters/md-to-pm.ts
@@ -254,20 +254,37 @@ function convertCodeBlock(editor: TypedEditor, cursor: TreeCursor, text: string)
 }
 
 function convertTable(editor: TypedEditor, cursor: TreeCursor, text: string): ProseMirrorNode {
+  // The delimiter row (a `TableDelimiter` that is a direct child of `Table`)
+  // is the only source that always encodes every column, so it drives the
+  // column count. `@lezer/markdown` emits no `TableCell` for an empty cell, so
+  // counting per-row cells would drop empty columns and misalign the rest.
+  let columnCount = 0
+  if (cursor.firstChild()) {
+    do {
+      if (cursor.type.id === LEZER_NODE_IDS.TableDelimiter) {
+        columnCount = countDelimiterColumns(text.slice(cursor.from, cursor.to))
+      }
+    } while (cursor.nextSibling())
+    cursor.parent()
+  }
+
   const rows: ProseMirrorNode[] = []
   if (cursor.firstChild()) {
     do {
       const id = cursor.type.id
       if (id === LEZER_NODE_IDS.TableHeader) {
-        rows.push(convertTableRow(editor, cursor, text, true))
+        rows.push(convertTableRow(editor, cursor, text, true, columnCount))
       } else if (id === LEZER_NODE_IDS.TableRow) {
-        rows.push(convertTableRow(editor, cursor, text, false))
+        rows.push(convertTableRow(editor, cursor, text, false, columnCount))
       }
-      // TableDelimiter between header and body is intentionally skipped.
     } while (cursor.nextSibling())
     cursor.parent()
   }
   return editor.nodes.table(rows)
+}
+
+function countDelimiterColumns(separator: string): number {
+  return separator.split('|').filter((segment) => segment.trim() !== '').length
 }
 
 function convertTableRow(
@@ -275,19 +292,28 @@ function convertTableRow(
   cursor: TreeCursor,
   text: string,
   isHeader: boolean,
+  columnCount: number,
 ): ProseMirrorNode {
-  const cells: ProseMirrorNode[] = []
+  const cellTexts: string[] = Array<string>(columnCount).fill('')
   if (cursor.firstChild()) {
+    const hasLeadingPipe = cursor.type.id === LEZER_NODE_IDS.TableDelimiter
+    let delimiterCount = 0
     do {
-      if (cursor.type.id === LEZER_NODE_IDS.TableCell) {
-        const cellText = text.slice(cursor.from, cursor.to).trim()
-        const paragraph = editor.nodes.paragraph(cellText)
-        cells.push(
-          isHeader ? editor.nodes.tableHeaderCell(paragraph) : editor.nodes.tableCell(paragraph),
-        )
+      if (cursor.type.id === LEZER_NODE_IDS.TableDelimiter) {
+        delimiterCount++
+      } else if (cursor.type.id === LEZER_NODE_IDS.TableCell) {
+        const column = delimiterCount - (hasLeadingPipe ? 1 : 0)
+        if (column >= 0 && column < columnCount) {
+          cellTexts[column] = text.slice(cursor.from, cursor.to).trim()
+        }
       }
     } while (cursor.nextSibling())
     cursor.parent()
   }
+
+  const cells = cellTexts.map((cellText) => {
+    const paragraph = editor.nodes.paragraph(cellText)
+    return isHeader ? editor.nodes.tableHeaderCell(paragraph) : editor.nodes.tableCell(paragraph)
+  })
   return editor.nodes.tableRow(cells)
 }

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -1,4 +1,5 @@
 import { createEditor } from '@prosekit/core'
+import dedent from 'dedent'
 import { describe, expect, it } from 'vitest'
 
 import { defineEditorExtension } from '../extensions/extension.ts'
@@ -24,19 +25,43 @@ describe('markdown round-trip is byte-identical', () => {
     // Task lists (GFM `Task` / `TaskMarker`)
     '- [ ] todo',
     '- [x] done',
-    '- [ ] todo\n- [x] done\n- [ ] another',
-    '- [x] done\n- plain item\n- [ ] todo',
-    '- [ ] parent\n  - [x] child',
+    dedent`
+      - [ ] todo
+      - [x] done
+      - [ ] another
+    `,
+    dedent`
+      - [x] done
+      - plain item
+      - [ ] todo
+    `,
+    dedent`
+      - [ ] parent
+        - [x] child
+    `,
     '- [ ]  double-spaced text',
     // Task marker inside an ordered list has no `task` list kind to map to;
     // the marker survives as literal paragraph text instead.
     '1. [x] done',
     // Tight lists stay tight
-    '- a\n- b',
-    '- parent\n  - child',
-    '1. one\n1. two',
+    dedent`
+      - a
+      - b
+    `,
+    dedent`
+      - parent
+        - child
+    `,
+    dedent`
+      1. one
+      1. two
+    `,
     // A genuinely loose item (two blocks) keeps its blank line
-    '- a\n\n  second paragraph',
+    dedent`
+      - a
+
+        second paragraph
+    `,
     // Tags are plain text to the converters
     'hello #meow',
     // `#tag` at line start is NOT a heading (no space after `#`)
@@ -49,6 +74,23 @@ describe('markdown round-trip is byte-identical', () => {
     '- [ ] [[note]] item',
     '> [[note]] quoted',
     '[[note with spaces]] and #tag',
+    // Tables, including empty and partially-empty cells. The serializer writes
+    // empty cells unpadded (`|  |`), so these stay unaligned to match its bytes.
+    dedent`
+      | a | b |
+      | --- | --- |
+      | 1 | 2 |
+    `,
+    dedent`
+      |  |  |  |
+      | --- | --- | --- |
+      |  |  |  |
+    `,
+    dedent`
+      | a |  | c |
+      | --- | --- | --- |
+      |  | b |  |
+    `,
   ]
 
   for (const markdown of cases) {

--- a/packages/core/src/lezer/hashtag.test.ts
+++ b/packages/core/src/lezer/hashtag.test.ts
@@ -1,3 +1,4 @@
+import dedent from 'dedent'
 import { describe, expect, it } from 'vitest'
 
 import { type InlineElement, parseInline } from './inline.ts'
@@ -113,7 +114,12 @@ describe('hashtag inline parser', () => {
   })
 
   it('is never produced by gfmBlockOnlyParser', () => {
-    const tree = gfmBlockOnlyParser.parse('hello #meow\n\n# heading #tag')
+    const markdown = dedent`
+      hello #meow
+
+      # heading #tag
+    `
+    const tree = gfmBlockOnlyParser.parse(markdown)
     let sawHashtag = false
     tree.iterate({
       enter(node) {

--- a/packages/core/src/lezer/wikilink.test.ts
+++ b/packages/core/src/lezer/wikilink.test.ts
@@ -1,3 +1,4 @@
+import dedent from 'dedent'
 import { describe, expect, it } from 'vitest'
 
 import { type InlineElement, parseInline } from './inline.ts'
@@ -134,7 +135,12 @@ describe('wikilink inline parser', () => {
   })
 
   it('is never produced by gfmBlockOnlyParser', () => {
-    const tree = gfmBlockOnlyParser.parse('hello [[note]]\n\n# heading [[x]]')
+    const markdown = dedent`
+      hello [[note]]
+
+      # heading [[x]]
+    `
+    const tree = gfmBlockOnlyParser.parse(markdown)
     let sawWikilink = false
     tree.iterate({
       enter(node) {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -52,6 +52,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitest/browser-playwright": "^4.1.8",
+    "dedent": "^1.7.2",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "tsdown": "^0.22.2",

--- a/packages/react/src/components/table-handle.test.tsx
+++ b/packages/react/src/components/table-handle.test.tsx
@@ -1,5 +1,6 @@
 import '../testing/index.ts'
 
+import dedent from 'dedent'
 import { createRef, type Ref } from 'react'
 import { describe, expect, it } from 'vitest'
 import { render } from 'vitest-browser-react'
@@ -16,7 +17,11 @@ const rowHandle = page.getByTestId('table-handle-row')
 const columnMenu = page.getByTestId('table-handle-column-menu')
 const rowMenu = page.getByTestId('table-handle-row-menu')
 
-const TABLE_MARKDOWN = '| a | b |\n| --- | --- |\n| 1 | 2 |\n'
+const TABLE_MARKDOWN = dedent`
+  | a | b |
+  | --- | --- |
+  | 1 | 2 |
+`
 
 // The mouse position persists across tests; park it first so a leftover
 // position over the new editor cannot open a handle.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: ^4.1.8
         version: 4.1.8(playwright@1.60.0)(vite@8.0.16)(vitest@4.1.8)
+      dedent:
+        specifier: ^1.7.2
+        version: 1.7.2
       diffable-html-snapshot:
         specifier: ^0.2.0
         version: 0.2.0
@@ -152,6 +155,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: ^4.1.8
         version: 4.1.8(playwright@1.60.0)(vite@8.0.16)(vitest@4.1.8)
+      dedent:
+        specifier: ^1.7.2
+        version: 1.7.2
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -1828,6 +1834,14 @@ packages:
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
+  dedent@1.7.2:
+    resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -5139,6 +5153,8 @@ snapshots:
   decode-named-character-reference@1.3.0:
     dependencies:
       character-entities: 2.0.2
+
+  dedent@1.7.2: {}
 
   deep-is@0.1.4: {}
 


### PR DESCRIPTION
## Problem

A Markdown table whose cells are empty (e.g. a freshly inserted table) does not survive a parse-then-serialize round trip. The whole table disappears, or, for a partially-empty table, columns collapse and cell content shifts into the wrong columns.

This surfaced downstream in reflect-open, whose data-loss gate (`checkRoundTrip`) opens any note read-only when its Markdown does not round-trip faithfully. A daily note with an empty table opened read-only with the banner "This note contains markdown the editor can't yet reproduce faithfully".

## Root cause

`@lezer/markdown`'s GFM table parser does not emit a `TableCell` node for an empty cell, it only emits the `|` separators as `TableDelimiter` nodes. `convertTableRow` in `md-to-pm.ts` built cells solely from `TableCell` nodes, so every empty cell was silently dropped:

- All-empty table: rows end up with zero cells, and `docToMarkdown` then serializes nothing.
- Partially-empty table: surviving cells shift left into the wrong columns.

## Fix

Reconstruct one cell per column from the table geometry instead of trusting Lezer to emit a `TableCell` per cell:

- `convertTable` derives the column count from the delimiter (separator) row, the single `TableDelimiter` that is a direct child of `Table`. It always encodes every column.
- `convertTableRow` builds exactly that many cells, placing each `TableCell` into its column slot (`delimitersSeen - leadingPipe`) and filling the rest with empty paragraphs.

`pm-to-md.ts` needs no change: once every row carries the full column count, its existing padding produces the expected `|  |  |  |` output.

## Tests

- New `md-to-pm` cases: all-empty table, correct column placement with interleaved empties, and short-row padding.
- New `roundtrip` and `check-roundtrip` cases: empty and partially-empty tables now round-trip byte-identically and classify as `exact`.

## Test fixture refactor

Multi-line Markdown **input** fixtures across the test suite now use `dedent` template literals instead of `'a\nb\nc'` packed strings, which are hard to read. Expected-**output** assertions (`expect(...).toBe('a\nb\n')`) are left unchanged.