### PR TITLE
fix(react): constrain autocomplete menu width

### DIFF
--- a/packages/react/src/components/autocomplete-menu.module.css
+++ b/packages/react/src/components/autocomplete-menu.module.css
@@ -1,7 +1,7 @@
 .Positioner {
   display: block;
   z-index: 50;
-  width: min-content;
+  width: min(24rem, calc(100vw - 1rem));
   height: min-content;
   overflow: visible;
 }
@@ -10,9 +10,12 @@
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
-  min-width: 15rem;
+  width: 100%;
+  min-width: min(15rem, 100%);
+  max-width: 100%;
   max-height: 25rem;
   padding: 0.25rem;
+  overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: contain;
   white-space: nowrap;
@@ -39,6 +42,7 @@
   cursor: default;
   user-select: none;
   scroll-margin: 0.25rem;
+  min-width: 0;
 
   /* `display: flex` above would override the UA's `[hidden]` rule, which
    * the menu relies on to hide filtered-out items. */
@@ -58,8 +62,17 @@
   }
 }
 
+.Label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .Detail {
   flex-shrink: 0;
+  max-width: 40%;
+  overflow: hidden;
+  text-overflow: ellipsis;
   font-size: 0.8125rem;
   color: var(--meowdown-muted);
 }

--- a/packages/react/src/components/autocomplete-menu.module.d.css.ts
+++ b/packages/react/src/components/autocomplete-menu.module.d.css.ts
@@ -3,6 +3,7 @@ declare const styles = {
   'Positioner': '' as string,
   'Popup': '' as string,
   'Item': '' as string,
+  'Label': '' as string,
   'Detail': '' as string,
 } as const;
 export default styles;

--- a/packages/react/src/components/tag-menu.tsx
+++ b/packages/react/src/components/tag-menu.tsx
@@ -77,7 +77,7 @@ export function TagMenu({ onTagSearch }: TagMenuProps) {
                 item.onSelect?.()
               }}
             >
-              <span>{item.label ?? `#${item.tag}`}</span>
+              <span className={styles.Label}>{item.label ?? `#${item.tag}`}</span>
               {item.detail ? <span className={styles.Detail}>{item.detail}</span> : null}
             </AutocompleteItem>
           ))}

--- a/packages/react/src/components/wikilink-menu.test.tsx
+++ b/packages/react/src/components/wikilink-menu.test.tsx
@@ -93,6 +93,28 @@ describe('WikilinkMenu', () => {
     expect(onSelect).toHaveBeenCalled()
   })
 
+  it('keeps long rows within the menu width', async () => {
+    const longTitle = 'A very long note title '.repeat(12)
+    const richSearch = (): WikilinkItem[] => [
+      {
+        target: longTitle,
+        label: longTitle,
+        detail: 'A very long detail '.repeat(8),
+      },
+    ]
+
+    await render(<ProseKitEditor onWikilinkSearch={richSearch} />)
+    await pmRoot.click()
+    await userEvent.keyboard(TWO_BRACKETS)
+    await expect.element(menu.getByText(longTitle)).toBeVisible()
+
+    const menuBox = menu.element().getBoundingClientRect()
+    const label = menu.getByText(longTitle).element()
+
+    expect(menuBox.width).toBeLessThanOrEqual(384)
+    expect(label.scrollWidth).toBeGreaterThan(label.clientWidth)
+  })
+
   it('inserts the selected note as [[Name]] and removes the query', async () => {
     const ref = createRef<EditorHandle>()
     await render(<ProseKitEditor ref={ref} onWikilinkSearch={searchNotes} />)

--- a/packages/react/src/components/wikilink-menu.tsx
+++ b/packages/react/src/components/wikilink-menu.tsx
@@ -77,7 +77,7 @@ export function WikilinkMenu({ onWikilinkSearch }: WikilinkMenuProps) {
                 item.onSelect?.()
               }}
             >
-              <span>{item.label ?? item.target}</span>
+              <span className={styles.Label}>{item.label ?? item.target}</span>
               {item.detail ? <span className={styles.Detail}>{item.detail}</span> : null}
             </AutocompleteItem>
           ))}


### PR DESCRIPTION
## Summary
- constrain the shared autocomplete menu to a viewport-safe max width
- ellipsize long tag/wikilink labels and details instead of letting rows expand the popup
- add a wikilink menu regression test for long note titles

## Testing
- pnpm test packages/react/src/components/wikilink-menu.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm build