### PR TITLE
refactor(core): typed mark creation in the inline walk

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,8 +26,8 @@
     "@lezer/highlight": "^1.2.3",
     "@lezer/markdown": "^1.6.4",
     "@ocavue/utils": "^1.7.0",
-    "@prosekit/core": "^0.13.0-beta.0",
-    "@prosekit/extensions": "^0.17.5-beta.1",
+    "@prosekit/core": "^0.13.0-beta.1",
+    "@prosekit/extensions": "^0.17.5-beta.2",
     "@prosekit/pm": "^0.1.18",
     "prosemirror-highlight": "^0.15.2",
     "prosemirror-tables": "^1.8.5"

--- a/packages/core/src/extensions/inline-mark-plugin.bench.ts
+++ b/packages/core/src/extensions/inline-mark-plugin.bench.ts
@@ -21,7 +21,8 @@ const mixedParagraph =
 const longParagraph = (mixedParagraph + ' ').repeat(50)
 
 describe('inlineTextToMarkChunks', () => {
-  const markBuilders = createMarkBuilders<EditorExtension>(defineEditorExtension().schema!)
+  const schema = defineEditorExtension().schema!
+  const markBuilders = createMarkBuilders<EditorExtension>(schema)
 
   bench('plain', () => {
     inlineTextToMarkChunks(markBuilders, plainParagraph)

--- a/packages/core/src/extensions/inline-mark-plugin.bench.ts
+++ b/packages/core/src/extensions/inline-mark-plugin.bench.ts
@@ -1,6 +1,7 @@
+import { createMarkBuilders } from '@prosekit/core'
 import { bench, describe } from 'vitest'
 
-import { defineEditorExtension } from './extension.ts'
+import { defineEditorExtension, type EditorExtension } from './extension.ts'
 import { inlineTextToMarkChunks } from './inline-text-to-mark-chunks.ts'
 
 // Run with:  pnpm bench
@@ -20,17 +21,17 @@ const mixedParagraph =
 const longParagraph = (mixedParagraph + ' ').repeat(50)
 
 describe('inlineTextToMarkChunks', () => {
-  const schema = defineEditorExtension().schema!
+  const markBuilders = createMarkBuilders<EditorExtension>(defineEditorExtension().schema!)
 
   bench('plain', () => {
-    inlineTextToMarkChunks(schema, plainParagraph)
+    inlineTextToMarkChunks(markBuilders, plainParagraph)
   })
 
   bench('mixed', () => {
-    inlineTextToMarkChunks(schema, mixedParagraph)
+    inlineTextToMarkChunks(markBuilders, mixedParagraph)
   })
 
   bench('long', () => {
-    inlineTextToMarkChunks(schema, longParagraph)
+    inlineTextToMarkChunks(markBuilders, longParagraph)
   })
 })

--- a/packages/core/src/extensions/inline-mark-plugin.ts
+++ b/packages/core/src/extensions/inline-mark-plugin.ts
@@ -8,7 +8,7 @@
  *     -> compute affected range from step maps (fall back to full doc)
  *     -> walk participating textblocks (paragraph / heading etc.) inside that range
  *     -> for each: text = node.textContent
- *                  chunks = inlineTextToMarkChunks(schema, text)
+ *                  chunks = inlineTextToMarkChunks(getMarkBuildersForSchema(schema), text)
  *     -> if chunks is non-empty: tr.step(new BatchSetMarkStep(chunks))
  *                                  .setMeta(META_KEY, true)
  */
@@ -21,6 +21,7 @@ import { Plugin, PluginKey } from '@prosekit/pm/state'
 import { BatchSetMarkStep } from './batch-set-mark-step.ts'
 import { inlineTextToMarkChunks } from './inline-text-to-mark-chunks.ts'
 import type { MarkChunk } from './mark-chunk.ts'
+import { getMarkBuildersForSchema } from './schema.ts'
 
 const META_KEY = 'inline-marks-applied'
 
@@ -61,7 +62,7 @@ function chunksForTextblock(
     chunkCacheHits++
   } else {
     chunkCacheParses++
-    relative = inlineTextToMarkChunks(schema, node.textContent)
+    relative = inlineTextToMarkChunks(getMarkBuildersForSchema(schema), node.textContent)
     CHUNK_CACHE.set(node, relative)
   }
   if (baseOffset === 0) return relative

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
@@ -35,7 +35,8 @@ describe('inlineTextToMarkChunks', () => {
   let markBuilders: TypedMarkBuilders
 
   beforeAll(() => {
-    markBuilders = createMarkBuilders<EditorExtension>(defineEditorExtension().schema!)
+    const schema = defineEditorExtension().schema!
+    markBuilders = createMarkBuilders<EditorExtension>(schema)
   })
 
   it('plain text returns no chunks (no marks anywhere)', () => {

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
@@ -1,9 +1,10 @@
-import type { Schema } from '@prosekit/pm/model'
+import { createMarkBuilders } from '@prosekit/core'
 import { beforeAll, describe, expect, it } from 'vitest'
 
-import { defineEditorExtension } from './extension.ts'
+import { defineEditorExtension, type EditorExtension } from './extension.ts'
 import { inlineTextToMarkChunks } from './inline-text-to-mark-chunks.ts'
 import type { MarkChunk } from './mark-chunk.ts'
+import type { TypedMarkBuilders } from './schema.ts'
 
 /**
  * Helper: serialize chunk to a compact string form so inline
@@ -31,14 +32,14 @@ function foramtMarkChunks(chunks: MarkChunk[]): string {
 }
 
 describe('inlineTextToMarkChunks', () => {
-  let schema: Schema
+  let markBuilders: TypedMarkBuilders
 
   beforeAll(() => {
-    schema = defineEditorExtension().schema!
+    markBuilders = createMarkBuilders<EditorExtension>(defineEditorExtension().schema!)
   })
 
   it('plain text returns no chunks (no marks anywhere)', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'hello world')
+    const chunks = inlineTextToMarkChunks(markBuilders, 'hello world')
     // Pure text has no inline nodes; the implementation does not emit
     // a "no-mark" gap when the entire range is plain.
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
@@ -49,7 +50,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('emphasis yields gap + mark + content + mark', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'Hello *world*')
+    const chunks = inlineTextToMarkChunks(markBuilders, 'Hello *world*')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-6: -
@@ -61,7 +62,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('strong emphasis', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'a **bold** b')
+    const chunks = inlineTextToMarkChunks(markBuilders, 'a **bold** b')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
@@ -74,7 +75,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('inline code', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'a `c` b')
+    const chunks = inlineTextToMarkChunks(markBuilders, 'a `c` b')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
@@ -87,7 +88,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('strikethrough', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'a ~~b~~ c')
+    const chunks = inlineTextToMarkChunks(markBuilders, 'a ~~b~~ c')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
@@ -100,7 +101,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('link with href on its text portion', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'see [docs](http://x) now')
+    const chunks = inlineTextToMarkChunks(markBuilders, 'see [docs](http://x) now')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-4: -
@@ -115,7 +116,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('link with emphasis nested inside the text', () => {
-    const chunks = inlineTextToMarkChunks(schema, '[*ital*](http://x)')
+    const chunks = inlineTextToMarkChunks(markBuilders, '[*ital*](http://x)')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-1: mdLinkText(href=http://x) + mdMark
@@ -130,7 +131,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('autolinks a bare https URL', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'visit https://example.com now')
+    const chunks = inlineTextToMarkChunks(markBuilders, 'visit https://example.com now')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-6: -
@@ -141,7 +142,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('autolinks a www URL with an implied https scheme', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'see www.example.com here')
+    const chunks = inlineTextToMarkChunks(markBuilders, 'see www.example.com here')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-4: -
@@ -152,7 +153,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('autolinks a bare email as mailto', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'mail me@example.com ok')
+    const chunks = inlineTextToMarkChunks(markBuilders, 'mail me@example.com ok')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-5: -
@@ -163,7 +164,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('autolinks a bare mailto URL, keeping the scheme', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'a mailto:me@example.com b')
+    const chunks = inlineTextToMarkChunks(markBuilders, 'a mailto:me@example.com b')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
@@ -174,7 +175,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('autolinks an angle-bracket URL, with the brackets as mdMark', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'a <https://example.com> b')
+    const chunks = inlineTextToMarkChunks(markBuilders, 'a <https://example.com> b')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
@@ -187,7 +188,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('keeps a non-http scheme in an angle autolink', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'a <ftp://example.com> b')
+    const chunks = inlineTextToMarkChunks(markBuilders, 'a <ftp://example.com> b')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
@@ -200,7 +201,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('keeps an ssh scheme in an angle autolink', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'a <ssh://example.com> b')
+    const chunks = inlineTextToMarkChunks(markBuilders, 'a <ssh://example.com> b')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
@@ -213,7 +214,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('excludes trailing punctuation from an autolink', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'end https://example.com.')
+    const chunks = inlineTextToMarkChunks(markBuilders, 'end https://example.com.')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-4: -
@@ -224,7 +225,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('autolinks a URL nested in emphasis', () => {
-    const chunks = inlineTextToMarkChunks(schema, '*https://example.com*')
+    const chunks = inlineTextToMarkChunks(markBuilders, '*https://example.com*')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-1: mdEm + mdMark
@@ -235,7 +236,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('does not bare-autolink a non-http scheme', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'a ftp://example.com b')
+    const chunks = inlineTextToMarkChunks(markBuilders, 'a ftp://example.com b')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-21: -
@@ -244,7 +245,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('does not autolink a schemeless host', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'a example.com b')
+    const chunks = inlineTextToMarkChunks(markBuilders, 'a example.com b')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-15: -
@@ -253,7 +254,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('nested emphasis inside strong (***foo***)', () => {
-    const chunks = inlineTextToMarkChunks(schema, '***foo***')
+    const chunks = inlineTextToMarkChunks(markBuilders, '***foo***')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-1: mdEm + mdMark
@@ -266,7 +267,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('adjacent emphasis and strong', () => {
-    const chunks = inlineTextToMarkChunks(schema, '*a***b**')
+    const chunks = inlineTextToMarkChunks(markBuilders, '*a***b**')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-1: mdEm + mdMark
@@ -280,7 +281,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('emphasis at start and end of text', () => {
-    const chunks = inlineTextToMarkChunks(schema, '*a* mid *b*')
+    const chunks = inlineTextToMarkChunks(markBuilders, '*a* mid *b*')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-1: mdEm + mdMark
@@ -295,7 +296,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('entire content is emphasized', () => {
-    const chunks = inlineTextToMarkChunks(schema, '*all*')
+    const chunks = inlineTextToMarkChunks(markBuilders, '*all*')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-1: mdEm + mdMark
@@ -306,11 +307,11 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('empty input returns no chunks', () => {
-    expect(inlineTextToMarkChunks(schema, '')).toEqual([])
+    expect(inlineTextToMarkChunks(markBuilders, '')).toEqual([])
   })
 
   it('escape characters produce no marks (visible literal text)', () => {
-    const chunks = inlineTextToMarkChunks(schema, String.raw`\*not\*`)
+    const chunks = inlineTextToMarkChunks(markBuilders, String.raw`\*not\*`)
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-7: -
@@ -319,7 +320,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('hard break produces no mark', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'a  \nb')
+    const chunks = inlineTextToMarkChunks(markBuilders, 'a  \nb')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-5: -
@@ -328,7 +329,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('tag yields a single mdTag chunk covering the # too', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'a #meow b')
+    const chunks = inlineTextToMarkChunks(markBuilders, 'a #meow b')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
@@ -339,7 +340,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('two tags', () => {
-    const chunks = inlineTextToMarkChunks(schema, '#a #b')
+    const chunks = inlineTextToMarkChunks(markBuilders, '#a #b')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: mdTag
@@ -350,7 +351,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('tag inside emphasis', () => {
-    const chunks = inlineTextToMarkChunks(schema, '*x #tag y*')
+    const chunks = inlineTextToMarkChunks(markBuilders, '*x #tag y*')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-1: mdEm + mdMark
@@ -363,7 +364,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('tag inside a link label', () => {
-    const chunks = inlineTextToMarkChunks(schema, '[see #tag](http://x)')
+    const chunks = inlineTextToMarkChunks(markBuilders, '[see #tag](http://x)')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-1: mdLinkText(href=http://x) + mdMark
@@ -377,7 +378,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('heading-like text produces no tag', () => {
-    const chunks = inlineTextToMarkChunks(schema, '# heading text')
+    const chunks = inlineTextToMarkChunks(markBuilders, '# heading text')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-14: -
@@ -386,7 +387,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('all-digit tag produces no mark', () => {
-    const chunks = inlineTextToMarkChunks(schema, "we're #1")
+    const chunks = inlineTextToMarkChunks(markBuilders, "we're #1")
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-8: -
@@ -395,7 +396,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('wikilink yields mdMark brackets around an mdWikilink target', () => {
-    const chunks = inlineTextToMarkChunks(schema, 'a [[note]] b')
+    const chunks = inlineTextToMarkChunks(markBuilders, 'a [[note]] b')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
@@ -408,7 +409,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('adjacent wikilinks coalesce the middle ]][[ into one chunk', () => {
-    const chunks = inlineTextToMarkChunks(schema, '[[a]][[b]]')
+    const chunks = inlineTextToMarkChunks(markBuilders, '[[a]][[b]]')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: mdMark + mdWikilink
@@ -421,7 +422,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('wikilink inside emphasis', () => {
-    const chunks = inlineTextToMarkChunks(schema, '*x [[n]] y*')
+    const chunks = inlineTextToMarkChunks(markBuilders, '*x [[n]] y*')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-1: mdEm + mdMark
@@ -436,7 +437,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('wikilink inside a link label', () => {
-    const chunks = inlineTextToMarkChunks(schema, '[see [[x]]](http://y)')
+    const chunks = inlineTextToMarkChunks(markBuilders, '[see [[x]]](http://y)')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-1: mdLinkText(href=http://y) + mdMark
@@ -452,7 +453,7 @@ describe('inlineTextToMarkChunks', () => {
   })
 
   it('no mdTag inside a wikilink target', () => {
-    const chunks = inlineTextToMarkChunks(schema, '[[note #tag]]')
+    const chunks = inlineTextToMarkChunks(markBuilders, '[[note #tag]]')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: mdMark + mdWikilink
@@ -465,7 +466,7 @@ describe('inlineTextToMarkChunks', () => {
   it('unclosed wikilink falls back to link parsing of the inner [a]', () => {
     // No mdWikilink anywhere; the inner `[a]` becomes a shortcut
     // reference link (pre-existing lezer behavior).
-    const chunks = inlineTextToMarkChunks(schema, '[[a]')
+    const chunks = inlineTextToMarkChunks(markBuilders, '[[a]')
     expect(foramtMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-1: -

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.ts
@@ -1,4 +1,4 @@
-import type { Mark, Schema } from '@prosekit/pm/model'
+import type { Mark } from '@prosekit/pm/model'
 
 import type { InlineElement } from '../lezer/inline.ts'
 import { parseInline } from '../lezer/inline.ts'
@@ -7,6 +7,7 @@ import { LEZER_NODE_IDS } from '../lezer/node-ids.ts'
 import type { MarkName } from './inline-marks.ts'
 import type { MarkChunk } from './mark-chunk.ts'
 import { marksEqual } from './marks-equal.ts'
+import type { TypedMarkBuilders } from './schema.ts'
 
 /**
  * Lookup from Lezer node type id to the ProseMirror mark.
@@ -40,14 +41,14 @@ const MARK_NAME_BY_TYPE_ID: ReadonlyMap<number, MarkName> = new Map([
  * Callers shift the chunks into the document's coordinate space.
  */
 export function inlineTextToMarkChunks(
-  /** ProseMirror schema with our inline marks defined. */
-  schema: Schema,
+  /** Typed mark builders bound to the target schema (see {@link getMarkBuildersForSchema}). */
+  marks: TypedMarkBuilders,
   /** The raw inline text of one textblock (no block prefix). */
   text: string,
 ): MarkChunk[] {
   const elements = parseInline(text)
   const out: MarkChunk[] = []
-  walk(elements, [], 0, text.length, text, schema, out)
+  walk(elements, [], 0, text.length, text, marks, out)
   return out
 }
 
@@ -72,7 +73,7 @@ function walk(
   rangeStart: number,
   rangeEnd: number,
   text: string,
-  schema: Schema,
+  marks: TypedMarkBuilders,
   out: MarkChunk[],
 ): void {
   let pos = rangeStart
@@ -81,25 +82,23 @@ function walk(
       emit(out, pos, node.from, parentMarks)
     }
     if (node.type === LEZER_NODE_IDS.Link || node.type === LEZER_NODE_IDS.Image) {
-      walkLink(node, parentMarks, text, schema, out)
+      walkLink(node, parentMarks, text, marks, out)
     } else if (node.type === LEZER_NODE_IDS.URL) {
       // A standalone `URL` node is a GFM autolink (the address part of a real
       // `[text](url)` is handled inside `walkLink`, not here). Linkify the
       // shapes we recognize; anything else keeps the muted `mdLinkUri`.
       const href = getAutolinkHref(text.slice(node.from, node.to))
-      // TODO: replace the stringly-typed `schema.marks[name].create()` pattern
-      // in this file with typed mark creation threaded through `walk`.
-      const mark = href ? schema.marks.mdLinkText.create({ href }) : schema.marks.mdLinkUri.create()
+      const mark = href ? marks.mdLinkText.create({ href }) : marks.mdLinkUri.create()
       emit(out, node.from, node.to, [...parentMarks, mark])
     } else {
       const maybeMarkName = MARK_NAME_BY_TYPE_ID.get(node.type)
       const childMarks = maybeMarkName
-        ? [...parentMarks, schema.marks[maybeMarkName].create()]
+        ? [...parentMarks, marks[maybeMarkName].create()]
         : parentMarks
       if (node.children.length === 0) {
         emit(out, node.from, node.to, childMarks)
       } else {
-        walk(node.children, childMarks, node.from, node.to, text, schema, out)
+        walk(node.children, childMarks, node.from, node.to, text, marks, out)
       }
     }
     pos = node.to
@@ -130,7 +129,7 @@ function walkLink(
   node: InlineElement,
   parentMarks: readonly Mark[],
   text: string,
-  schema: Schema,
+  marks: TypedMarkBuilders,
   out: MarkChunk[],
 ): void {
   let labelEnd = -1
@@ -145,25 +144,24 @@ function walkLink(
     }
   }
   const href = urlNode ? text.slice(urlNode.from, urlNode.to) : ''
-  const linkTextMark =
-    href && schema.marks.mdLinkText ? schema.marks.mdLinkText.create({ href }) : null
+  const linkTextMark = href ? marks.mdLinkText.create({ href }) : null
   const inLabel = (pos: number): boolean => labelEnd >= 0 && pos < labelEnd && linkTextMark !== null
 
   let pos = node.from
   for (const child of node.children) {
     if (child.from > pos) {
-      const marks = inLabel(pos) ? [...parentMarks, linkTextMark!] : parentMarks
-      emit(out, pos, child.from, marks)
+      const childMarks = inLabel(pos) ? [...parentMarks, linkTextMark!] : parentMarks
+      emit(out, pos, child.from, childMarks)
     }
     const baseForChild = inLabel(child.from) ? [...parentMarks, linkTextMark!] : parentMarks
     const maybeMarkName = MARK_NAME_BY_TYPE_ID.get(child.type)
     const childMarks = maybeMarkName
-      ? [...baseForChild, schema.marks[maybeMarkName].create()]
+      ? [...baseForChild, marks[maybeMarkName].create()]
       : baseForChild
     if (child.children.length === 0) {
       emit(out, child.from, child.to, childMarks)
     } else {
-      walk(child.children, childMarks, child.from, child.to, text, schema, out)
+      walk(child.children, childMarks, child.from, child.to, text, marks, out)
     }
     pos = child.to
   }

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.ts
@@ -41,7 +41,7 @@ const MARK_NAME_BY_TYPE_ID: ReadonlyMap<number, MarkName> = new Map([
  * Callers shift the chunks into the document's coordinate space.
  */
 export function inlineTextToMarkChunks(
-  /** Typed mark builders bound to the target schema (see {@link getMarkBuildersForSchema}). */
+  /** Typed mark builders bound to the target schema. */
   marks: TypedMarkBuilders,
   /** The raw inline text of one textblock (no block prefix). */
   text: string,

--- a/packages/core/src/extensions/schema.ts
+++ b/packages/core/src/extensions/schema.ts
@@ -31,27 +31,13 @@ export const getMarkBuilders: () => TypedMarkBuilders = /* @__PURE__ */ once(() 
   return createMarkBuilders<EditorExtension>(getSharedSchema())
 })
 
-const markBuildersBySchema = new WeakMap<Schema, TypedMarkBuilders>()
+const MARK_BUILDERS_CACHE_KEY = 'meowdown_mark_builders'
 
-/**
- * Typed mark builders bound to a specific schema, cached per schema.
- */
+/** Typed mark builders bound to a specific schema, cached per schema. */
 export function getMarkBuildersForSchema(schema: Schema): TypedMarkBuilders {
-  let builders = markBuildersBySchema.get(schema)
-  if (!builders) {
-    builders = createMarkBuilders<EditorExtension>(schema)
-    markBuildersBySchema.set(schema, builders)
-  }
+  const cached = schema.cached[MARK_BUILDERS_CACHE_KEY] as TypedMarkBuilders | undefined
+  if (cached) return cached
+  const builders = createMarkBuilders<EditorExtension>(schema)
+  schema.cached[MARK_BUILDERS_CACHE_KEY] = builders
   return builders
 }
-
-// REVIEW: `schema` has a `cached` property for extensions to store whatever values they want to cache per schema. You do not need to
-// use WeekMap here.
-// /**
-// An object for storing whatever values modules may want to
-// compute and cache per schema. (If you want to store something
-// in it, try to use property names unlikely to clash.)
-// */
-// cached: {
-//     [key: string]: any;
-// };

--- a/packages/core/src/extensions/schema.ts
+++ b/packages/core/src/extensions/schema.ts
@@ -30,3 +30,23 @@ export const getNodeBuilders: () => TypedNodeBuilders = /* @__PURE__ */ once(() 
 export const getMarkBuilders: () => TypedMarkBuilders = /* @__PURE__ */ once(() => {
   return createMarkBuilders<EditorExtension>(getSharedSchema())
 })
+
+const markBuildersBySchema = new WeakMap<Schema, TypedMarkBuilders>()
+
+/**
+ * Typed mark builders bound to a specific schema, cached per schema.
+ *
+ * The inline-mark plugin creates marks from the live editor's own
+ * `state.schema`, which is a different `Schema` instance than
+ * {@link getSharedSchema}. A mark carries its `MarkType`, and a mark built from
+ * a different schema instance is not type-identical, so the plugin must not use
+ * {@link getMarkBuilders} (which is bound to the shared schema).
+ */
+export function getMarkBuildersForSchema(schema: Schema): TypedMarkBuilders {
+  let builders = markBuildersBySchema.get(schema)
+  if (!builders) {
+    builders = createMarkBuilders<EditorExtension>(schema)
+    markBuildersBySchema.set(schema, builders)
+  }
+  return builders
+}

--- a/packages/core/src/extensions/schema.ts
+++ b/packages/core/src/extensions/schema.ts
@@ -44,3 +44,14 @@ export function getMarkBuildersForSchema(schema: Schema): TypedMarkBuilders {
   }
   return builders
 }
+
+// REVIEW: `schema` has a `cached` property for extensions to store whatever values they want to cache per schema. You do not need to
+// use WeekMap here.
+// /**
+// An object for storing whatever values modules may want to
+// compute and cache per schema. (If you want to store something
+// in it, try to use property names unlikely to clash.)
+// */
+// cached: {
+//     [key: string]: any;
+// };

--- a/packages/core/src/extensions/schema.ts
+++ b/packages/core/src/extensions/schema.ts
@@ -35,12 +35,6 @@ const markBuildersBySchema = new WeakMap<Schema, TypedMarkBuilders>()
 
 /**
  * Typed mark builders bound to a specific schema, cached per schema.
- *
- * The inline-mark plugin creates marks from the live editor's own
- * `state.schema`, which is a different `Schema` instance than
- * {@link getSharedSchema}. A mark carries its `MarkType`, and a mark built from
- * a different schema instance is not type-identical, so the plugin must not use
- * {@link getMarkBuilders} (which is bound to the shared schema).
  */
 export function getMarkBuildersForSchema(schema: Schema): TypedMarkBuilders {
   let builders = markBuildersBySchema.get(schema)

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,9 +28,9 @@
     "@codemirror/view": "^6.43.1",
     "@meowdown/core": "workspace:*",
     "@ocavue/utils": "^1.7.0",
-    "@prosekit/core": "^0.13.0-beta.0",
+    "@prosekit/core": "^0.13.0-beta.1",
     "@prosekit/pm": "^0.1.18",
-    "@prosekit/react": "^0.8.0-beta.1",
+    "@prosekit/react": "^0.8.0-beta.2",
     "clsx": "^2.1.1"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,13 @@ settings:
   dedupePeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@prosekit/core': https://pkg.pr.new/@prosekit/core@b1a035b
+  '@prosekit/extensions': https://pkg.pr.new/@prosekit/extensions@b1a035b
+  '@prosekit/pm': https://pkg.pr.new/@prosekit/pm@b1a035b
+  '@prosekit/react': https://pkg.pr.new/@prosekit/react@b1a035b
+  '@prosekit/web': https://pkg.pr.new/@prosekit/web@b1a035b
+
 importers:
 
   .:
@@ -32,7 +39,7 @@ importers:
         version: 0.53.0
       playwright:
         specifier: ^1.60.0
-        version: 1.60.0
+        version: 1.61.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -64,17 +71,17 @@ importers:
         specifier: ^1.7.0
         version: 1.7.0
       '@prosekit/core':
-        specifier: ^0.13.0-beta.0
-        version: 0.13.0-beta.0(prosemirror-model@1.25.8)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+        specifier: https://pkg.pr.new/@prosekit/core@b1a035b
+        version: https://pkg.pr.new/@prosekit/core@b1a035b(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       '@prosekit/extensions':
-        specifier: ^0.17.5-beta.1
-        version: 0.17.5-beta.1(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.8)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+        specifier: https://pkg.pr.new/@prosekit/extensions@b1a035b
+        version: https://pkg.pr.new/@prosekit/extensions@b1a035b(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
       '@prosekit/pm':
-        specifier: ^0.1.18
-        version: 0.1.18
+        specifier: https://pkg.pr.new/@prosekit/pm@b1a035b
+        version: https://pkg.pr.new/@prosekit/pm@b1a035b
       prosemirror-highlight:
         specifier: ^0.15.2
-        version: 0.15.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.8)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+        version: 0.15.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
       prosemirror-tables:
         specifier: ^1.8.5
         version: 1.8.5
@@ -87,7 +94,7 @@ importers:
         version: 0.22.2(jiti@2.7.0)(postcss@8.5.15)(tsdown@0.22.2)(yaml@2.9.0)
       '@vitest/browser-playwright':
         specifier: ^4.1.8
-        version: 4.1.9(playwright@1.60.0)(vite@8.0.16)(vitest@4.1.9)
+        version: 4.1.9(playwright@1.61.0)(vite@8.0.16)(vitest@4.1.9)
       dedent:
         specifier: ^1.7.2
         version: 1.7.2
@@ -128,14 +135,14 @@ importers:
         specifier: ^1.7.0
         version: 1.7.0
       '@prosekit/core':
-        specifier: ^0.13.0-beta.0
-        version: 0.13.0-beta.0(prosemirror-model@1.25.8)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+        specifier: https://pkg.pr.new/@prosekit/core@b1a035b
+        version: https://pkg.pr.new/@prosekit/core@b1a035b(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       '@prosekit/pm':
-        specifier: ^0.1.18
-        version: 0.1.18
+        specifier: https://pkg.pr.new/@prosekit/pm@b1a035b
+        version: https://pkg.pr.new/@prosekit/pm@b1a035b
       '@prosekit/react':
-        specifier: ^0.8.0-beta.1
-        version: 0.8.0-beta.1(prosemirror-model@1.25.8)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(react-dom@19.2.7)(react@19.2.7)
+        specifier: https://pkg.pr.new/@prosekit/react@b1a035b
+        version: https://pkg.pr.new/@prosekit/react@b1a035b(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(react-dom@19.2.7)(react@19.2.7)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -157,7 +164,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitest/browser-playwright':
         specifier: ^4.1.8
-        version: 4.1.9(playwright@1.60.0)(vite@8.0.16)(vitest@4.1.9)
+        version: 4.1.9(playwright@1.61.0)(vite@8.0.16)(vitest@4.1.9)
       dedent:
         specifier: ^1.7.2
         version: 1.7.2
@@ -1085,11 +1092,13 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@prosekit/core@0.13.0-beta.0':
-    resolution: {integrity: sha512-P8DnrZ5aDhFHs6JNTWwAS9rD+sU12DTzKo1fCpGwR9EXGR0r/ABo5+vlHqcMD+c3EcXF7+w5Y8FHidQXcTpjAg==}
+  '@prosekit/core@https://pkg.pr.new/@prosekit/core@b1a035b':
+    resolution: {integrity: sha512-l6jhAThuBNVe8f2G4eRbrR4/ULFgK47zTS6mngMGL278uRgFYbCYZqRCLtJXAfK15IVS+yhF7muOoEZvpM7F/A==, tarball: https://pkg.pr.new/@prosekit/core@b1a035b}
+    version: 0.13.0-beta.0
 
-  '@prosekit/extensions@0.17.5-beta.1':
-    resolution: {integrity: sha512-biWVqoACeulYEKnqEsjytRxUCfbQmiimSFoMqda+FEX9qMvstLqIpQKRAXlLpNjXEPpQDQg8t0M3Wg1yaMAKfg==}
+  '@prosekit/extensions@https://pkg.pr.new/@prosekit/extensions@b1a035b':
+    resolution: {integrity: sha512-/sKOA/lvCrVPXn9yLULOk5ictravMixSc4lsQb4gsDtFk2tf0ztvsZ4k4GLvpF3DeCGnxNK/ZKNiDUhxl2UucQ==, tarball: https://pkg.pr.new/@prosekit/extensions@b1a035b}
+    version: 0.17.5-beta.1
     peerDependencies:
       loro-crdt: '>= 1.10.0'
       loro-prosemirror: '>= 0.4.1'
@@ -1105,11 +1114,13 @@ packages:
       yjs:
         optional: true
 
-  '@prosekit/pm@0.1.18':
-    resolution: {integrity: sha512-K00S6TY4gIlkWo1Y53h9STePNSPZ6UroHaIiKTkJvfMnwBBUZEc7+CUpmtNMzLtUqjmVAoaCTnW6VDBJaEXqWg==}
+  '@prosekit/pm@https://pkg.pr.new/@prosekit/pm@b1a035b':
+    resolution: {integrity: sha512-K00S6TY4gIlkWo1Y53h9STePNSPZ6UroHaIiKTkJvfMnwBBUZEc7+CUpmtNMzLtUqjmVAoaCTnW6VDBJaEXqWg==, tarball: https://pkg.pr.new/@prosekit/pm@b1a035b}
+    version: 0.1.18
 
-  '@prosekit/react@0.8.0-beta.1':
-    resolution: {integrity: sha512-zVZdn0tGOSTWAOjGWegKQ07w4s3/6mHqUc6aiA0z2Xn42jmxsfX8l+g1KsPZIou9sX9si50JHOlGnhrcPKCQ7A==}
+  '@prosekit/react@https://pkg.pr.new/@prosekit/react@b1a035b':
+    resolution: {integrity: sha512-IHEOpEoaO/XU6EGZBEW4ZH/IwsYBsayRv7QLe/2FZMpgdtcR7fBiYuV3Nb0yKaz88Ue+Dfe+WVpzEgcCbzPXuA==, tarball: https://pkg.pr.new/@prosekit/react@b1a035b}
+    version: 0.8.0-beta.1
     peerDependencies:
       react: '>= 18.2.0'
       react-dom: '>= 18.2.0'
@@ -1119,8 +1130,9 @@ packages:
       react-dom:
         optional: true
 
-  '@prosekit/web@0.9.0-beta.1':
-    resolution: {integrity: sha512-T5R8TKMDDinwtqLTRvhx78HHzc+rMDCHBsp25GqPv6QLGj0xHoE3lHHjvqalPXbUuNWUpHnp/pGa3ofvO01y/A==}
+  '@prosekit/web@https://pkg.pr.new/@prosekit/web@b1a035b':
+    resolution: {integrity: sha512-RiVWmo7D3YBHwX8KTt4gj4m6OumjSrJ7g7GcsB18A3MLrIaKF05ADMJJJag7Krj2F8VlaJn/G2kJM5kGoVEpeg==, tarball: https://pkg.pr.new/@prosekit/web@b1a035b}
+    version: 0.9.0-beta.1
 
   '@prosemirror-adapter/core@0.5.3':
     resolution: {integrity: sha512-jGcI/eq3USFqf1fCaejgCmifmXYDyFco6/5KjyyNBnuEhLqyLjD+020CtcduEOsnN4xPZr5ikclgHIR6kEFkQg==}
@@ -2694,13 +2706,13 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  playwright-core@1.60.0:
-    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+  playwright-core@1.61.0:
+    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.60.0:
-    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+  playwright@1.61.0:
+    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2832,8 +2844,8 @@ packages:
   prosemirror-math@0.2.2:
     resolution: {integrity: sha512-9k3oRRAEeQBAc2Yjq0G6+Z7anJ62ODEo0CcYFYwbH+1aVVqQoGMWur+8qTrXdbPpKg5q/d1dyDcpVA3p2Xf0xA==}
 
-  prosemirror-model@1.25.8:
-    resolution: {integrity: sha512-BswA4BLSFEiORV6Vjj/yZBXDbos1zTEnhyeSSgT8psGFhstQS7UJ8/WOLiDos9Byaee27+tml0/DuMNxYR84zg==}
+  prosemirror-model@1.25.9:
+    resolution: {integrity: sha512-pRTklkDDMMRopyoAcrr9wV/8g/RYgrLHBuJAb5hlEuYZRdm5yqmPjWId83fpBwPpSFqEdja0H7Dfd7z1X/npcA==}
 
   prosemirror-safari-ime-span@1.0.2:
     resolution: {integrity: sha512-QJqD8s1zE/CuK56kDsUhndh5hiHh/gFnAuPOA9ytva2s85/ZEt2tNWeALTJN48DtWghSKOmiBsvVn2OlnJ5H2w==}
@@ -4407,30 +4419,30 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@prosekit/core@0.13.0-beta.0(prosemirror-model@1.25.8)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)':
+  '@prosekit/core@https://pkg.pr.new/@prosekit/core@b1a035b(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)':
     dependencies:
       '@ocavue/utils': 1.7.0
-      '@prosekit/pm': 0.1.18
+      '@prosekit/pm': https://pkg.pr.new/@prosekit/pm@b1a035b
       orderedmap: 2.1.1
-      prosemirror-splittable: 0.1.1(prosemirror-model@1.25.8)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      prosemirror-splittable: 0.1.1(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       type-fest: 5.7.0
     transitivePeerDependencies:
       - prosemirror-model
       - prosemirror-state
       - prosemirror-transform
 
-  '@prosekit/extensions@0.17.5-beta.1(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.8)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
+  '@prosekit/extensions@https://pkg.pr.new/@prosekit/extensions@b1a035b(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
     dependencies:
       '@ocavue/utils': 1.7.0
-      '@prosekit/core': 0.13.0-beta.0(prosemirror-model@1.25.8)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
-      '@prosekit/pm': 0.1.18
+      '@prosekit/core': https://pkg.pr.new/@prosekit/core@b1a035b(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      '@prosekit/pm': https://pkg.pr.new/@prosekit/pm@b1a035b
       prosemirror-changeset: 2.4.1
       prosemirror-drop-indicator: 0.1.4
       prosemirror-dropcursor: 1.8.2
       prosemirror-enter-rules: 0.1.5
       prosemirror-flat-list: 0.6.0
       prosemirror-gapcursor: 1.4.1
-      prosemirror-highlight: 0.15.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.8)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+      prosemirror-highlight: 0.15.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
       prosemirror-math: 0.2.2
       prosemirror-search: 1.1.1
       prosemirror-tables: 1.8.5
@@ -4450,22 +4462,22 @@ snapshots:
       - refractor
       - sugar-high
 
-  '@prosekit/pm@0.1.18':
+  '@prosekit/pm@https://pkg.pr.new/@prosekit/pm@b1a035b':
     dependencies:
       prosemirror-commands: 1.7.1
       prosemirror-history: 1.5.0
       prosemirror-inputrules: 1.5.1
       prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.8
+      prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.9
 
-  '@prosekit/react@0.8.0-beta.1(prosemirror-model@1.25.8)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(react-dom@19.2.7)(react@19.2.7)':
+  '@prosekit/react@https://pkg.pr.new/@prosekit/react@b1a035b(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(react-dom@19.2.7)(react@19.2.7)':
     dependencies:
-      '@prosekit/core': 0.13.0-beta.0(prosemirror-model@1.25.8)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
-      '@prosekit/pm': 0.1.18
-      '@prosekit/web': 0.9.0-beta.1(prosemirror-model@1.25.8)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      '@prosekit/core': https://pkg.pr.new/@prosekit/core@b1a035b(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      '@prosekit/pm': https://pkg.pr.new/@prosekit/pm@b1a035b
+      '@prosekit/web': https://pkg.pr.new/@prosekit/web@b1a035b(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       '@prosemirror-adapter/core': 0.5.3
       '@prosemirror-adapter/react': 0.5.3(react-dom@19.2.7)(react@19.2.7)
     optionalDependencies:
@@ -4489,16 +4501,16 @@ snapshots:
       - y-prosemirror
       - yjs
 
-  '@prosekit/web@0.9.0-beta.1(prosemirror-model@1.25.8)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)':
+  '@prosekit/web@https://pkg.pr.new/@prosekit/web@b1a035b(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)':
     dependencies:
       '@aria-ui/core': 0.2.1
       '@aria-ui/elements': 0.1.10
       '@aria-ui/utils': 0.1.6
       '@floating-ui/dom': 1.7.6
       '@ocavue/utils': 1.7.0
-      '@prosekit/core': 0.13.0-beta.0(prosemirror-model@1.25.8)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
-      '@prosekit/extensions': 0.17.5-beta.1(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.8)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
-      '@prosekit/pm': 0.1.18
+      '@prosekit/core': https://pkg.pr.new/@prosekit/core@b1a035b(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      '@prosekit/extensions': https://pkg.pr.new/@prosekit/extensions@b1a035b(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+      '@prosekit/pm': https://pkg.pr.new/@prosekit/pm@b1a035b
       prosemirror-tables: 1.8.5
     transitivePeerDependencies:
       - '@lezer/common'
@@ -4521,14 +4533,14 @@ snapshots:
   '@prosemirror-adapter/core@0.5.3':
     dependencies:
       '@ocavue/utils': 1.7.0
-      prosemirror-model: 1.25.8
+      prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
       prosemirror-view: 1.41.9
 
   '@prosemirror-adapter/react@0.5.3(react-dom@19.2.7)(react@19.2.7)':
     dependencies:
       '@prosemirror-adapter/core': 0.5.3
-      prosemirror-model: 1.25.8
+      prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
       prosemirror-view: 1.41.9
     optionalDependencies:
@@ -4959,11 +4971,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@24.13.2)(jiti@2.7.0)(yaml@2.9.0)
 
-  '@vitest/browser-playwright@4.1.9(playwright@1.60.0)(vite@8.0.16)(vitest@4.1.9)':
+  '@vitest/browser-playwright@4.1.9(playwright@1.61.0)(vite@8.0.16)(vitest@4.1.9)':
     dependencies:
       '@vitest/browser': 4.1.9(vite@8.0.16)(vitest@4.1.9)
       '@vitest/mocker': 4.1.9(vite@8.0.16)
-      playwright: 1.60.0
+      playwright: 1.61.0
       tinyrainbow: 3.1.0
       vitest: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.0.16)
     transitivePeerDependencies:
@@ -6297,11 +6309,11 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  playwright-core@1.60.0: {}
+  playwright-core@1.61.0: {}
 
-  playwright@1.60.0:
+  playwright@1.61.0:
     dependencies:
-      playwright-core: 1.60.0
+      playwright-core: 1.61.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -6346,14 +6358,14 @@ snapshots:
 
   prosemirror-commands@1.7.1:
     dependencies:
-      prosemirror-model: 1.25.8
+      prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
 
   prosemirror-drop-indicator@0.1.4:
     dependencies:
       '@ocavue/utils': 1.7.0
-      prosemirror-model: 1.25.8
+      prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
       prosemirror-view: 1.41.9
 
@@ -6366,7 +6378,7 @@ snapshots:
   prosemirror-enter-rules@0.1.5:
     dependencies:
       prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.8
+      prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
       prosemirror-view: 1.41.9
 
@@ -6374,7 +6386,7 @@ snapshots:
     dependencies:
       prosemirror-commands: 1.7.1
       prosemirror-inputrules: 1.5.1
-      prosemirror-model: 1.25.8
+      prosemirror-model: 1.25.9
       prosemirror-safari-ime-span: 1.0.2
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
@@ -6383,17 +6395,17 @@ snapshots:
   prosemirror-gapcursor@1.4.1:
     dependencies:
       prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.8
+      prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
       prosemirror-view: 1.41.9
 
-  prosemirror-highlight@0.15.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.8)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9):
+  prosemirror-highlight@0.15.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9):
     optionalDependencies:
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@shikijs/types': 4.2.0
       '@types/hast': 3.0.4
-      prosemirror-model: 1.25.8
+      prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.9
@@ -6420,11 +6432,11 @@ snapshots:
       '@ocavue/utils': 1.7.0
       prosemirror-enter-rules: 0.1.5
       prosemirror-inputrules: 1.5.1
-      prosemirror-model: 1.25.8
+      prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
       prosemirror-view: 1.41.9
 
-  prosemirror-model@1.25.8:
+  prosemirror-model@1.25.9:
     dependencies:
       orderedmap: 2.1.1
 
@@ -6435,37 +6447,37 @@ snapshots:
 
   prosemirror-search@1.1.1:
     dependencies:
-      prosemirror-model: 1.25.8
+      prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
       prosemirror-view: 1.41.9
 
-  prosemirror-splittable@0.1.1(prosemirror-model@1.25.8)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0):
+  prosemirror-splittable@0.1.1(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0):
     optionalDependencies:
-      prosemirror-model: 1.25.8
+      prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
 
   prosemirror-state@1.4.4:
     dependencies:
-      prosemirror-model: 1.25.8
+      prosemirror-model: 1.25.9
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.9
 
   prosemirror-tables@1.8.5:
     dependencies:
       prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.8
+      prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.9
 
   prosemirror-transform@1.12.0:
     dependencies:
-      prosemirror-model: 1.25.8
+      prosemirror-model: 1.25.9
 
   prosemirror-view@1.41.9:
     dependencies:
-      prosemirror-model: 1.25.8
+      prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
 
@@ -6826,7 +6838,7 @@ snapshots:
 
   vitest-browser-commands@0.2.1(@vitest/browser-playwright@4.1.9)(vitest@4.1.9):
     optionalDependencies:
-      '@vitest/browser-playwright': 4.1.9(playwright@1.60.0)(vite@8.0.16)(vitest@4.1.9)
+      '@vitest/browser-playwright': 4.1.9(playwright@1.61.0)(vite@8.0.16)(vitest@4.1.9)
       vitest: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(vite@8.0.16)
 
   vitest-browser-react@2.2.0(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(vitest@4.1.9):
@@ -6862,7 +6874,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.2
-      '@vitest/browser-playwright': 4.1.9(playwright@1.60.0)(vite@8.0.16)(vitest@4.1.9)
+      '@vitest/browser-playwright': 4.1.9(playwright@1.61.0)(vite@8.0.16)(vitest@4.1.9)
       '@vitest/coverage-v8': 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
     transitivePeerDependencies:
       - msw

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,13 +5,6 @@ settings:
   dedupePeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@prosekit/core': https://pkg.pr.new/@prosekit/core@b1a035b
-  '@prosekit/extensions': https://pkg.pr.new/@prosekit/extensions@b1a035b
-  '@prosekit/pm': https://pkg.pr.new/@prosekit/pm@b1a035b
-  '@prosekit/react': https://pkg.pr.new/@prosekit/react@b1a035b
-  '@prosekit/web': https://pkg.pr.new/@prosekit/web@b1a035b
-
 importers:
 
   .:
@@ -71,14 +64,14 @@ importers:
         specifier: ^1.7.0
         version: 1.7.0
       '@prosekit/core':
-        specifier: https://pkg.pr.new/@prosekit/core@b1a035b
-        version: https://pkg.pr.new/@prosekit/core@b1a035b(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+        specifier: ^0.13.0-beta.1
+        version: 0.13.0-beta.1(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       '@prosekit/extensions':
-        specifier: https://pkg.pr.new/@prosekit/extensions@b1a035b
-        version: https://pkg.pr.new/@prosekit/extensions@b1a035b(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+        specifier: ^0.17.5-beta.2
+        version: 0.17.5-beta.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
       '@prosekit/pm':
-        specifier: https://pkg.pr.new/@prosekit/pm@b1a035b
-        version: https://pkg.pr.new/@prosekit/pm@b1a035b
+        specifier: ^0.1.18
+        version: 0.1.18
       prosemirror-highlight:
         specifier: ^0.15.2
         version: 0.15.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
@@ -135,14 +128,14 @@ importers:
         specifier: ^1.7.0
         version: 1.7.0
       '@prosekit/core':
-        specifier: https://pkg.pr.new/@prosekit/core@b1a035b
-        version: https://pkg.pr.new/@prosekit/core@b1a035b(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+        specifier: ^0.13.0-beta.1
+        version: 0.13.0-beta.1(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       '@prosekit/pm':
-        specifier: https://pkg.pr.new/@prosekit/pm@b1a035b
-        version: https://pkg.pr.new/@prosekit/pm@b1a035b
+        specifier: ^0.1.18
+        version: 0.1.18
       '@prosekit/react':
-        specifier: https://pkg.pr.new/@prosekit/react@b1a035b
-        version: https://pkg.pr.new/@prosekit/react@b1a035b(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(react-dom@19.2.7)(react@19.2.7)
+        specifier: ^0.8.0-beta.2
+        version: 0.8.0-beta.2(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(react-dom@19.2.7)(react@19.2.7)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1092,13 +1085,11 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@prosekit/core@https://pkg.pr.new/@prosekit/core@b1a035b':
-    resolution: {integrity: sha512-l6jhAThuBNVe8f2G4eRbrR4/ULFgK47zTS6mngMGL278uRgFYbCYZqRCLtJXAfK15IVS+yhF7muOoEZvpM7F/A==, tarball: https://pkg.pr.new/@prosekit/core@b1a035b}
-    version: 0.13.0-beta.0
+  '@prosekit/core@0.13.0-beta.1':
+    resolution: {integrity: sha512-EbeGlJwJmulRECahMKaKsHcGHOOFCYOu0hjHOgc0dBLFmhk1m64LOYdE4zC5Ek9KlSnt5DPq6y7T8UakdsnS8Q==}
 
-  '@prosekit/extensions@https://pkg.pr.new/@prosekit/extensions@b1a035b':
-    resolution: {integrity: sha512-/sKOA/lvCrVPXn9yLULOk5ictravMixSc4lsQb4gsDtFk2tf0ztvsZ4k4GLvpF3DeCGnxNK/ZKNiDUhxl2UucQ==, tarball: https://pkg.pr.new/@prosekit/extensions@b1a035b}
-    version: 0.17.5-beta.1
+  '@prosekit/extensions@0.17.5-beta.2':
+    resolution: {integrity: sha512-Clr9AFdT6IG/XrJlCYUeLChsEkj83q8uka6InbkFIKwmxlADUc7SgZyOjeteG7Hv7+pyOVzKdrlU4KTbZYEaPQ==}
     peerDependencies:
       loro-crdt: '>= 1.10.0'
       loro-prosemirror: '>= 0.4.1'
@@ -1114,13 +1105,11 @@ packages:
       yjs:
         optional: true
 
-  '@prosekit/pm@https://pkg.pr.new/@prosekit/pm@b1a035b':
-    resolution: {integrity: sha512-K00S6TY4gIlkWo1Y53h9STePNSPZ6UroHaIiKTkJvfMnwBBUZEc7+CUpmtNMzLtUqjmVAoaCTnW6VDBJaEXqWg==, tarball: https://pkg.pr.new/@prosekit/pm@b1a035b}
-    version: 0.1.18
+  '@prosekit/pm@0.1.18':
+    resolution: {integrity: sha512-K00S6TY4gIlkWo1Y53h9STePNSPZ6UroHaIiKTkJvfMnwBBUZEc7+CUpmtNMzLtUqjmVAoaCTnW6VDBJaEXqWg==}
 
-  '@prosekit/react@https://pkg.pr.new/@prosekit/react@b1a035b':
-    resolution: {integrity: sha512-IHEOpEoaO/XU6EGZBEW4ZH/IwsYBsayRv7QLe/2FZMpgdtcR7fBiYuV3Nb0yKaz88Ue+Dfe+WVpzEgcCbzPXuA==, tarball: https://pkg.pr.new/@prosekit/react@b1a035b}
-    version: 0.8.0-beta.1
+  '@prosekit/react@0.8.0-beta.2':
+    resolution: {integrity: sha512-4q6PtB+RrmS+aZryr2fZA0w0MfY0BEWesyvpt7pqd1Dn5jKu/ri9sGdHZnKdDILlaIZ3tAMQce1dUmfs+iUqeg==}
     peerDependencies:
       react: '>= 18.2.0'
       react-dom: '>= 18.2.0'
@@ -1130,9 +1119,8 @@ packages:
       react-dom:
         optional: true
 
-  '@prosekit/web@https://pkg.pr.new/@prosekit/web@b1a035b':
-    resolution: {integrity: sha512-RiVWmo7D3YBHwX8KTt4gj4m6OumjSrJ7g7GcsB18A3MLrIaKF05ADMJJJag7Krj2F8VlaJn/G2kJM5kGoVEpeg==, tarball: https://pkg.pr.new/@prosekit/web@b1a035b}
-    version: 0.9.0-beta.1
+  '@prosekit/web@0.9.0-beta.2':
+    resolution: {integrity: sha512-pXS+g5gvLX4Pi4eddbTBwTKOhpYBCXRyED3xc+xv/sc7Y3uPuvdwh6xl1rD5MCqTWp+fNAs8PKycoBCwMK1VNg==}
 
   '@prosemirror-adapter/core@0.5.3':
     resolution: {integrity: sha512-jGcI/eq3USFqf1fCaejgCmifmXYDyFco6/5KjyyNBnuEhLqyLjD+020CtcduEOsnN4xPZr5ikclgHIR6kEFkQg==}
@@ -4419,10 +4407,10 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@prosekit/core@https://pkg.pr.new/@prosekit/core@b1a035b(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)':
+  '@prosekit/core@0.13.0-beta.1(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)':
     dependencies:
       '@ocavue/utils': 1.7.0
-      '@prosekit/pm': https://pkg.pr.new/@prosekit/pm@b1a035b
+      '@prosekit/pm': 0.1.18
       orderedmap: 2.1.1
       prosemirror-splittable: 0.1.1(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       type-fest: 5.7.0
@@ -4431,11 +4419,11 @@ snapshots:
       - prosemirror-state
       - prosemirror-transform
 
-  '@prosekit/extensions@https://pkg.pr.new/@prosekit/extensions@b1a035b(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
+  '@prosekit/extensions@0.17.5-beta.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)':
     dependencies:
       '@ocavue/utils': 1.7.0
-      '@prosekit/core': https://pkg.pr.new/@prosekit/core@b1a035b(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
-      '@prosekit/pm': https://pkg.pr.new/@prosekit/pm@b1a035b
+      '@prosekit/core': 0.13.0-beta.1(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      '@prosekit/pm': 0.1.18
       prosemirror-changeset: 2.4.1
       prosemirror-drop-indicator: 0.1.4
       prosemirror-dropcursor: 1.8.2
@@ -4462,7 +4450,7 @@ snapshots:
       - refractor
       - sugar-high
 
-  '@prosekit/pm@https://pkg.pr.new/@prosekit/pm@b1a035b':
+  '@prosekit/pm@0.1.18':
     dependencies:
       prosemirror-commands: 1.7.1
       prosemirror-history: 1.5.0
@@ -4473,11 +4461,11 @@ snapshots:
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.9
 
-  '@prosekit/react@https://pkg.pr.new/@prosekit/react@b1a035b(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(react-dom@19.2.7)(react@19.2.7)':
+  '@prosekit/react@0.8.0-beta.2(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(react-dom@19.2.7)(react@19.2.7)':
     dependencies:
-      '@prosekit/core': https://pkg.pr.new/@prosekit/core@b1a035b(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
-      '@prosekit/pm': https://pkg.pr.new/@prosekit/pm@b1a035b
-      '@prosekit/web': https://pkg.pr.new/@prosekit/web@b1a035b(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      '@prosekit/core': 0.13.0-beta.1(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      '@prosekit/pm': 0.1.18
+      '@prosekit/web': 0.9.0-beta.2(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       '@prosemirror-adapter/core': 0.5.3
       '@prosemirror-adapter/react': 0.5.3(react-dom@19.2.7)(react@19.2.7)
     optionalDependencies:
@@ -4501,16 +4489,16 @@ snapshots:
       - y-prosemirror
       - yjs
 
-  '@prosekit/web@https://pkg.pr.new/@prosekit/web@b1a035b(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)':
+  '@prosekit/web@0.9.0-beta.2(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)':
     dependencies:
       '@aria-ui/core': 0.2.1
       '@aria-ui/elements': 0.1.10
       '@aria-ui/utils': 0.1.6
       '@floating-ui/dom': 1.7.6
       '@ocavue/utils': 1.7.0
-      '@prosekit/core': https://pkg.pr.new/@prosekit/core@b1a035b(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
-      '@prosekit/extensions': https://pkg.pr.new/@prosekit/extensions@b1a035b(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
-      '@prosekit/pm': https://pkg.pr.new/@prosekit/pm@b1a035b
+      '@prosekit/core': 0.13.0-beta.1(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      '@prosekit/extensions': 0.17.5-beta.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+      '@prosekit/pm': 0.1.18
       prosemirror-tables: 1.8.5
     transitivePeerDependencies:
       - '@lezer/common'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,19 @@ trustPolicyIgnoreAfter: 10080 # 7 days
 
 trustLockfile: true
 
+# Temporary: testing the unreleased `MarkBuilder.create` change from
+# prosekit/prosekit#1683 via pkg.pr.new. Once a prosekit beta that includes
+# `create` is released, remove this block and bump the `@prosekit/*` specifiers
+# in the package.json files to that version.
+blockExoticSubdeps: false
+
+overrides:
+  '@prosekit/core': 'https://pkg.pr.new/@prosekit/core@b1a035b'
+  '@prosekit/extensions': 'https://pkg.pr.new/@prosekit/extensions@b1a035b'
+  '@prosekit/pm': 'https://pkg.pr.new/@prosekit/pm@b1a035b'
+  '@prosekit/react': 'https://pkg.pr.new/@prosekit/react@b1a035b'
+  '@prosekit/web': 'https://pkg.pr.new/@prosekit/web@b1a035b'
+
 minimumReleaseAgeExclude:
   - prosemirror-highlight@0.15.2
   - '@ocavue/utils@1.7.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,25 +14,12 @@ trustPolicyIgnoreAfter: 10080 # 7 days
 
 trustLockfile: true
 
-# Temporary: testing the unreleased `MarkBuilder.create` change from
-# prosekit/prosekit#1683 via pkg.pr.new. Once a prosekit beta that includes
-# `create` is released, remove this block and bump the `@prosekit/*` specifiers
-# in the package.json files to that version.
-blockExoticSubdeps: false
-
-overrides:
-  '@prosekit/core': 'https://pkg.pr.new/@prosekit/core@b1a035b'
-  '@prosekit/extensions': 'https://pkg.pr.new/@prosekit/extensions@b1a035b'
-  '@prosekit/pm': 'https://pkg.pr.new/@prosekit/pm@b1a035b'
-  '@prosekit/react': 'https://pkg.pr.new/@prosekit/react@b1a035b'
-  '@prosekit/web': 'https://pkg.pr.new/@prosekit/web@b1a035b'
-
 minimumReleaseAgeExclude:
   - prosemirror-highlight@0.15.2
   - '@ocavue/utils@1.7.0'
-  - '@prosekit/core@0.13.0-beta.0'
-  - '@prosekit/extensions@0.17.5-beta.1'
-  - '@prosekit/react@0.8.0-beta.1'
-  - '@prosekit/web@0.9.0-beta.1'
+  - '@prosekit/core@0.13.0-beta.1'
+  - '@prosekit/extensions@0.17.5-beta.2'
+  - '@prosekit/react@0.8.0-beta.2'
+  - '@prosekit/web@0.9.0-beta.2'
   - eslint-plugin-unicorn@66.0.0
   - '@ocavue/eslint-config@4.7.1'


### PR DESCRIPTION
Replaces the stringly-typed `schema.marks[name].create()` access in the inline-mark walk with typed mark builders, using the new `MarkBuilder.create` method from prosekit/prosekit#1683.

## What changed

- `inline-text-to-mark-chunks.ts`: `inlineTextToMarkChunks` / `walk` / `walkLink` now take `TypedMarkBuilders` instead of a raw `Schema`, and create marks via `marks.mdLinkText.create({ href })` / `marks[name].create()`. Attributes are now type-checked per mark.
- `schema.ts`: adds `getMarkBuildersForSchema(schema)`, a per-schema-cached accessor. The plugin must create marks from the live editor's own `state.schema` (a different `Schema` instance than the shared schema), so it cannot reuse `getMarkBuilders()`.
- `inline-mark-plugin.ts`: passes `getMarkBuildersForSchema(schema)` into the walk.
- Test and bench callers updated to pass builders.

Pure refactor: no behavior change. All 414 core tests pass with no snapshot updates.

## Dependency note (temporary)

This consumes an unreleased prosekit change via pkg.pr.new (pinned to commit `b1a035b`). The `pnpm-workspace.yaml` `overrides` / `blockExoticSubdeps` block is temporary scaffolding (first commit) and will be removed once a prosekit beta with `create` is released, at which point the `@prosekit/*` specifiers get bumped to that version.

Depends on prosekit/prosekit#1683.