### PR TITLE
feat: make autocomplete menu colors themeable

### DIFF
--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -18,6 +18,8 @@
   --meowdown-border: light-dark(#e4e4e7, #3f3f46);
   --meowdown-code-bg: light-dark(#f4f4f5, #18181b);
   --meowdown-table-header-bg: light-dark(#fafafa, #27272a);
+  --meowdown-autocomplete-bg: light-dark(#fff, #18181b);
+  --meowdown-autocomplete-highlight-bg: light-dark(#f4f4f5, #27272a);
   --meowdown-font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
 
   /* Selection colors. Deliberately standalone variables, not derived from

--- a/packages/react/src/components/autocomplete-menu.module.css
+++ b/packages/react/src/components/autocomplete-menu.module.css
@@ -22,7 +22,8 @@
   user-select: none;
   border: 1px solid var(--meowdown-border);
   border-radius: 0.75rem;
-  background: light-dark(#fff, #18181b);
+  background: #fff;
+  background: var(--meowdown-autocomplete-bg, light-dark(#fff, #18181b));
   box-shadow:
     0 10px 15px -3px rgb(0 0 0 / 0.1),
     0 4px 6px -4px rgb(0 0 0 / 0.1);
@@ -51,7 +52,8 @@
   }
 
   &[data-highlighted] {
-    background: light-dark(#f4f4f5, #27272a);
+    background: #f4f4f5;
+    background: var(--meowdown-autocomplete-highlight-bg, light-dark(#f4f4f5, #27272a));
   }
 
   kbd {


### PR DESCRIPTION
## Summary
- add default CSS variables for autocomplete popup and highlighted-row backgrounds
- route the React autocomplete menu through those variables
- keep plain-color fallback declarations before the variable-based backgrounds so unsupported theme functions still leave the menu opaque

## Testing
- pnpm typecheck && pnpm lint
- pnpm build

## Notes
- pnpm build passed with existing sourcemap warnings from @tsdown/css and the website chunk-size warning.