### PR TITLE
fix(core): allow table node selection

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,8 +29,7 @@
     "@prosekit/core": "^0.13.0-beta.1",
     "@prosekit/extensions": "^0.17.5-beta.2",
     "@prosekit/pm": "^0.1.18",
-    "prosemirror-highlight": "^0.15.2",
-    "prosemirror-tables": "^1.8.5"
+    "prosemirror-highlight": "^0.15.2"
   },
   "devDependencies": {
     "@ocavue/tsconfig": "^0.7.1",

--- a/packages/core/src/extensions/table.test.ts
+++ b/packages/core/src/extensions/table.test.ts
@@ -23,11 +23,15 @@ describe('table', () => {
     view.dispatch(view.state.tr.setSelection(selection))
 
     view.focus()
-    expect(getTablePos(fixture.doc)).toBeGreaterThan(-1)
+    expect(hasTable(fixture.doc)).toBe(true)
     await userEvent.keyboard('{Backspace}')
-    expect(getTablePos(fixture.doc)).toBe(-1)
+    expect(hasTable(fixture.doc)).toBe(false)
   })
 })
+
+function hasTable(doc: EditorNode): boolean {
+  return getTablePos(doc) > -1
+}
 
 function getTablePos(doc: EditorNode): number {
   let tablePos = -1

--- a/packages/core/src/extensions/table.test.ts
+++ b/packages/core/src/extensions/table.test.ts
@@ -1,0 +1,35 @@
+import { NodeSelection } from '@prosekit/pm/state'
+import { describe, expect, it } from 'vitest'
+import { userEvent } from 'vitest/browser'
+
+import { docToMarkdown } from '../converters/pm-to-md.ts'
+import { setupFixture } from '../testing/index.ts'
+
+describe('table block-handle deletion', () => {
+  it('deletes the whole table when Backspace follows a block-handle node-selection', async () => {
+    using fixture = setupFixture()
+    const { n, view } = fixture
+    fixture.set(
+      n.doc(
+        n.paragraph('before'),
+        n.table(
+          n.tableRow(n.tableHeaderCell(n.paragraph('a')), n.tableHeaderCell(n.paragraph('b'))),
+          n.tableRow(n.tableCell(n.paragraph('1')), n.tableCell(n.paragraph('2'))),
+        ),
+      ),
+    )
+
+    // Reproduce what the block handle does: node-select the table node.
+    let tablePos = -1
+    fixture.doc.forEach((node, offset) => {
+      if (node.type.name === 'table') tablePos = offset
+    })
+    view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, tablePos)))
+
+    view.focus()
+    await userEvent.keyboard('{Backspace}')
+
+    // The whole table is gone: no pipe characters remain.
+    expect(docToMarkdown(fixture.doc).includes('|')).toBe(false)
+  })
+})

--- a/packages/core/src/extensions/table.test.ts
+++ b/packages/core/src/extensions/table.test.ts
@@ -1,15 +1,15 @@
+import type { EditorNode } from '@prosekit/pm/model'
 import { NodeSelection } from '@prosekit/pm/state'
 import { describe, expect, it } from 'vitest'
 import { userEvent } from 'vitest/browser'
 
-import type { EditorNode } from '@prosekit/pm/model'
 import { setupFixture } from '../testing/index.ts'
 
 describe('table', () => {
   it('deletes the whole selected table when Backspace', async () => {
     using fixture = setupFixture()
     const { n, view } = fixture
-    let doc = n.doc(
+    const doc = n.doc(
       n.paragraph('before'),
       n.table(
         n.tableRow(n.tableHeaderCell(n.paragraph('a')), n.tableHeaderCell(n.paragraph('b'))),
@@ -18,8 +18,8 @@ describe('table', () => {
     )
     fixture.set(doc)
 
-    let tablePos = getTablePos(fixture.doc)
-    let selection = NodeSelection.create(view.state.doc, tablePos)
+    const tablePos = getTablePos(fixture.doc)
+    const selection = NodeSelection.create(view.state.doc, tablePos)
     view.dispatch(view.state.tr.setSelection(selection))
 
     view.focus()

--- a/packages/core/src/extensions/table.test.ts
+++ b/packages/core/src/extensions/table.test.ts
@@ -2,34 +2,37 @@ import { NodeSelection } from '@prosekit/pm/state'
 import { describe, expect, it } from 'vitest'
 import { userEvent } from 'vitest/browser'
 
-import { docToMarkdown } from '../converters/pm-to-md.ts'
+import type { EditorNode } from '@prosekit/pm/model'
 import { setupFixture } from '../testing/index.ts'
 
-describe('table block-handle deletion', () => {
-  it('deletes the whole table when Backspace follows a block-handle node-selection', async () => {
+describe('table', () => {
+  it('deletes the whole selected table when Backspace', async () => {
     using fixture = setupFixture()
     const { n, view } = fixture
-    fixture.set(
-      n.doc(
-        n.paragraph('before'),
-        n.table(
-          n.tableRow(n.tableHeaderCell(n.paragraph('a')), n.tableHeaderCell(n.paragraph('b'))),
-          n.tableRow(n.tableCell(n.paragraph('1')), n.tableCell(n.paragraph('2'))),
-        ),
+    let doc = n.doc(
+      n.paragraph('before'),
+      n.table(
+        n.tableRow(n.tableHeaderCell(n.paragraph('a')), n.tableHeaderCell(n.paragraph('b'))),
+        n.tableRow(n.tableCell(n.paragraph('1')), n.tableCell(n.paragraph('2'))),
       ),
     )
+    fixture.set(doc)
 
-    // Reproduce what the block handle does: node-select the table node.
-    let tablePos = -1
-    fixture.doc.forEach((node, offset) => {
-      if (node.type.name === 'table') tablePos = offset
-    })
-    view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, tablePos)))
+    let tablePos = getTablePos(fixture.doc)
+    let selection = NodeSelection.create(view.state.doc, tablePos)
+    view.dispatch(view.state.tr.setSelection(selection))
 
     view.focus()
+    expect(getTablePos(fixture.doc)).toBeGreaterThan(-1)
     await userEvent.keyboard('{Backspace}')
-
-    // The whole table is gone: no pipe characters remain.
-    expect(docToMarkdown(fixture.doc).includes('|')).toBe(false)
+    expect(getTablePos(fixture.doc)).toBe(-1)
   })
 })
+
+function getTablePos(doc: EditorNode): number {
+  let tablePos = -1
+  doc.forEach((node, offset) => {
+    if (node.type.name === 'table') tablePos = offset
+  })
+  return tablePos
+}

--- a/packages/core/src/extensions/table.ts
+++ b/packages/core/src/extensions/table.ts
@@ -1,13 +1,13 @@
-import { definePlugin, union } from '@prosekit/core'
+import { union } from '@prosekit/core'
 import {
   defineTableCellSpec,
   defineTableCommands,
   defineTableDropIndicator,
+  defineTableEditingPlugin,
   defineTableHeaderCellSpec,
   defineTableRowSpec,
   defineTableSpec,
 } from '@prosekit/extensions/table'
-import { tableEditing } from 'prosemirror-tables'
 
 export function defineTable() {
   return union(
@@ -15,7 +15,7 @@ export function defineTable() {
     defineTableRowSpec(),
     defineTableCellSpec(),
     defineTableHeaderCellSpec(),
-    definePlugin(tableEditing()), // TODO: export related API from prosekit so that we don't have to install prosemirror-tables as a separate dependency
+    defineTableEditingPlugin({ allowTableNodeSelection: true }),
     defineTableCommands(),
     defineTableDropIndicator(),
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,9 +75,6 @@ importers:
       prosemirror-highlight:
         specifier: ^0.15.2
         version: 0.15.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
-      prosemirror-tables:
-        specifier: ^1.8.5
-        version: 1.8.5
     devDependencies:
       '@ocavue/tsconfig':
         specifier: ^0.7.1


### PR DESCRIPTION
## Problem

Selecting a table via the block handle (drag grip) and pressing `Backspace` wiped every cell's text but left the empty table structure behind. Every other block deletes cleanly the same way, so tables were inconsistent.

## Root cause

The block handle dispatches a `NodeSelection` on the hovered block. With `prosemirror-tables`' default `allowTableNodeSelection: false`, the table-editing plugin's `normalizeSelection` rewrites that node selection into an all-cells `CellSelection`. `Backspace` on a `CellSelection` runs `deleteCellSelection`, which only clears cell contents and never removes the table node. It is an integration gap in how meowdown configured the table extension, not a defect in prosekit or prosemirror-tables.

## Fix

Opt into table node selection through prosekit's own API. `@prosekit/extensions/table` already exports `defineTableEditingPlugin(options?)`, whose `TableEditingOptions.allowTableNodeSelection` is the exact knob. With it enabled, the block handle's `NodeSelection` on the table survives, so `Backspace` falls through to the base keymap's `deleteSelection` and removes the whole table. The table now also shows the standard `ProseMirror-selectednode` outline like every other block.

Using `defineTableEditingPlugin` lets `table.ts` stop importing `tableEditing` from `prosemirror-tables` directly, so the direct `prosemirror-tables` dependency is dropped from `packages/core` (it remains transitively under `@prosekit/extensions`). This resolves the long-standing `TODO` in `table.ts`. Normal cross-cell drag-delete is unchanged: that is still a real `CellSelection`, so `deleteCellSelection` still clears those cells.

## Test

Adds `packages/core/src/extensions/table.test.ts`, which node-selects a table (exactly what the block handle does), presses `Backspace`, and asserts the table is gone. It fails before the fix and passes after. Full suite (513 tests) green; typecheck, eslint, oxfmt, and knip all pass.