### PR TITLE
fix(core): keep empty list item markers on serialize

### DIFF
--- a/packages/core/src/converters/pm-to-md.test.ts
+++ b/packages/core/src/converters/pm-to-md.test.ts
@@ -112,6 +112,30 @@ describe('docToMarkdown', () => {
     expect(docToMarkdown(node)).toBe('- item\n\nafter\n')
   })
 
+  it('keeps an empty bullet between two paragraphs', () => {
+    const bullet: NodeJSON = {
+      type: 'list',
+      attrs: { kind: 'bullet', order: null, checked: false, collapsed: false },
+      content: [paragraph('')],
+    }
+    const node = docFromJSON(wrapInDoc(paragraph('LINE 1'), bullet, paragraph('LINE 2')))
+    expect(docToMarkdown(node)).toBe('LINE 1\n\n-\n\nLINE 2\n')
+  })
+
+  it('keeps an empty item marker for every list kind', () => {
+    const empty = (attrs: Record<string, unknown>): NodeJSON => ({
+      type: 'list',
+      attrs,
+      content: [paragraph('')],
+    })
+    const bullet = empty({ kind: 'bullet', order: null, checked: false, collapsed: false })
+    const task = empty({ kind: 'task', order: null, checked: false, collapsed: false })
+    const ordered = empty({ kind: 'ordered', order: 1, checked: false, collapsed: false })
+    expect(docToMarkdown(docFromJSON(wrapInDoc(bullet)))).toBe('-\n')
+    expect(docToMarkdown(docFromJSON(wrapInDoc(task)))).toBe('- [ ]\n')
+    expect(docToMarkdown(docFromJSON(wrapInDoc(ordered)))).toBe('1.\n')
+  })
+
   it('serializes a fenced code block with language', () => {
     const node = docFromJSON(
       wrapInDoc({

--- a/packages/core/src/converters/pm-to-md.ts
+++ b/packages/core/src/converters/pm-to-md.ts
@@ -86,6 +86,14 @@ class MdOut {
 
   /** End the current block; the next write gets a blank line before it. */
   closeBlock(): void {
+    // An empty block (e.g. an empty list item `- `) still owns a line: flush
+    // its pending marker, trimmed, so it is neither dropped nor left dangling.
+    if (this.atLineStart && this.pendingFirst !== null) {
+      this.emitDeferredBlankLine()
+      this.parts.push(this.pendingFirst.trimEnd())
+      this.pendingFirst = null
+      this.atLineStart = false
+    }
     if (!this.atLineStart) this.parts.push('\n')
     this.atLineStart = true
     this.deferredBlankPrefix = this.linePrefix

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -51,6 +51,13 @@ describe('markdown round-trip is byte-identical', () => {
       1. one
       1. two
     `,
+    // Empty list items keep their marker; the line is not dropped
+    '-',
+    dedent`
+      - a
+      -
+      - b
+    `,
     // A genuinely loose item (two blocks) keeps its blank line
     dedent`
       - a
@@ -120,5 +127,10 @@ describe('markdown round-trip normalizations', () => {
 
   it('normalizes an uppercase task marker to lowercase', () => {
     expect(roundtrip('- [X] done')).toBe('- [x] done\n')
+  })
+
+  it('trims an empty list item to a bare marker', () => {
+    expect(roundtrip('- ')).toBe('-\n')
+    expect(roundtrip('- a\n- \n- b')).toBe('- a\n-\n- b\n')
   })
 })


### PR DESCRIPTION
An empty list item (e.g. an empty bullet `- `) was dropped entirely by `docToMarkdown`: its marker lives in `MdOut.pendingFirst` and is only flushed when some content is written, so a content-less item emitted nothing and the line vanished. This silently erased empty bullets from saved files in editors that persist `docToMarkdown(editor.state.doc)` (e.g. reflect-open, which writes the output verbatim). `closeBlock` now flushes a pending marker (trimmed) for content-less blocks, so empty items serialize to `-` / `- [ ]` / `1.` and round-trip stably.