### PR TITLE
feat(core): autolink bare URLs

### DIFF
--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -73,7 +73,7 @@ describe('markdown round-trip is byte-identical', () => {
     'visit https://example.com now',
     'see www.example.com here',
     'mail me@example.com ok',
-    'a <https://x.io> b',
+    'a <https://example.com> b',
     'end https://example.com.',
     // Tables, including empty and partially-empty cells. The serializer writes
     // empty cells unpadded (`|  |`), so these stay unaligned to match its bytes.

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -69,6 +69,12 @@ describe('markdown round-trip is byte-identical', () => {
     '- [ ] [[note]] item',
     '> [[note]] quoted',
     '[[note with spaces]] and #tag',
+    // Autolinks are plain text to the converters (marks decorate, not rewrite)
+    'visit https://example.com now',
+    'see www.example.com here',
+    'mail me@example.com ok',
+    'a <https://x.io> b',
+    'end https://example.com.',
     // Tables, including empty and partially-empty cells. The serializer writes
     // empty cells unpadded (`|  |`), so these stay unaligned to match its bytes.
     dedent`

--- a/packages/core/src/extensions/inline-mark-plugin.test.ts
+++ b/packages/core/src/extensions/inline-mark-plugin.test.ts
@@ -53,6 +53,19 @@ describe('inlineMarkPlugin', () => {
     expect(linkText!.attrs.href).toBe('http://x.test')
   })
 
+  it('applies mdLinkText with a derived href on a bare autolink', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    const doc = n.doc(n.paragraph('visit https://example.com now'))
+    fixture.set(doc)
+
+    const pos = findText(fixture.doc, 'https://example.com')
+    const $pos = fixture.doc.resolve(pos + 1)
+    const linkText = $pos.marks().find((m) => m.type.name === 'mdLinkText')
+    expect(linkText).toBeTruthy()
+    expect(linkText!.attrs.href).toBe('https://example.com')
+  })
+
   it('marks `*foo*` inside headings as well', () => {
     using fixture = setupFixture()
     const { n } = fixture

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
@@ -163,51 +163,51 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('autolinks a bare mailto URL, keeping the scheme', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'a mailto:me@x.io b')
+    const chunks = inlineTextToMarkChunks(schema, 'a mailto:me@example.com b')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
-      2-16: mdLinkText(href=mailto:me@x.io)
-      16-18: -
+      2-23: mdLinkText(href=mailto:me@example.com)
+      23-25: -
       "
     `)
   })
 
   it('autolinks an angle-bracket URL, with the brackets as mdMark', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'a <https://x.io> b')
+    const chunks = inlineTextToMarkChunks(schema, 'a <https://example.com> b')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
       2-3: mdMark
-      3-15: mdLinkText(href=https://x.io)
-      15-16: mdMark
-      16-18: -
+      3-22: mdLinkText(href=https://example.com)
+      22-23: mdMark
+      23-25: -
       "
     `)
   })
 
   it('keeps a non-http scheme in an angle autolink', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'a <ftp://host> b')
+    const chunks = inlineTextToMarkChunks(schema, 'a <ftp://example.com> b')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
       2-3: mdMark
-      3-13: mdLinkText(href=ftp://host)
-      13-14: mdMark
-      14-16: -
+      3-20: mdLinkText(href=ftp://example.com)
+      20-21: mdMark
+      21-23: -
       "
     `)
   })
 
   it('keeps an ssh scheme in an angle autolink', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'a <ssh://host> b')
+    const chunks = inlineTextToMarkChunks(schema, 'a <ssh://example.com> b')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
       2-3: mdMark
-      3-13: mdLinkText(href=ssh://host)
-      13-14: mdMark
-      14-16: -
+      3-20: mdLinkText(href=ssh://example.com)
+      20-21: mdMark
+      21-23: -
       "
     `)
   })
@@ -224,21 +224,21 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('autolinks a URL nested in emphasis', () => {
-    const chunks = inlineTextToMarkChunks(schema, '*https://x.io*')
+    const chunks = inlineTextToMarkChunks(schema, '*https://example.com*')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-1: mdEm + mdMark
-      1-13: mdEm + mdLinkText(href=https://x.io)
-      13-14: mdEm + mdMark
+      1-20: mdEm + mdLinkText(href=https://example.com)
+      20-21: mdEm + mdMark
       "
     `)
   })
 
   it('does not bare-autolink a non-http scheme', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'a ftp://host b')
+    const chunks = inlineTextToMarkChunks(schema, 'a ftp://example.com b')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-14: -
+      0-21: -
       "
     `)
   })

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
@@ -129,6 +129,129 @@ describe('inlineTextToMarkChunks', () => {
     `)
   })
 
+  it('autolinks a bare https URL', () => {
+    const chunks = inlineTextToMarkChunks(schema, 'visit https://example.com now')
+    expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
+      "
+      0-6: -
+      6-25: mdLinkText(href=https://example.com)
+      25-29: -
+      "
+    `)
+  })
+
+  it('autolinks a www URL with an implied https scheme', () => {
+    const chunks = inlineTextToMarkChunks(schema, 'see www.example.com here')
+    expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
+      "
+      0-4: -
+      4-19: mdLinkText(href=https://www.example.com)
+      19-24: -
+      "
+    `)
+  })
+
+  it('autolinks a bare email as mailto', () => {
+    const chunks = inlineTextToMarkChunks(schema, 'mail me@example.com ok')
+    expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
+      "
+      0-5: -
+      5-19: mdLinkText(href=mailto:me@example.com)
+      19-22: -
+      "
+    `)
+  })
+
+  it('autolinks a bare mailto URL, keeping the scheme', () => {
+    const chunks = inlineTextToMarkChunks(schema, 'a mailto:me@x.io b')
+    expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
+      "
+      0-2: -
+      2-16: mdLinkText(href=mailto:me@x.io)
+      16-18: -
+      "
+    `)
+  })
+
+  it('autolinks an angle-bracket URL, with the brackets as mdMark', () => {
+    const chunks = inlineTextToMarkChunks(schema, 'a <https://x.io> b')
+    expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
+      "
+      0-2: -
+      2-3: mdMark
+      3-15: mdLinkText(href=https://x.io)
+      15-16: mdMark
+      16-18: -
+      "
+    `)
+  })
+
+  it('keeps a non-http scheme in an angle autolink', () => {
+    const chunks = inlineTextToMarkChunks(schema, 'a <ftp://host> b')
+    expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
+      "
+      0-2: -
+      2-3: mdMark
+      3-13: mdLinkText(href=ftp://host)
+      13-14: mdMark
+      14-16: -
+      "
+    `)
+  })
+
+  it('keeps an ssh scheme in an angle autolink', () => {
+    const chunks = inlineTextToMarkChunks(schema, 'a <ssh://host> b')
+    expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
+      "
+      0-2: -
+      2-3: mdMark
+      3-13: mdLinkText(href=ssh://host)
+      13-14: mdMark
+      14-16: -
+      "
+    `)
+  })
+
+  it('excludes trailing punctuation from an autolink', () => {
+    const chunks = inlineTextToMarkChunks(schema, 'end https://example.com.')
+    expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
+      "
+      0-4: -
+      4-23: mdLinkText(href=https://example.com)
+      23-24: -
+      "
+    `)
+  })
+
+  it('autolinks a URL nested in emphasis', () => {
+    const chunks = inlineTextToMarkChunks(schema, '*https://x.io*')
+    expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
+      "
+      0-1: mdEm + mdMark
+      1-13: mdEm + mdLinkText(href=https://x.io)
+      13-14: mdEm + mdMark
+      "
+    `)
+  })
+
+  it('does not bare-autolink a non-http scheme', () => {
+    const chunks = inlineTextToMarkChunks(schema, 'a ftp://host b')
+    expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
+      "
+      0-14: -
+      "
+    `)
+  })
+
+  it('does not autolink a schemeless host', () => {
+    const chunks = inlineTextToMarkChunks(schema, 'a example.com b')
+    expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
+      "
+      0-15: -
+      "
+    `)
+  })
+
   it('nested emphasis inside strong (***foo***)', () => {
     const chunks = inlineTextToMarkChunks(schema, '***foo***')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.ts
@@ -51,6 +51,18 @@ export function inlineTextToMarkChunks(
   return out
 }
 
+/**
+ * Derive the `href` for a bare autolink from its visible text: a URL with a
+ * scheme is used as-is; an email becomes `mailto:`; a `www.` URL gets an
+ * implied `https://`. Returns `undefined` for anything else.
+ */
+function getAutolinkHref(urlText: string): string | undefined {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(urlText)) return urlText
+  if (/^[^\s@]+@[^\s@]+$/.test(urlText)) return `mailto:${urlText}`
+  if (/^www\./i.test(urlText)) return `https://${urlText}`
+  return undefined
+}
+
 function walk(
   nodes: readonly InlineElement[],
   parentMarks: readonly Mark[],
@@ -67,6 +79,15 @@ function walk(
     }
     if (node.type === LEZER_NODE_IDS.Link || node.type === LEZER_NODE_IDS.Image) {
       walkLink(node, parentMarks, text, schema, out)
+    } else if (node.type === LEZER_NODE_IDS.URL) {
+      // A standalone `URL` node is a GFM autolink (the address part of a real
+      // `[text](url)` is handled inside `walkLink`, not here). Linkify the
+      // shapes we recognize; anything else keeps the muted `mdLinkUri`.
+      const href = getAutolinkHref(text.slice(node.from, node.to))
+      // TODO: replace the stringly-typed `schema.marks[name].create()` pattern
+      // in this file with typed mark creation threaded through `walk`.
+      const mark = href ? schema.marks.mdLinkText.create({ href }) : schema.marks.mdLinkUri.create()
+      emit(out, node.from, node.to, [...parentMarks, mark])
     } else {
       const maybeMarkName = MARK_NAME_BY_TYPE_ID.get(node.type)
       const childMarks = maybeMarkName

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.ts
@@ -52,9 +52,12 @@ export function inlineTextToMarkChunks(
 }
 
 /**
- * Derive the `href` for a bare autolink from its visible text: a URL with a
- * scheme is used as-is; an email becomes `mailto:`; a `www.` URL gets an
- * implied `https://`. Returns `undefined` for anything else.
+ * Derive the `href` for a bare autolink from its visible text:
+ *
+ * - a URL with a scheme is used as-is
+ * - an email becomes `mailto:`
+ * - a `www.` URL gets an implied `https://`
+ * - anything else returns `undefined`
  */
 function getAutolinkHref(urlText: string): string | undefined {
   if (/^[a-z][a-z0-9+.-]*:/i.test(urlText)) return urlText

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -108,7 +108,7 @@ describe('defineMarkMode', () => {
       using fixture = setupFixture()
       fixture.editor.use(defineMarkMode('focus'))
       const { n } = fixture
-      const doc = n.doc(n.paragraph('a <https://<a>x.io> b'))
+      const doc = n.doc(n.paragraph('a <https://<a>example.com> b'))
       fixture.set(doc)
       await expectRevealedMarkers(2)
     })

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -95,6 +95,24 @@ describe('defineMarkMode', () => {
       await expectRevealedMarkers(4)
     })
 
+    it('reveals nothing when the cursor is inside a bare autolink', async () => {
+      using fixture = setupFixture()
+      fixture.editor.use(defineMarkMode('focus'))
+      const { n } = fixture
+      const doc = n.doc(n.paragraph('visit https://exa<a>mple.com now'))
+      fixture.set(doc)
+      await expectRevealedMarkers(0)
+    })
+
+    it('reveals the angle brackets when the cursor is inside <url>', async () => {
+      using fixture = setupFixture()
+      fixture.editor.use(defineMarkMode('focus'))
+      const { n } = fixture
+      const doc = n.doc(n.paragraph('a <https://<a>x.io> b'))
+      fixture.set(doc)
+      await expectRevealedMarkers(2)
+    })
+
     it('reveals when the cursor sits right after the closing **', async () => {
       using fixture = setupFixture()
       fixture.editor.use(defineMarkMode('focus'))
@@ -200,6 +218,15 @@ describe('defineMarkMode', () => {
       const doc = n.doc(n.paragraph('see [docs](http://x.test)'))
       fixture.set(doc)
       expect(clipboardText(fixture)).toBe('see docs')
+    })
+
+    it('keeps a bare autolink in the copied text', () => {
+      using fixture = setupFixture()
+      fixture.editor.use(defineMarkMode('hide'))
+      const { n } = fixture
+      const doc = n.doc(n.paragraph('visit https://example.com now'))
+      fixture.set(doc)
+      expect(clipboardText(fixture)).toBe('visit https://example.com now')
     })
 
     it('strips [[ ]] from the copied text', () => {


### PR DESCRIPTION
## What

Bare URLs in the editor now render as real, clickable links without the user typing `[text](url)`:

- `https://example.com` / `http://example.com`
- `www.example.com` (implied `https://`)
- `me@example.com` (implied `mailto:`)
- the angle form `<https://example.com>` (any scheme, e.g. `<ftp://host>`)

## How

A standalone GFM `URL` node previously mapped to the muted, non-clickable `mdLinkUri` (which is also hidden in hide/focus mode and stripped from copied text, so bare URLs effectively vanished). It now gets the existing `mdLinkText` mark with a derived `href`, so it renders as `<a href>`, stays visible in every mark mode, copies as text, and round-trips byte-identically.

The whole change is one special-case in `inline-text-to-mark-chunks.ts` plus a `getAutolinkHref` helper:
- scheme URLs are kept as-is; emails become `mailto:`; `www.` gets `https://`; anything unrecognized falls back to the old `mdLinkUri`.
- The `(url)` address inside a real `[text](url)` is handled separately by `walkLink` and is unaffected.

No new mark, parser, converter, or mark-mode code; no public API change. Autolinks reuse `mdLinkText`, so they inherit link click/hover for free if/when that lands.

## Tests

- chunk snapshots for https / www / email / bare-mailto / `<…>` / `<ftp://>` / `<ssh://>` / trailing punctuation / nested-in-emphasis / bare-`ftp://` not linked / schemeless host not linked
- integration: a bare URL text node carries `mdLinkText` with the derived href
- mark-mode: cursor in a bare autolink reveals nothing; cursor in `<…>` reveals the brackets; hide-mode copy keeps the bare URL (regression of the strip bug)
- round-trip byte-identity for the autolink forms

`pnpm typecheck`, `pnpm lint`, and the full `@meowdown/core` suite (414 tests) are green.