### PR TITLE
fix(core): improve focus-mode marker reveal

### DIFF
--- a/packages/core/src/extensions/inline-mark-plugin.test.ts
+++ b/packages/core/src/extensions/inline-mark-plugin.test.ts
@@ -15,9 +15,9 @@ describe('inlineMarkPlugin', () => {
 
     const pos = findText(fixture.doc, 'bold')
     expect(pos).toBeGreaterThan(0)
-    expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdGroup', 'mdStrong'])
-    // The `**` syntax markers carry the group, mdStrong + mdMark.
-    expect(marksAt(fixture.doc, pos - 1)).toEqual(['mdGroup', 'mdMark', 'mdStrong'])
+    expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdPack', 'mdStrong'])
+    // The `**` syntax markers carry the pack, mdStrong + mdMark.
+    expect(marksAt(fixture.doc, pos - 1)).toEqual(['mdMark', 'mdPack', 'mdStrong'])
   })
 
   it('applies mdEm inside *italic*', () => {
@@ -27,7 +27,7 @@ describe('inlineMarkPlugin', () => {
     fixture.set(doc)
 
     const pos = findText(fixture.doc, 'ital')
-    expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdEm', 'mdGroup'])
+    expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdEm', 'mdPack'])
   })
 
   it('applies mdCode inside `code`', () => {
@@ -37,7 +37,7 @@ describe('inlineMarkPlugin', () => {
     fixture.set(doc)
 
     const pos = findText(fixture.doc, 'bar')
-    expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdCode', 'mdGroup'])
+    expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdCode', 'mdPack'])
   })
 
   it('applies mdLinkText with href attr inside [text](url)', () => {
@@ -96,7 +96,7 @@ describe('inlineMarkPlugin', () => {
     fixture.set(doc)
 
     const pos = findText(fixture.doc, 'italic')
-    expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdEm', 'mdGroup'])
+    expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdEm', 'mdPack'])
   })
 
   it('does NOT mark inline syntax inside code blocks', () => {
@@ -182,7 +182,7 @@ describe('inlineMarkPlugin', () => {
     fixture.set(doc)
 
     const pos = findText(fixture.doc, 'italic')
-    expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdEm', 'mdGroup'])
+    expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdEm', 'mdPack'])
   })
 
   it('applies mdTag across the whole #tag, # included', () => {
@@ -262,11 +262,11 @@ describe('inlineMarkPlugin', () => {
     expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdWikilinkSource'])
     // Delete one ']': "see [[note] end" is no longer a wikilink. The inner
     // `[note]` becomes a shortcut reference link, so it loses mdWikilinkSource
-    // but gains the link group wrapper.
+    // but gains the link pack wrapper.
     const firstBracket = findText(fixture.doc, ']')
     fixture.view.dispatch(fixture.state.tr.delete(firstBracket + 1, firstBracket + 2))
     const after = findText(fixture.doc, 'note')
-    expect(marksAt(fixture.doc, after + 1)).toEqual(['mdGroup'])
+    expect(marksAt(fixture.doc, after + 1)).toEqual(['mdPack'])
   })
 
   it('removes mdTag when text is glued in front of the #', () => {

--- a/packages/core/src/extensions/inline-mark-plugin.test.ts
+++ b/packages/core/src/extensions/inline-mark-plugin.test.ts
@@ -15,9 +15,9 @@ describe('inlineMarkPlugin', () => {
 
     const pos = findText(fixture.doc, 'bold')
     expect(pos).toBeGreaterThan(0)
-    expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdStrong'])
-    // The `**` syntax markers carry mdStrong + mdMark.
-    expect(marksAt(fixture.doc, pos - 1)).toEqual(['mdMark', 'mdStrong'])
+    expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdGroup', 'mdStrong'])
+    // The `**` syntax markers carry the group, mdStrong + mdMark.
+    expect(marksAt(fixture.doc, pos - 1)).toEqual(['mdGroup', 'mdMark', 'mdStrong'])
   })
 
   it('applies mdEm inside *italic*', () => {
@@ -27,7 +27,7 @@ describe('inlineMarkPlugin', () => {
     fixture.set(doc)
 
     const pos = findText(fixture.doc, 'ital')
-    expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdEm'])
+    expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdEm', 'mdGroup'])
   })
 
   it('applies mdCode inside `code`', () => {
@@ -37,7 +37,7 @@ describe('inlineMarkPlugin', () => {
     fixture.set(doc)
 
     const pos = findText(fixture.doc, 'bar')
-    expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdCode'])
+    expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdCode', 'mdGroup'])
   })
 
   it('applies mdLinkText with href attr inside [text](url)', () => {
@@ -96,7 +96,7 @@ describe('inlineMarkPlugin', () => {
     fixture.set(doc)
 
     const pos = findText(fixture.doc, 'italic')
-    expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdEm'])
+    expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdEm', 'mdGroup'])
   })
 
   it('does NOT mark inline syntax inside code blocks', () => {
@@ -182,7 +182,7 @@ describe('inlineMarkPlugin', () => {
     fixture.set(doc)
 
     const pos = findText(fixture.doc, 'italic')
-    expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdEm'])
+    expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdEm', 'mdGroup'])
   })
 
   it('applies mdTag across the whole #tag, # included', () => {
@@ -260,11 +260,13 @@ describe('inlineMarkPlugin', () => {
 
     const pos = findText(fixture.doc, 'note')
     expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdWikilinkSource'])
-    // Delete one ']': "see [[note] end" is no longer a wikilink.
+    // Delete one ']': "see [[note] end" is no longer a wikilink. The inner
+    // `[note]` becomes a shortcut reference link, so it loses mdWikilinkSource
+    // but gains the link group wrapper.
     const firstBracket = findText(fixture.doc, ']')
     fixture.view.dispatch(fixture.state.tr.delete(firstBracket + 1, firstBracket + 2))
     const after = findText(fixture.doc, 'note')
-    expect(marksAt(fixture.doc, after + 1)).toEqual([])
+    expect(marksAt(fixture.doc, after + 1)).toEqual(['mdGroup'])
   })
 
   it('removes mdTag when text is glued in front of the #', () => {

--- a/packages/core/src/extensions/inline-marks.test.ts
+++ b/packages/core/src/extensions/inline-marks.test.ts
@@ -22,11 +22,11 @@ describe('inline-marks', () => {
     expect(order.indexOf('mdImageSource')).toBeLessThan(order.indexOf('mdLinkUri'))
   })
 
-  it('ranks the group mark outermost of all, so it wraps the whole unit', () => {
-    // mdGroup must be the outer DOM wrapper, including outside an image mark view,
+  it('ranks the pack mark outermost of all, so it wraps the whole unit', () => {
+    // mdPack must be the outer DOM wrapper, including outside an image mark view,
     // so a reveal range can cover the entire unit.
     const schema = defineEditorExtension().schema!
     const order = Object.keys(schema.marks)
-    expect(order.indexOf('mdGroup')).toBeLessThan(order.indexOf('mdImageView'))
+    expect(order.indexOf('mdPack')).toBeLessThan(order.indexOf('mdImageView'))
   })
 })

--- a/packages/core/src/extensions/inline-marks.test.ts
+++ b/packages/core/src/extensions/inline-marks.test.ts
@@ -21,4 +21,12 @@ describe('inline-marks', () => {
     expect(order.indexOf('mdImageSource')).toBeLessThan(order.indexOf('mdMark'))
     expect(order.indexOf('mdImageSource')).toBeLessThan(order.indexOf('mdLinkUri'))
   })
+
+  it('ranks the group mark outermost of all, so it wraps the whole unit', () => {
+    // mdGroup must be the outer DOM wrapper, including outside an image mark view,
+    // so a reveal range can cover the entire unit.
+    const schema = defineEditorExtension().schema!
+    const order = Object.keys(schema.marks)
+    expect(order.indexOf('mdGroup')).toBeLessThan(order.indexOf('mdImageView'))
+  })
 })

--- a/packages/core/src/extensions/inline-marks.ts
+++ b/packages/core/src/extensions/inline-marks.ts
@@ -174,7 +174,7 @@ export interface MdWikilinkViewAttrs {
   display: string
 }
 
-export interface MdGroupAttrs {
+export interface MdPackAttrs {
   /**
    * Content-derived identity of one inline syntax unit. Adjacent units of the
    * same kind are kept apart by it (so they do not merge into one mark run), and
@@ -191,25 +191,21 @@ export interface MdGroupAttrs {
  * `getMarkRange` lookup instead of stitching its punctuation back together.
  * `excludes: ''` lets nested units carry two of these marks at once.
  */
-function defineMdGroup() {
-  return defineMarkSpec<'mdGroup', MdGroupAttrs>({
-    name: 'mdGroup' satisfies MarkName,
+function defineMdPack() {
+  return defineMarkSpec<'mdPack', MdPackAttrs>({
+    name: 'mdPack' satisfies MarkName,
     excludes: '',
     inclusive: false,
     attrs: { key: { default: '' } },
-    toDOM: (mark) => [
-      'span',
-      { class: 'md-m-group', 'data-key': (mark.attrs as MdGroupAttrs).key },
-      0,
-    ],
-    parseDOM: [{ tag: 'span.md-m-group' }],
+    toDOM: (mark) => ['span', { class: 'md-pack', 'data-key': (mark.attrs as MdPackAttrs).key }, 0],
+    parseDOM: [{ tag: 'span.md-pack' }],
   })
 }
 
 export function defineInlineMarks() {
   // The last mark registered gets the lowest rank and becomes the outermost DOM
   // wrapper, so the wikilink/image marks go last: the view mark (mdWikilinkView /
-  // mdImageView) wraps the source, which wraps the syntax marks. The group mark
+  // mdImageView) wraps the source, which wraps the syntax marks. The pack mark
   // goes last of all, so it wraps the whole unit (including a mark view).
   return union(
     defineMdMark(),
@@ -225,6 +221,6 @@ export function defineInlineMarks() {
     defineMdWikilinkView(),
     defineMdImageSource(),
     defineMdImageView(),
-    defineMdGroup(),
+    defineMdPack(),
   )
 }

--- a/packages/core/src/extensions/inline-marks.ts
+++ b/packages/core/src/extensions/inline-marks.ts
@@ -52,7 +52,7 @@ function defineMdMark() {
     name: 'mdMark' satisfies MarkName,
     // `inclusive: false` so typing right after a mark boundary does not extend the mark
     inclusive: false,
-    toDOM: () => ['span', { class: 'md-mark', "contenteditable": "false" }, 0],
+    toDOM: () => ['span', { class: 'md-mark',  }, 0],
     parseDOM: [{ tag: 'span.md-mark' }],
   })
 }

--- a/packages/core/src/extensions/inline-marks.ts
+++ b/packages/core/src/extensions/inline-marks.ts
@@ -52,7 +52,7 @@ function defineMdMark() {
     name: 'mdMark' satisfies MarkName,
     // `inclusive: false` so typing right after a mark boundary does not extend the mark
     inclusive: false,
-    toDOM: () => ['span', { class: 'md-mark',  }, 0],
+    toDOM: () => ['span', { class: 'md-mark' }, 0],
     parseDOM: [{ tag: 'span.md-mark' }],
   })
 }

--- a/packages/core/src/extensions/inline-marks.ts
+++ b/packages/core/src/extensions/inline-marks.ts
@@ -52,7 +52,7 @@ function defineMdMark() {
     name: 'mdMark' satisfies MarkName,
     // `inclusive: false` so typing right after a mark boundary does not extend the mark
     inclusive: false,
-    toDOM: () => ['span', { class: 'md-mark' }, 0],
+    toDOM: () => ['span', { class: 'md-mark', "contenteditable": "false" }, 0],
     parseDOM: [{ tag: 'span.md-mark' }],
   })
 }

--- a/packages/core/src/extensions/inline-marks.ts
+++ b/packages/core/src/extensions/inline-marks.ts
@@ -174,10 +174,43 @@ export interface MdWikilinkViewAttrs {
   display: string
 }
 
+export interface MdGroupAttrs {
+  /**
+   * Content-derived identity of one inline syntax unit. Adjacent units of the
+   * same kind are kept apart by it (so they do not merge into one mark run), and
+   * it stays stable when unrelated text in the block is edited, so editing one
+   * unit never re-marks the others. Values: `bold` | `italic` | `code` |
+   * `strike` | `autolink` | `link_${href}` | `image_${src}`.
+   */
+  key: string
+}
+
+/**
+ * Wraps a whole revealable inline unit (emphasis, strong, code, strikethrough,
+ * link, autolink, image) so focus mode can reveal the unit with one
+ * `getMarkRange` lookup instead of stitching its punctuation back together.
+ * `excludes: ''` lets nested units carry two of these marks at once.
+ */
+function defineMdGroup() {
+  return defineMarkSpec<'mdGroup', MdGroupAttrs>({
+    name: 'mdGroup' satisfies MarkName,
+    excludes: '',
+    inclusive: false,
+    attrs: { key: { default: '' } },
+    toDOM: (mark) => [
+      'span',
+      { class: 'md-m-group', 'data-key': (mark.attrs as MdGroupAttrs).key },
+      0,
+    ],
+    parseDOM: [{ tag: 'span.md-m-group' }],
+  })
+}
+
 export function defineInlineMarks() {
   // The last mark registered gets the lowest rank and becomes the outermost DOM
   // wrapper, so the wikilink/image marks go last: the view mark (mdWikilinkView /
-  // mdImageView) wraps the source, which wraps the syntax marks.
+  // mdImageView) wraps the source, which wraps the syntax marks. The group mark
+  // goes last of all, so it wraps the whole unit (including a mark view).
   return union(
     defineMdMark(),
     defineMdEm(),
@@ -192,5 +225,6 @@ export function defineInlineMarks() {
     defineMdWikilinkView(),
     defineMdImageSource(),
     defineMdImageView(),
+    defineMdGroup(),
   )
 }

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
@@ -55,9 +55,9 @@ describe('inlineTextToMarkChunks', () => {
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-6: -
-      6-7: mdEm + mdGroup(key=italic) + mdMark
-      7-12: mdEm + mdGroup(key=italic)
-      12-13: mdEm + mdGroup(key=italic) + mdMark
+      6-7: mdEm + mdMark + mdPack(key=italic)
+      7-12: mdEm + mdPack(key=italic)
+      12-13: mdEm + mdMark + mdPack(key=italic)
       "
     `)
   })
@@ -67,9 +67,9 @@ describe('inlineTextToMarkChunks', () => {
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
-      2-4: mdGroup(key=bold) + mdMark + mdStrong
-      4-8: mdGroup(key=bold) + mdStrong
-      8-10: mdGroup(key=bold) + mdMark + mdStrong
+      2-4: mdMark + mdPack(key=bold) + mdStrong
+      4-8: mdPack(key=bold) + mdStrong
+      8-10: mdMark + mdPack(key=bold) + mdStrong
       10-12: -
       "
     `)
@@ -80,9 +80,9 @@ describe('inlineTextToMarkChunks', () => {
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
-      2-3: mdCode + mdGroup(key=code) + mdMark
-      3-4: mdCode + mdGroup(key=code)
-      4-5: mdCode + mdGroup(key=code) + mdMark
+      2-3: mdCode + mdMark + mdPack(key=code)
+      3-4: mdCode + mdPack(key=code)
+      4-5: mdCode + mdMark + mdPack(key=code)
       5-7: -
       "
     `)
@@ -93,9 +93,9 @@ describe('inlineTextToMarkChunks', () => {
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
-      2-4: mdDel + mdGroup(key=strike) + mdMark
-      4-5: mdDel + mdGroup(key=strike)
-      5-7: mdDel + mdGroup(key=strike) + mdMark
+      2-4: mdDel + mdMark + mdPack(key=strike)
+      4-5: mdDel + mdPack(key=strike)
+      5-7: mdDel + mdMark + mdPack(key=strike)
       7-9: -
       "
     `)
@@ -106,11 +106,11 @@ describe('inlineTextToMarkChunks', () => {
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-4: -
-      4-5: mdGroup(key=link_http://x) + mdLinkText(href=http://x) + mdMark
-      5-9: mdGroup(key=link_http://x) + mdLinkText(href=http://x)
-      9-11: mdGroup(key=link_http://x) + mdMark
-      11-19: mdGroup(key=link_http://x) + mdLinkUri
-      19-20: mdGroup(key=link_http://x) + mdMark
+      4-5: mdLinkText(href=http://x) + mdMark + mdPack(key=link_http://x)
+      5-9: mdLinkText(href=http://x) + mdPack(key=link_http://x)
+      9-11: mdMark + mdPack(key=link_http://x)
+      11-19: mdLinkUri + mdPack(key=link_http://x)
+      19-20: mdMark + mdPack(key=link_http://x)
       20-24: -
       "
     `)
@@ -120,13 +120,13 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '[*ital*](http://x)')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdGroup(key=link_http://x) + mdLinkText(href=http://x) + mdMark
-      1-2: mdEm + mdGroup(key=link_http://x) + mdLinkText(href=http://x) + mdMark
-      2-6: mdEm + mdGroup(key=link_http://x) + mdLinkText(href=http://x)
-      6-7: mdEm + mdGroup(key=link_http://x) + mdLinkText(href=http://x) + mdMark
-      7-9: mdGroup(key=link_http://x) + mdMark
-      9-17: mdGroup(key=link_http://x) + mdLinkUri
-      17-18: mdGroup(key=link_http://x) + mdMark
+      0-1: mdLinkText(href=http://x) + mdMark + mdPack(key=link_http://x)
+      1-2: mdEm + mdLinkText(href=http://x) + mdMark + mdPack(key=link_http://x)
+      2-6: mdEm + mdLinkText(href=http://x) + mdPack(key=link_http://x)
+      6-7: mdEm + mdLinkText(href=http://x) + mdMark + mdPack(key=link_http://x)
+      7-9: mdMark + mdPack(key=link_http://x)
+      9-17: mdLinkUri + mdPack(key=link_http://x)
+      17-18: mdMark + mdPack(key=link_http://x)
       "
     `)
   })
@@ -136,11 +136,11 @@ describe('inlineTextToMarkChunks', () => {
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-4: -
-      4-6: mdGroup(key=image_http://x/p.png) + mdImageSource(src=http://x/p.png,alt=alt) + mdMark
-      6-9: mdGroup(key=image_http://x/p.png) + mdImageSource(src=http://x/p.png,alt=alt)
-      9-11: mdGroup(key=image_http://x/p.png) + mdImageSource(src=http://x/p.png,alt=alt) + mdMark
-      11-25: mdGroup(key=image_http://x/p.png) + mdImageSource(src=http://x/p.png,alt=alt) + mdLinkUri
-      25-26: mdGroup(key=image_http://x/p.png) + mdImageSource(src=http://x/p.png,alt=alt) + mdImageView(src=http://x/p.png,alt=alt) + mdMark
+      4-6: mdImageSource(src=http://x/p.png,alt=alt) + mdMark + mdPack(key=image_http://x/p.png)
+      6-9: mdImageSource(src=http://x/p.png,alt=alt) + mdPack(key=image_http://x/p.png)
+      9-11: mdImageSource(src=http://x/p.png,alt=alt) + mdMark + mdPack(key=image_http://x/p.png)
+      11-25: mdImageSource(src=http://x/p.png,alt=alt) + mdLinkUri + mdPack(key=image_http://x/p.png)
+      25-26: mdImageSource(src=http://x/p.png,alt=alt) + mdImageView(src=http://x/p.png,alt=alt) + mdMark + mdPack(key=image_http://x/p.png)
       26-30: -
       "
     `)
@@ -150,9 +150,9 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '![](z.png)')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-4: mdGroup(key=image_z.png) + mdImageSource(src=z.png) + mdMark
-      4-9: mdGroup(key=image_z.png) + mdImageSource(src=z.png) + mdLinkUri
-      9-10: mdGroup(key=image_z.png) + mdImageSource(src=z.png) + mdImageView(src=z.png) + mdMark
+      0-4: mdImageSource(src=z.png) + mdMark + mdPack(key=image_z.png)
+      4-9: mdImageSource(src=z.png) + mdLinkUri + mdPack(key=image_z.png)
+      9-10: mdImageSource(src=z.png) + mdImageView(src=z.png) + mdMark + mdPack(key=image_z.png)
       "
     `)
   })
@@ -162,10 +162,10 @@ describe('inlineTextToMarkChunks', () => {
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
-      2-4: mdGroup(key=link_) + mdMark
-      4-5: mdGroup(key=link_)
-      5-6: mdGroup(key=link_) + mdMark
-      6-10: mdGroup(key=link_)
+      2-4: mdMark + mdPack(key=link_)
+      4-5: mdPack(key=link_)
+      5-6: mdMark + mdPack(key=link_)
+      6-10: mdPack(key=link_)
       10-12: -
       "
     `)
@@ -175,12 +175,12 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '![a](http://x "t")')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-2: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a) + mdMark
-      2-3: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a)
-      3-5: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a) + mdMark
-      5-13: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a) + mdLinkUri
-      13-17: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a)
-      17-18: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a) + mdImageView(src=http://x,alt=a) + mdMark
+      0-2: mdImageSource(src=http://x,alt=a) + mdMark + mdPack(key=image_http://x)
+      2-3: mdImageSource(src=http://x,alt=a) + mdPack(key=image_http://x)
+      3-5: mdImageSource(src=http://x,alt=a) + mdMark + mdPack(key=image_http://x)
+      5-13: mdImageSource(src=http://x,alt=a) + mdLinkUri + mdPack(key=image_http://x)
+      13-17: mdImageSource(src=http://x,alt=a) + mdPack(key=image_http://x)
+      17-18: mdImageSource(src=http://x,alt=a) + mdImageView(src=http://x,alt=a) + mdMark + mdPack(key=image_http://x)
       "
     `)
   })
@@ -189,15 +189,15 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '![a **b** c](http://x)')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-2: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a **b** c) + mdMark
-      2-4: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a **b** c)
-      4-6: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a **b** c) + mdMark + mdStrong
-      6-7: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a **b** c) + mdStrong
-      7-9: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a **b** c) + mdMark + mdStrong
-      9-11: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a **b** c)
-      11-13: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a **b** c) + mdMark
-      13-21: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a **b** c) + mdLinkUri
-      21-22: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a **b** c) + mdImageView(src=http://x,alt=a **b** c) + mdMark
+      0-2: mdImageSource(src=http://x,alt=a **b** c) + mdMark + mdPack(key=image_http://x)
+      2-4: mdImageSource(src=http://x,alt=a **b** c) + mdPack(key=image_http://x)
+      4-6: mdImageSource(src=http://x,alt=a **b** c) + mdMark + mdPack(key=image_http://x) + mdStrong
+      6-7: mdImageSource(src=http://x,alt=a **b** c) + mdPack(key=image_http://x) + mdStrong
+      7-9: mdImageSource(src=http://x,alt=a **b** c) + mdMark + mdPack(key=image_http://x) + mdStrong
+      9-11: mdImageSource(src=http://x,alt=a **b** c) + mdPack(key=image_http://x)
+      11-13: mdImageSource(src=http://x,alt=a **b** c) + mdMark + mdPack(key=image_http://x)
+      13-21: mdImageSource(src=http://x,alt=a **b** c) + mdLinkUri + mdPack(key=image_http://x)
+      21-22: mdImageSource(src=http://x,alt=a **b** c) + mdImageView(src=http://x,alt=a **b** c) + mdMark + mdPack(key=image_http://x)
       "
     `)
   })
@@ -251,9 +251,9 @@ describe('inlineTextToMarkChunks', () => {
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
-      2-3: mdGroup(key=autolink) + mdMark
-      3-22: mdGroup(key=autolink) + mdLinkText(href=https://example.com)
-      22-23: mdGroup(key=autolink) + mdMark
+      2-3: mdMark + mdPack(key=autolink)
+      3-22: mdLinkText(href=https://example.com) + mdPack(key=autolink)
+      22-23: mdMark + mdPack(key=autolink)
       23-25: -
       "
     `)
@@ -264,9 +264,9 @@ describe('inlineTextToMarkChunks', () => {
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
-      2-3: mdGroup(key=autolink) + mdMark
-      3-20: mdGroup(key=autolink) + mdLinkText(href=ftp://example.com)
-      20-21: mdGroup(key=autolink) + mdMark
+      2-3: mdMark + mdPack(key=autolink)
+      3-20: mdLinkText(href=ftp://example.com) + mdPack(key=autolink)
+      20-21: mdMark + mdPack(key=autolink)
       21-23: -
       "
     `)
@@ -277,9 +277,9 @@ describe('inlineTextToMarkChunks', () => {
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
-      2-3: mdGroup(key=autolink) + mdMark
-      3-20: mdGroup(key=autolink) + mdLinkText(href=ssh://example.com)
-      20-21: mdGroup(key=autolink) + mdMark
+      2-3: mdMark + mdPack(key=autolink)
+      3-20: mdLinkText(href=ssh://example.com) + mdPack(key=autolink)
+      20-21: mdMark + mdPack(key=autolink)
       21-23: -
       "
     `)
@@ -300,9 +300,9 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '*https://example.com*')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdEm + mdGroup(key=italic) + mdMark
-      1-20: mdEm + mdGroup(key=italic) + mdLinkText(href=https://example.com)
-      20-21: mdEm + mdGroup(key=italic) + mdMark
+      0-1: mdEm + mdMark + mdPack(key=italic)
+      1-20: mdEm + mdLinkText(href=https://example.com) + mdPack(key=italic)
+      20-21: mdEm + mdMark + mdPack(key=italic)
       "
     `)
   })
@@ -396,11 +396,11 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '[google.com](http://x)')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdGroup(key=link_http://x) + mdLinkText(href=http://x) + mdMark
-      1-11: mdGroup(key=link_http://x) + mdLinkText(href=http://x)
-      11-13: mdGroup(key=link_http://x) + mdMark
-      13-21: mdGroup(key=link_http://x) + mdLinkUri
-      21-22: mdGroup(key=link_http://x) + mdMark
+      0-1: mdLinkText(href=http://x) + mdMark + mdPack(key=link_http://x)
+      1-11: mdLinkText(href=http://x) + mdPack(key=link_http://x)
+      11-13: mdMark + mdPack(key=link_http://x)
+      13-21: mdLinkUri + mdPack(key=link_http://x)
+      21-22: mdMark + mdPack(key=link_http://x)
       "
     `)
   })
@@ -409,9 +409,9 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '`see google.com`')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdCode + mdGroup(key=code) + mdMark
-      1-15: mdCode + mdGroup(key=code)
-      15-16: mdCode + mdGroup(key=code) + mdMark
+      0-1: mdCode + mdMark + mdPack(key=code)
+      1-15: mdCode + mdPack(key=code)
+      15-16: mdCode + mdMark + mdPack(key=code)
       "
     `)
   })
@@ -431,11 +431,11 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '***foo***')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdEm + mdGroup(key=italic) + mdMark
-      1-3: mdEm + mdGroup(key=bold) + mdGroup(key=italic) + mdMark + mdStrong
-      3-6: mdEm + mdGroup(key=bold) + mdGroup(key=italic) + mdStrong
-      6-8: mdEm + mdGroup(key=bold) + mdGroup(key=italic) + mdMark + mdStrong
-      8-9: mdEm + mdGroup(key=italic) + mdMark
+      0-1: mdEm + mdMark + mdPack(key=italic)
+      1-3: mdEm + mdMark + mdPack(key=bold) + mdPack(key=italic) + mdStrong
+      3-6: mdEm + mdPack(key=bold) + mdPack(key=italic) + mdStrong
+      6-8: mdEm + mdMark + mdPack(key=bold) + mdPack(key=italic) + mdStrong
+      8-9: mdEm + mdMark + mdPack(key=italic)
       "
     `)
   })
@@ -444,12 +444,12 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '*a***b**')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdEm + mdGroup(key=italic) + mdMark
-      1-2: mdEm + mdGroup(key=italic)
-      2-3: mdEm + mdGroup(key=italic) + mdMark
-      3-5: mdGroup(key=bold) + mdMark + mdStrong
-      5-6: mdGroup(key=bold) + mdStrong
-      6-8: mdGroup(key=bold) + mdMark + mdStrong
+      0-1: mdEm + mdMark + mdPack(key=italic)
+      1-2: mdEm + mdPack(key=italic)
+      2-3: mdEm + mdMark + mdPack(key=italic)
+      3-5: mdMark + mdPack(key=bold) + mdStrong
+      5-6: mdPack(key=bold) + mdStrong
+      6-8: mdMark + mdPack(key=bold) + mdStrong
       "
     `)
   })
@@ -458,13 +458,13 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '*a* mid *b*')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdEm + mdGroup(key=italic) + mdMark
-      1-2: mdEm + mdGroup(key=italic)
-      2-3: mdEm + mdGroup(key=italic) + mdMark
+      0-1: mdEm + mdMark + mdPack(key=italic)
+      1-2: mdEm + mdPack(key=italic)
+      2-3: mdEm + mdMark + mdPack(key=italic)
       3-8: -
-      8-9: mdEm + mdGroup(key=italic) + mdMark
-      9-10: mdEm + mdGroup(key=italic)
-      10-11: mdEm + mdGroup(key=italic) + mdMark
+      8-9: mdEm + mdMark + mdPack(key=italic)
+      9-10: mdEm + mdPack(key=italic)
+      10-11: mdEm + mdMark + mdPack(key=italic)
       "
     `)
   })
@@ -473,9 +473,9 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '*all*')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdEm + mdGroup(key=italic) + mdMark
-      1-4: mdEm + mdGroup(key=italic)
-      4-5: mdEm + mdGroup(key=italic) + mdMark
+      0-1: mdEm + mdMark + mdPack(key=italic)
+      1-4: mdEm + mdPack(key=italic)
+      4-5: mdEm + mdMark + mdPack(key=italic)
       "
     `)
   })
@@ -528,11 +528,11 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '*x #tag y*')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdEm + mdGroup(key=italic) + mdMark
-      1-3: mdEm + mdGroup(key=italic)
-      3-7: mdEm + mdGroup(key=italic) + mdTag
-      7-9: mdEm + mdGroup(key=italic)
-      9-10: mdEm + mdGroup(key=italic) + mdMark
+      0-1: mdEm + mdMark + mdPack(key=italic)
+      1-3: mdEm + mdPack(key=italic)
+      3-7: mdEm + mdPack(key=italic) + mdTag
+      7-9: mdEm + mdPack(key=italic)
+      9-10: mdEm + mdMark + mdPack(key=italic)
       "
     `)
   })
@@ -541,12 +541,12 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '[see #tag](http://x)')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdGroup(key=link_http://x) + mdLinkText(href=http://x) + mdMark
-      1-5: mdGroup(key=link_http://x) + mdLinkText(href=http://x)
-      5-9: mdGroup(key=link_http://x) + mdLinkText(href=http://x) + mdTag
-      9-11: mdGroup(key=link_http://x) + mdMark
-      11-19: mdGroup(key=link_http://x) + mdLinkUri
-      19-20: mdGroup(key=link_http://x) + mdMark
+      0-1: mdLinkText(href=http://x) + mdMark + mdPack(key=link_http://x)
+      1-5: mdLinkText(href=http://x) + mdPack(key=link_http://x)
+      5-9: mdLinkText(href=http://x) + mdPack(key=link_http://x) + mdTag
+      9-11: mdMark + mdPack(key=link_http://x)
+      11-19: mdLinkUri + mdPack(key=link_http://x)
+      19-20: mdMark + mdPack(key=link_http://x)
       "
     `)
   })
@@ -603,14 +603,14 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '*x [[n]] y*')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdEm + mdGroup(key=italic) + mdMark
-      1-3: mdEm + mdGroup(key=italic)
-      3-5: mdEm + mdGroup(key=italic) + mdMark + mdWikilinkSource(target=n)
-      5-6: mdEm + mdGroup(key=italic) + mdWikilinkSource(target=n)
-      6-7: mdEm + mdGroup(key=italic) + mdMark + mdWikilinkSource(target=n)
-      7-8: mdEm + mdGroup(key=italic) + mdMark + mdWikilinkSource(target=n) + mdWikilinkView(target=n)
-      8-10: mdEm + mdGroup(key=italic)
-      10-11: mdEm + mdGroup(key=italic) + mdMark
+      0-1: mdEm + mdMark + mdPack(key=italic)
+      1-3: mdEm + mdPack(key=italic)
+      3-5: mdEm + mdMark + mdPack(key=italic) + mdWikilinkSource(target=n)
+      5-6: mdEm + mdPack(key=italic) + mdWikilinkSource(target=n)
+      6-7: mdEm + mdMark + mdPack(key=italic) + mdWikilinkSource(target=n)
+      7-8: mdEm + mdMark + mdPack(key=italic) + mdWikilinkSource(target=n) + mdWikilinkView(target=n)
+      8-10: mdEm + mdPack(key=italic)
+      10-11: mdEm + mdMark + mdPack(key=italic)
       "
     `)
   })
@@ -619,15 +619,15 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '[see [[x]]](http://y)')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdGroup(key=link_http://y) + mdLinkText(href=http://y) + mdMark
-      1-5: mdGroup(key=link_http://y) + mdLinkText(href=http://y)
-      5-7: mdGroup(key=link_http://y) + mdLinkText(href=http://y) + mdMark + mdWikilinkSource(target=x)
-      7-8: mdGroup(key=link_http://y) + mdLinkText(href=http://y) + mdWikilinkSource(target=x)
-      8-9: mdGroup(key=link_http://y) + mdLinkText(href=http://y) + mdMark + mdWikilinkSource(target=x)
-      9-10: mdGroup(key=link_http://y) + mdLinkText(href=http://y) + mdMark + mdWikilinkSource(target=x) + mdWikilinkView(target=x)
-      10-12: mdGroup(key=link_http://y) + mdMark
-      12-20: mdGroup(key=link_http://y) + mdLinkUri
-      20-21: mdGroup(key=link_http://y) + mdMark
+      0-1: mdLinkText(href=http://y) + mdMark + mdPack(key=link_http://y)
+      1-5: mdLinkText(href=http://y) + mdPack(key=link_http://y)
+      5-7: mdLinkText(href=http://y) + mdMark + mdPack(key=link_http://y) + mdWikilinkSource(target=x)
+      7-8: mdLinkText(href=http://y) + mdPack(key=link_http://y) + mdWikilinkSource(target=x)
+      8-9: mdLinkText(href=http://y) + mdMark + mdPack(key=link_http://y) + mdWikilinkSource(target=x)
+      9-10: mdLinkText(href=http://y) + mdMark + mdPack(key=link_http://y) + mdWikilinkSource(target=x) + mdWikilinkView(target=x)
+      10-12: mdMark + mdPack(key=link_http://y)
+      12-20: mdLinkUri + mdPack(key=link_http://y)
+      20-21: mdMark + mdPack(key=link_http://y)
       "
     `)
   })
@@ -651,51 +651,51 @@ describe('inlineTextToMarkChunks', () => {
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-1: -
-      1-2: mdGroup(key=link_) + mdMark
-      2-3: mdGroup(key=link_)
-      3-4: mdGroup(key=link_) + mdMark
+      1-2: mdMark + mdPack(key=link_)
+      2-3: mdPack(key=link_)
+      3-4: mdMark + mdPack(key=link_)
       "
     `)
   })
 
-  it('nested bold>italic carries both group keys, inner text in both', () => {
+  it('nested bold>italic carries both pack keys, inner text in both', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '**bold *italic* bold**')
-    // The `italic` run carries mdGroup(key=bold) AND mdGroup(key=italic); the
-    // bold-only runs carry only mdGroup(key=bold).
+    // The `italic` run carries mdPack(key=bold) AND mdPack(key=italic); the
+    // bold-only runs carry only mdPack(key=bold).
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-2: mdGroup(key=bold) + mdMark + mdStrong
-      2-7: mdGroup(key=bold) + mdStrong
-      7-8: mdEm + mdGroup(key=bold) + mdGroup(key=italic) + mdMark + mdStrong
-      8-14: mdEm + mdGroup(key=bold) + mdGroup(key=italic) + mdStrong
-      14-15: mdEm + mdGroup(key=bold) + mdGroup(key=italic) + mdMark + mdStrong
-      15-20: mdGroup(key=bold) + mdStrong
-      20-22: mdGroup(key=bold) + mdMark + mdStrong
+      0-2: mdMark + mdPack(key=bold) + mdStrong
+      2-7: mdPack(key=bold) + mdStrong
+      7-8: mdEm + mdMark + mdPack(key=bold) + mdPack(key=italic) + mdStrong
+      8-14: mdEm + mdPack(key=bold) + mdPack(key=italic) + mdStrong
+      14-15: mdEm + mdMark + mdPack(key=bold) + mdPack(key=italic) + mdStrong
+      15-20: mdPack(key=bold) + mdStrong
+      20-22: mdMark + mdPack(key=bold) + mdStrong
       "
     `)
   })
 
-  it('adjacent links to different urls get distinct group keys', () => {
+  it('adjacent links to different urls get distinct pack keys', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '[a](x)[b](y)')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdGroup(key=link_x) + mdLinkText(href=x) + mdMark
-      1-2: mdGroup(key=link_x) + mdLinkText(href=x)
-      2-4: mdGroup(key=link_x) + mdMark
-      4-5: mdGroup(key=link_x) + mdLinkUri
-      5-6: mdGroup(key=link_x) + mdMark
-      6-7: mdGroup(key=link_y) + mdLinkText(href=y) + mdMark
-      7-8: mdGroup(key=link_y) + mdLinkText(href=y)
-      8-10: mdGroup(key=link_y) + mdMark
-      10-11: mdGroup(key=link_y) + mdLinkUri
-      11-12: mdGroup(key=link_y) + mdMark
+      0-1: mdLinkText(href=x) + mdMark + mdPack(key=link_x)
+      1-2: mdLinkText(href=x) + mdPack(key=link_x)
+      2-4: mdMark + mdPack(key=link_x)
+      4-5: mdLinkUri + mdPack(key=link_x)
+      5-6: mdMark + mdPack(key=link_x)
+      6-7: mdLinkText(href=y) + mdMark + mdPack(key=link_y)
+      7-8: mdLinkText(href=y) + mdPack(key=link_y)
+      8-10: mdMark + mdPack(key=link_y)
+      10-11: mdLinkUri + mdPack(key=link_y)
+      11-12: mdMark + mdPack(key=link_y)
       "
     `)
   })
 
-  it('wikilink, tag, and bare autolink carry no group', () => {
+  it('wikilink, tag, and bare autolink carry no pack', () => {
     for (const text of ['see [[note]] end', 'hello #tag world', 'visit https://example.com now']) {
-      expect(formatMarkChunks(inlineTextToMarkChunks(markBuilders, text))).not.toContain('mdGroup')
+      expect(formatMarkChunks(inlineTextToMarkChunks(markBuilders, text))).not.toContain('mdPack')
     }
   })
 })

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
@@ -55,9 +55,9 @@ describe('inlineTextToMarkChunks', () => {
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-6: -
-      6-7: mdEm + mdMark
-      7-12: mdEm
-      12-13: mdEm + mdMark
+      6-7: mdEm + mdGroup(key=italic) + mdMark
+      7-12: mdEm + mdGroup(key=italic)
+      12-13: mdEm + mdGroup(key=italic) + mdMark
       "
     `)
   })
@@ -67,9 +67,9 @@ describe('inlineTextToMarkChunks', () => {
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
-      2-4: mdMark + mdStrong
-      4-8: mdStrong
-      8-10: mdMark + mdStrong
+      2-4: mdGroup(key=bold) + mdMark + mdStrong
+      4-8: mdGroup(key=bold) + mdStrong
+      8-10: mdGroup(key=bold) + mdMark + mdStrong
       10-12: -
       "
     `)
@@ -80,9 +80,9 @@ describe('inlineTextToMarkChunks', () => {
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
-      2-3: mdCode + mdMark
-      3-4: mdCode
-      4-5: mdCode + mdMark
+      2-3: mdCode + mdGroup(key=code) + mdMark
+      3-4: mdCode + mdGroup(key=code)
+      4-5: mdCode + mdGroup(key=code) + mdMark
       5-7: -
       "
     `)
@@ -93,9 +93,9 @@ describe('inlineTextToMarkChunks', () => {
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
-      2-4: mdDel + mdMark
-      4-5: mdDel
-      5-7: mdDel + mdMark
+      2-4: mdDel + mdGroup(key=strike) + mdMark
+      4-5: mdDel + mdGroup(key=strike)
+      5-7: mdDel + mdGroup(key=strike) + mdMark
       7-9: -
       "
     `)
@@ -106,11 +106,11 @@ describe('inlineTextToMarkChunks', () => {
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-4: -
-      4-5: mdLinkText(href=http://x) + mdMark
-      5-9: mdLinkText(href=http://x)
-      9-11: mdMark
-      11-19: mdLinkUri
-      19-20: mdMark
+      4-5: mdGroup(key=link_http://x) + mdLinkText(href=http://x) + mdMark
+      5-9: mdGroup(key=link_http://x) + mdLinkText(href=http://x)
+      9-11: mdGroup(key=link_http://x) + mdMark
+      11-19: mdGroup(key=link_http://x) + mdLinkUri
+      19-20: mdGroup(key=link_http://x) + mdMark
       20-24: -
       "
     `)
@@ -120,13 +120,13 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '[*ital*](http://x)')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdLinkText(href=http://x) + mdMark
-      1-2: mdEm + mdLinkText(href=http://x) + mdMark
-      2-6: mdEm + mdLinkText(href=http://x)
-      6-7: mdEm + mdLinkText(href=http://x) + mdMark
-      7-9: mdMark
-      9-17: mdLinkUri
-      17-18: mdMark
+      0-1: mdGroup(key=link_http://x) + mdLinkText(href=http://x) + mdMark
+      1-2: mdEm + mdGroup(key=link_http://x) + mdLinkText(href=http://x) + mdMark
+      2-6: mdEm + mdGroup(key=link_http://x) + mdLinkText(href=http://x)
+      6-7: mdEm + mdGroup(key=link_http://x) + mdLinkText(href=http://x) + mdMark
+      7-9: mdGroup(key=link_http://x) + mdMark
+      9-17: mdGroup(key=link_http://x) + mdLinkUri
+      17-18: mdGroup(key=link_http://x) + mdMark
       "
     `)
   })
@@ -136,11 +136,11 @@ describe('inlineTextToMarkChunks', () => {
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-4: -
-      4-6: mdImageSource(src=http://x/p.png,alt=alt) + mdMark
-      6-9: mdImageSource(src=http://x/p.png,alt=alt)
-      9-11: mdImageSource(src=http://x/p.png,alt=alt) + mdMark
-      11-25: mdImageSource(src=http://x/p.png,alt=alt) + mdLinkUri
-      25-26: mdImageSource(src=http://x/p.png,alt=alt) + mdImageView(src=http://x/p.png,alt=alt) + mdMark
+      4-6: mdGroup(key=image_http://x/p.png) + mdImageSource(src=http://x/p.png,alt=alt) + mdMark
+      6-9: mdGroup(key=image_http://x/p.png) + mdImageSource(src=http://x/p.png,alt=alt)
+      9-11: mdGroup(key=image_http://x/p.png) + mdImageSource(src=http://x/p.png,alt=alt) + mdMark
+      11-25: mdGroup(key=image_http://x/p.png) + mdImageSource(src=http://x/p.png,alt=alt) + mdLinkUri
+      25-26: mdGroup(key=image_http://x/p.png) + mdImageSource(src=http://x/p.png,alt=alt) + mdImageView(src=http://x/p.png,alt=alt) + mdMark
       26-30: -
       "
     `)
@@ -150,9 +150,9 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '![](z.png)')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-4: mdImageSource(src=z.png) + mdMark
-      4-9: mdImageSource(src=z.png) + mdLinkUri
-      9-10: mdImageSource(src=z.png) + mdImageView(src=z.png) + mdMark
+      0-4: mdGroup(key=image_z.png) + mdImageSource(src=z.png) + mdMark
+      4-9: mdGroup(key=image_z.png) + mdImageSource(src=z.png) + mdLinkUri
+      9-10: mdGroup(key=image_z.png) + mdImageSource(src=z.png) + mdImageView(src=z.png) + mdMark
       "
     `)
   })
@@ -162,10 +162,11 @@ describe('inlineTextToMarkChunks', () => {
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
-      2-4: mdMark
-      4-5: -
-      5-6: mdMark
-      6-12: -
+      2-4: mdGroup(key=link_) + mdMark
+      4-5: mdGroup(key=link_)
+      5-6: mdGroup(key=link_) + mdMark
+      6-10: mdGroup(key=link_)
+      10-12: -
       "
     `)
   })
@@ -174,12 +175,12 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '![a](http://x "t")')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-2: mdImageSource(src=http://x,alt=a) + mdMark
-      2-3: mdImageSource(src=http://x,alt=a)
-      3-5: mdImageSource(src=http://x,alt=a) + mdMark
-      5-13: mdImageSource(src=http://x,alt=a) + mdLinkUri
-      13-17: mdImageSource(src=http://x,alt=a)
-      17-18: mdImageSource(src=http://x,alt=a) + mdImageView(src=http://x,alt=a) + mdMark
+      0-2: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a) + mdMark
+      2-3: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a)
+      3-5: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a) + mdMark
+      5-13: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a) + mdLinkUri
+      13-17: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a)
+      17-18: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a) + mdImageView(src=http://x,alt=a) + mdMark
       "
     `)
   })
@@ -188,15 +189,15 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '![a **b** c](http://x)')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-2: mdImageSource(src=http://x,alt=a **b** c) + mdMark
-      2-4: mdImageSource(src=http://x,alt=a **b** c)
-      4-6: mdImageSource(src=http://x,alt=a **b** c) + mdMark + mdStrong
-      6-7: mdImageSource(src=http://x,alt=a **b** c) + mdStrong
-      7-9: mdImageSource(src=http://x,alt=a **b** c) + mdMark + mdStrong
-      9-11: mdImageSource(src=http://x,alt=a **b** c)
-      11-13: mdImageSource(src=http://x,alt=a **b** c) + mdMark
-      13-21: mdImageSource(src=http://x,alt=a **b** c) + mdLinkUri
-      21-22: mdImageSource(src=http://x,alt=a **b** c) + mdImageView(src=http://x,alt=a **b** c) + mdMark
+      0-2: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a **b** c) + mdMark
+      2-4: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a **b** c)
+      4-6: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a **b** c) + mdMark + mdStrong
+      6-7: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a **b** c) + mdStrong
+      7-9: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a **b** c) + mdMark + mdStrong
+      9-11: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a **b** c)
+      11-13: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a **b** c) + mdMark
+      13-21: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a **b** c) + mdLinkUri
+      21-22: mdGroup(key=image_http://x) + mdImageSource(src=http://x,alt=a **b** c) + mdImageView(src=http://x,alt=a **b** c) + mdMark
       "
     `)
   })
@@ -250,9 +251,9 @@ describe('inlineTextToMarkChunks', () => {
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
-      2-3: mdMark
-      3-22: mdLinkText(href=https://example.com)
-      22-23: mdMark
+      2-3: mdGroup(key=autolink) + mdMark
+      3-22: mdGroup(key=autolink) + mdLinkText(href=https://example.com)
+      22-23: mdGroup(key=autolink) + mdMark
       23-25: -
       "
     `)
@@ -263,9 +264,9 @@ describe('inlineTextToMarkChunks', () => {
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
-      2-3: mdMark
-      3-20: mdLinkText(href=ftp://example.com)
-      20-21: mdMark
+      2-3: mdGroup(key=autolink) + mdMark
+      3-20: mdGroup(key=autolink) + mdLinkText(href=ftp://example.com)
+      20-21: mdGroup(key=autolink) + mdMark
       21-23: -
       "
     `)
@@ -276,9 +277,9 @@ describe('inlineTextToMarkChunks', () => {
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-2: -
-      2-3: mdMark
-      3-20: mdLinkText(href=ssh://example.com)
-      20-21: mdMark
+      2-3: mdGroup(key=autolink) + mdMark
+      3-20: mdGroup(key=autolink) + mdLinkText(href=ssh://example.com)
+      20-21: mdGroup(key=autolink) + mdMark
       21-23: -
       "
     `)
@@ -299,9 +300,9 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '*https://example.com*')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdEm + mdMark
-      1-20: mdEm + mdLinkText(href=https://example.com)
-      20-21: mdEm + mdMark
+      0-1: mdEm + mdGroup(key=italic) + mdMark
+      1-20: mdEm + mdGroup(key=italic) + mdLinkText(href=https://example.com)
+      20-21: mdEm + mdGroup(key=italic) + mdMark
       "
     `)
   })
@@ -395,11 +396,11 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '[google.com](http://x)')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdLinkText(href=http://x) + mdMark
-      1-11: mdLinkText(href=http://x)
-      11-13: mdMark
-      13-21: mdLinkUri
-      21-22: mdMark
+      0-1: mdGroup(key=link_http://x) + mdLinkText(href=http://x) + mdMark
+      1-11: mdGroup(key=link_http://x) + mdLinkText(href=http://x)
+      11-13: mdGroup(key=link_http://x) + mdMark
+      13-21: mdGroup(key=link_http://x) + mdLinkUri
+      21-22: mdGroup(key=link_http://x) + mdMark
       "
     `)
   })
@@ -408,9 +409,9 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '`see google.com`')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdCode + mdMark
-      1-15: mdCode
-      15-16: mdCode + mdMark
+      0-1: mdCode + mdGroup(key=code) + mdMark
+      1-15: mdCode + mdGroup(key=code)
+      15-16: mdCode + mdGroup(key=code) + mdMark
       "
     `)
   })
@@ -430,11 +431,11 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '***foo***')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdEm + mdMark
-      1-3: mdEm + mdMark + mdStrong
-      3-6: mdEm + mdStrong
-      6-8: mdEm + mdMark + mdStrong
-      8-9: mdEm + mdMark
+      0-1: mdEm + mdGroup(key=italic) + mdMark
+      1-3: mdEm + mdGroup(key=bold) + mdGroup(key=italic) + mdMark + mdStrong
+      3-6: mdEm + mdGroup(key=bold) + mdGroup(key=italic) + mdStrong
+      6-8: mdEm + mdGroup(key=bold) + mdGroup(key=italic) + mdMark + mdStrong
+      8-9: mdEm + mdGroup(key=italic) + mdMark
       "
     `)
   })
@@ -443,12 +444,12 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '*a***b**')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdEm + mdMark
-      1-2: mdEm
-      2-3: mdEm + mdMark
-      3-5: mdMark + mdStrong
-      5-6: mdStrong
-      6-8: mdMark + mdStrong
+      0-1: mdEm + mdGroup(key=italic) + mdMark
+      1-2: mdEm + mdGroup(key=italic)
+      2-3: mdEm + mdGroup(key=italic) + mdMark
+      3-5: mdGroup(key=bold) + mdMark + mdStrong
+      5-6: mdGroup(key=bold) + mdStrong
+      6-8: mdGroup(key=bold) + mdMark + mdStrong
       "
     `)
   })
@@ -457,13 +458,13 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '*a* mid *b*')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdEm + mdMark
-      1-2: mdEm
-      2-3: mdEm + mdMark
+      0-1: mdEm + mdGroup(key=italic) + mdMark
+      1-2: mdEm + mdGroup(key=italic)
+      2-3: mdEm + mdGroup(key=italic) + mdMark
       3-8: -
-      8-9: mdEm + mdMark
-      9-10: mdEm
-      10-11: mdEm + mdMark
+      8-9: mdEm + mdGroup(key=italic) + mdMark
+      9-10: mdEm + mdGroup(key=italic)
+      10-11: mdEm + mdGroup(key=italic) + mdMark
       "
     `)
   })
@@ -472,9 +473,9 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '*all*')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdEm + mdMark
-      1-4: mdEm
-      4-5: mdEm + mdMark
+      0-1: mdEm + mdGroup(key=italic) + mdMark
+      1-4: mdEm + mdGroup(key=italic)
+      4-5: mdEm + mdGroup(key=italic) + mdMark
       "
     `)
   })
@@ -527,11 +528,11 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '*x #tag y*')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdEm + mdMark
-      1-3: mdEm
-      3-7: mdEm + mdTag
-      7-9: mdEm
-      9-10: mdEm + mdMark
+      0-1: mdEm + mdGroup(key=italic) + mdMark
+      1-3: mdEm + mdGroup(key=italic)
+      3-7: mdEm + mdGroup(key=italic) + mdTag
+      7-9: mdEm + mdGroup(key=italic)
+      9-10: mdEm + mdGroup(key=italic) + mdMark
       "
     `)
   })
@@ -540,12 +541,12 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '[see #tag](http://x)')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdLinkText(href=http://x) + mdMark
-      1-5: mdLinkText(href=http://x)
-      5-9: mdLinkText(href=http://x) + mdTag
-      9-11: mdMark
-      11-19: mdLinkUri
-      19-20: mdMark
+      0-1: mdGroup(key=link_http://x) + mdLinkText(href=http://x) + mdMark
+      1-5: mdGroup(key=link_http://x) + mdLinkText(href=http://x)
+      5-9: mdGroup(key=link_http://x) + mdLinkText(href=http://x) + mdTag
+      9-11: mdGroup(key=link_http://x) + mdMark
+      11-19: mdGroup(key=link_http://x) + mdLinkUri
+      19-20: mdGroup(key=link_http://x) + mdMark
       "
     `)
   })
@@ -602,14 +603,14 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '*x [[n]] y*')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdEm + mdMark
-      1-3: mdEm
-      3-5: mdEm + mdMark + mdWikilinkSource(target=n)
-      5-6: mdEm + mdWikilinkSource(target=n)
-      6-7: mdEm + mdMark + mdWikilinkSource(target=n)
-      7-8: mdEm + mdMark + mdWikilinkSource(target=n) + mdWikilinkView(target=n)
-      8-10: mdEm
-      10-11: mdEm + mdMark
+      0-1: mdEm + mdGroup(key=italic) + mdMark
+      1-3: mdEm + mdGroup(key=italic)
+      3-5: mdEm + mdGroup(key=italic) + mdMark + mdWikilinkSource(target=n)
+      5-6: mdEm + mdGroup(key=italic) + mdWikilinkSource(target=n)
+      6-7: mdEm + mdGroup(key=italic) + mdMark + mdWikilinkSource(target=n)
+      7-8: mdEm + mdGroup(key=italic) + mdMark + mdWikilinkSource(target=n) + mdWikilinkView(target=n)
+      8-10: mdEm + mdGroup(key=italic)
+      10-11: mdEm + mdGroup(key=italic) + mdMark
       "
     `)
   })
@@ -618,15 +619,15 @@ describe('inlineTextToMarkChunks', () => {
     const chunks = inlineTextToMarkChunks(markBuilders, '[see [[x]]](http://y)')
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
-      0-1: mdLinkText(href=http://y) + mdMark
-      1-5: mdLinkText(href=http://y)
-      5-7: mdLinkText(href=http://y) + mdMark + mdWikilinkSource(target=x)
-      7-8: mdLinkText(href=http://y) + mdWikilinkSource(target=x)
-      8-9: mdLinkText(href=http://y) + mdMark + mdWikilinkSource(target=x)
-      9-10: mdLinkText(href=http://y) + mdMark + mdWikilinkSource(target=x) + mdWikilinkView(target=x)
-      10-12: mdMark
-      12-20: mdLinkUri
-      20-21: mdMark
+      0-1: mdGroup(key=link_http://y) + mdLinkText(href=http://y) + mdMark
+      1-5: mdGroup(key=link_http://y) + mdLinkText(href=http://y)
+      5-7: mdGroup(key=link_http://y) + mdLinkText(href=http://y) + mdMark + mdWikilinkSource(target=x)
+      7-8: mdGroup(key=link_http://y) + mdLinkText(href=http://y) + mdWikilinkSource(target=x)
+      8-9: mdGroup(key=link_http://y) + mdLinkText(href=http://y) + mdMark + mdWikilinkSource(target=x)
+      9-10: mdGroup(key=link_http://y) + mdLinkText(href=http://y) + mdMark + mdWikilinkSource(target=x) + mdWikilinkView(target=x)
+      10-12: mdGroup(key=link_http://y) + mdMark
+      12-20: mdGroup(key=link_http://y) + mdLinkUri
+      20-21: mdGroup(key=link_http://y) + mdMark
       "
     `)
   })
@@ -650,10 +651,51 @@ describe('inlineTextToMarkChunks', () => {
     expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
       "
       0-1: -
-      1-2: mdMark
-      2-3: -
-      3-4: mdMark
+      1-2: mdGroup(key=link_) + mdMark
+      2-3: mdGroup(key=link_)
+      3-4: mdGroup(key=link_) + mdMark
       "
     `)
+  })
+
+  it('nested bold>italic carries both group keys, inner text in both', () => {
+    const chunks = inlineTextToMarkChunks(markBuilders, '**bold *italic* bold**')
+    // The `italic` run carries mdGroup(key=bold) AND mdGroup(key=italic); the
+    // bold-only runs carry only mdGroup(key=bold).
+    expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
+      "
+      0-2: mdGroup(key=bold) + mdMark + mdStrong
+      2-7: mdGroup(key=bold) + mdStrong
+      7-8: mdEm + mdGroup(key=bold) + mdGroup(key=italic) + mdMark + mdStrong
+      8-14: mdEm + mdGroup(key=bold) + mdGroup(key=italic) + mdStrong
+      14-15: mdEm + mdGroup(key=bold) + mdGroup(key=italic) + mdMark + mdStrong
+      15-20: mdGroup(key=bold) + mdStrong
+      20-22: mdGroup(key=bold) + mdMark + mdStrong
+      "
+    `)
+  })
+
+  it('adjacent links to different urls get distinct group keys', () => {
+    const chunks = inlineTextToMarkChunks(markBuilders, '[a](x)[b](y)')
+    expect(formatMarkChunks(chunks)).toMatchInlineSnapshot(`
+      "
+      0-1: mdGroup(key=link_x) + mdLinkText(href=x) + mdMark
+      1-2: mdGroup(key=link_x) + mdLinkText(href=x)
+      2-4: mdGroup(key=link_x) + mdMark
+      4-5: mdGroup(key=link_x) + mdLinkUri
+      5-6: mdGroup(key=link_x) + mdMark
+      6-7: mdGroup(key=link_y) + mdLinkText(href=y) + mdMark
+      7-8: mdGroup(key=link_y) + mdLinkText(href=y)
+      8-10: mdGroup(key=link_y) + mdMark
+      10-11: mdGroup(key=link_y) + mdLinkUri
+      11-12: mdGroup(key=link_y) + mdMark
+      "
+    `)
+  })
+
+  it('wikilink, tag, and bare autolink carry no group', () => {
+    for (const text of ['see [[note]] end', 'hello #tag world', 'visit https://example.com now']) {
+      expect(formatMarkChunks(inlineTextToMarkChunks(markBuilders, text))).not.toContain('mdGroup')
+    }
   })
 })

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.ts
@@ -6,6 +6,7 @@ import { parseInline } from '../lezer/inline.ts'
 import { LEZER_NODE_IDS } from '../lezer/node-ids.ts'
 
 import type {
+  MdGroupAttrs,
   MdImageSourceAttrs,
   MdImageViewAttrs,
   MdLinkTextAttrs,
@@ -41,6 +42,20 @@ const MARK_NAME_BY_TYPE_ID: ReadonlyMap<number, MarkName> = new Map([
   [LEZER_NODE_IDS.URL, 'mdLinkUri'],
   [LEZER_NODE_IDS.Hashtag, 'mdTag'],
   [LEZER_NODE_IDS.WikilinkMark, 'mdMark'],
+])
+
+/**
+ * Content-derived `mdGroup` key for inline units whose key is just the kind.
+ * Link and image are keyed by their url instead (see `walkLink` / `walkImage`),
+ * so adjacent ones with different urls stay separate. Wikilink, tag and bare
+ * autolinks are absent: they get no group (atomic, or nothing to reveal).
+ */
+const GROUP_KEY_BY_TYPE_ID: ReadonlyMap<number, string> = new Map([
+  [LEZER_NODE_IDS.Emphasis, 'italic'],
+  [LEZER_NODE_IDS.StrongEmphasis, 'bold'],
+  [LEZER_NODE_IDS.InlineCode, 'code'],
+  [LEZER_NODE_IDS.Strikethrough, 'strike'],
+  [LEZER_NODE_IDS.Autolink, 'autolink'],
 ])
 
 /**
@@ -107,10 +122,12 @@ function walk(
         : marks.mdLinkUri.create()
       emit(out, node.from, node.to, [...parentMarks, mark])
     } else {
-      const maybeMarkName = MARK_NAME_BY_TYPE_ID.get(node.type)
-      const childMarks = maybeMarkName
-        ? [...parentMarks, marks[maybeMarkName].create()]
+      const groupKey = GROUP_KEY_BY_TYPE_ID.get(node.type)
+      const base = groupKey
+        ? [...parentMarks, marks.mdGroup.create({ key: groupKey } satisfies MdGroupAttrs)]
         : parentMarks
+      const maybeMarkName = MARK_NAME_BY_TYPE_ID.get(node.type)
+      const childMarks = maybeMarkName ? [...base, marks[maybeMarkName].create()] : base
       if (node.children.length === 0) {
         emit(out, node.from, node.to, childMarks)
       } else {
@@ -163,13 +180,16 @@ function walkLink(
   const linkTextMark = href ? marks.mdLinkText.create({ href } satisfies MdLinkTextAttrs) : null
   const inLabel = (pos: number): boolean => labelEnd >= 0 && pos < labelEnd && linkTextMark !== null
 
+  const group = marks.mdGroup.create({ key: `link_${href}` } satisfies MdGroupAttrs)
+  const base = [...parentMarks, group]
+
   let pos = node.from
   for (const child of node.children) {
     if (child.from > pos) {
-      const childMarks = inLabel(pos) ? [...parentMarks, linkTextMark!] : parentMarks
+      const childMarks = inLabel(pos) ? [...base, linkTextMark!] : base
       emit(out, pos, child.from, childMarks)
     }
-    const baseForChild = inLabel(child.from) ? [...parentMarks, linkTextMark!] : parentMarks
+    const baseForChild = inLabel(child.from) ? [...base, linkTextMark!] : base
     // A wikilink in the label needs its own source/view walk, not the generic
     // per-child mark mapping.
     if (child.type === LEZER_NODE_IDS.Wikilink) {
@@ -189,7 +209,7 @@ function walkLink(
     pos = child.to
   }
   if (pos < node.to) {
-    emit(out, pos, node.to, parentMarks)
+    emit(out, pos, node.to, base)
   }
 }
 
@@ -224,16 +244,17 @@ function walkImage(
 
   const source = marks.mdImageSource.create({ src, alt } satisfies MdImageSourceAttrs)
   const view = marks.mdImageView.create({ src, alt } satisfies MdImageViewAttrs)
+  const group = marks.mdGroup.create({ key: `image_${src}` } satisfies MdGroupAttrs)
 
   // The image's final character, where `mdImageView` is anchored: `)` today, a
   // future `]` for `![alt][id]`.
   const anchorFrom = node.to - 1
 
-  // Marks shared by every chunk at `from`: `mdImageSource` over the whole
-  // source, plus `mdImageView` once we reach the final character (the render
-  // anchor). Each child layers its own syntax mark on top.
+  // Marks shared by every chunk at `from`: the `mdGroup` envelope plus
+  // `mdImageSource` over the whole source, plus `mdImageView` once we reach the
+  // final character (the render anchor). Each child layers its own syntax mark on top.
   const baseAt = (from: number): Mark[] =>
-    from >= anchorFrom ? [...parentMarks, source, view] : [...parentMarks, source]
+    from >= anchorFrom ? [...parentMarks, group, source, view] : [...parentMarks, group, source]
 
   let pos = node.from
   for (const child of node.children) {

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.ts
@@ -106,13 +106,14 @@ function walk(
     if (node.from > pos) {
       emit(out, pos, node.from, parentMarks)
     }
-    if (node.type === LEZER_NODE_IDS.Link) {
+    const type: number = node.type
+    if ( type === LEZER_NODE_IDS.Link) {
       walkLink(node, parentMarks, text, marks, out)
-    } else if (node.type === LEZER_NODE_IDS.Image) {
+    } else if ( type === LEZER_NODE_IDS.Image) {
       walkImage(node, parentMarks, text, marks, out)
-    } else if (node.type === LEZER_NODE_IDS.Wikilink) {
+    } else if ( type === LEZER_NODE_IDS.Wikilink) {
       walkWikilink(node, parentMarks, text, marks, out)
-    } else if (node.type === LEZER_NODE_IDS.URL) {
+    } else if ( type === LEZER_NODE_IDS.URL) {
       // A standalone `URL` node is a GFM autolink (the address part of a real
       // `[text](url)` is handled inside `walkLink`, not here). Linkify the
       // shapes we recognize; anything else keeps the muted `mdLinkUri`.
@@ -122,11 +123,12 @@ function walk(
         : marks.mdLinkUri.create()
       emit(out, node.from, node.to, [...parentMarks, mark])
     } else {
-      const packKey = PACK_KEY_BY_TYPE_ID.get(node.type)
+
+      const packKey = PACK_KEY_BY_TYPE_ID.get(type)
       const base = packKey
         ? [...parentMarks, marks.mdPack.create({ key: packKey } satisfies MdPackAttrs)]
         : parentMarks
-      const maybeMarkName = MARK_NAME_BY_TYPE_ID.get(node.type)
+      const maybeMarkName = MARK_NAME_BY_TYPE_ID.get(type)
       const childMarks = maybeMarkName ? [...base, marks[maybeMarkName].create()] : base
       if (node.children.length === 0) {
         emit(out, node.from, node.to, childMarks)

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.ts
@@ -107,13 +107,13 @@ function walk(
       emit(out, pos, node.from, parentMarks)
     }
     const type: number = node.type
-    if ( type === LEZER_NODE_IDS.Link) {
+    if (type === LEZER_NODE_IDS.Link) {
       walkLink(node, parentMarks, text, marks, out)
-    } else if ( type === LEZER_NODE_IDS.Image) {
+    } else if (type === LEZER_NODE_IDS.Image) {
       walkImage(node, parentMarks, text, marks, out)
-    } else if ( type === LEZER_NODE_IDS.Wikilink) {
+    } else if (type === LEZER_NODE_IDS.Wikilink) {
       walkWikilink(node, parentMarks, text, marks, out)
-    } else if ( type === LEZER_NODE_IDS.URL) {
+    } else if (type === LEZER_NODE_IDS.URL) {
       // A standalone `URL` node is a GFM autolink (the address part of a real
       // `[text](url)` is handled inside `walkLink`, not here). Linkify the
       // shapes we recognize; anything else keeps the muted `mdLinkUri`.
@@ -124,7 +124,21 @@ function walk(
       emit(out, node.from, node.to, [...parentMarks, mark])
     } else {
 
-      const packKey = PACK_KEY_BY_TYPE_ID.get(type)
+
+        let packKey: string | undefined
+
+      if (type === LEZER_NODE_IDS.Emphasis) {
+        packKey = "italic"
+      } else if (type === LEZER_NODE_IDS.StrongEmphasis) {
+        packKey = "bold"
+      } else if (type === LEZER_NODE_IDS.InlineCode) {
+        packKey = "code"
+      } else if (type === LEZER_NODE_IDS.Strikethrough) {
+        packKey = "strike"
+      } else if (type === LEZER_NODE_IDS.Autolink) {
+        packKey = "autolink"
+      }
+
       const base = packKey
         ? [...parentMarks, marks.mdPack.create({ key: packKey } satisfies MdPackAttrs)]
         : parentMarks

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.ts
@@ -6,7 +6,7 @@ import { parseInline } from '../lezer/inline.ts'
 import { LEZER_NODE_IDS } from '../lezer/node-ids.ts'
 
 import type {
-  MdGroupAttrs,
+  MdPackAttrs,
   MdImageSourceAttrs,
   MdImageViewAttrs,
   MdLinkTextAttrs,
@@ -45,12 +45,12 @@ const MARK_NAME_BY_TYPE_ID: ReadonlyMap<number, MarkName> = new Map([
 ])
 
 /**
- * Content-derived `mdGroup` key for inline units whose key is just the kind.
+ * Content-derived `mdPack` key for inline units whose key is just the kind.
  * Link and image are keyed by their url instead (see `walkLink` / `walkImage`),
  * so adjacent ones with different urls stay separate. Wikilink, tag and bare
- * autolinks are absent: they get no group (atomic, or nothing to reveal).
+ * autolinks are absent: they get no pack (atomic, or nothing to reveal).
  */
-const GROUP_KEY_BY_TYPE_ID: ReadonlyMap<number, string> = new Map([
+const PACK_KEY_BY_TYPE_ID: ReadonlyMap<number, string> = new Map([
   [LEZER_NODE_IDS.Emphasis, 'italic'],
   [LEZER_NODE_IDS.StrongEmphasis, 'bold'],
   [LEZER_NODE_IDS.InlineCode, 'code'],
@@ -122,9 +122,9 @@ function walk(
         : marks.mdLinkUri.create()
       emit(out, node.from, node.to, [...parentMarks, mark])
     } else {
-      const groupKey = GROUP_KEY_BY_TYPE_ID.get(node.type)
-      const base = groupKey
-        ? [...parentMarks, marks.mdGroup.create({ key: groupKey } satisfies MdGroupAttrs)]
+      const packKey = PACK_KEY_BY_TYPE_ID.get(node.type)
+      const base = packKey
+        ? [...parentMarks, marks.mdPack.create({ key: packKey } satisfies MdPackAttrs)]
         : parentMarks
       const maybeMarkName = MARK_NAME_BY_TYPE_ID.get(node.type)
       const childMarks = maybeMarkName ? [...base, marks[maybeMarkName].create()] : base
@@ -180,8 +180,8 @@ function walkLink(
   const linkTextMark = href ? marks.mdLinkText.create({ href } satisfies MdLinkTextAttrs) : null
   const inLabel = (pos: number): boolean => labelEnd >= 0 && pos < labelEnd && linkTextMark !== null
 
-  const group = marks.mdGroup.create({ key: `link_${href}` } satisfies MdGroupAttrs)
-  const base = [...parentMarks, group]
+  const pack = marks.mdPack.create({ key: `link_${href}` } satisfies MdPackAttrs)
+  const base = [...parentMarks, pack]
 
   let pos = node.from
   for (const child of node.children) {
@@ -244,17 +244,17 @@ function walkImage(
 
   const source = marks.mdImageSource.create({ src, alt } satisfies MdImageSourceAttrs)
   const view = marks.mdImageView.create({ src, alt } satisfies MdImageViewAttrs)
-  const group = marks.mdGroup.create({ key: `image_${src}` } satisfies MdGroupAttrs)
+  const pack = marks.mdPack.create({ key: `image_${src}` } satisfies MdPackAttrs)
 
   // The image's final character, where `mdImageView` is anchored: `)` today, a
   // future `]` for `![alt][id]`.
   const anchorFrom = node.to - 1
 
-  // Marks shared by every chunk at `from`: the `mdGroup` envelope plus
+  // Marks shared by every chunk at `from`: the `mdPack` envelope plus
   // `mdImageSource` over the whole source, plus `mdImageView` once we reach the
   // final character (the render anchor). Each child layers its own syntax mark on top.
   const baseAt = (from: number): Mark[] =>
-    from >= anchorFrom ? [...parentMarks, group, source, view] : [...parentMarks, group, source]
+    from >= anchorFrom ? [...parentMarks, pack, source, view] : [...parentMarks, pack, source]
 
   let pos = node.from
   for (const child of node.children) {

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.ts
@@ -44,19 +44,7 @@ const MARK_NAME_BY_TYPE_ID: ReadonlyMap<number, MarkName> = new Map([
   [LEZER_NODE_IDS.WikilinkMark, 'mdMark'],
 ])
 
-/**
- * Content-derived `mdPack` key for inline units whose key is just the kind.
- * Link and image are keyed by their url instead (see `walkLink` / `walkImage`),
- * so adjacent ones with different urls stay separate. Wikilink, tag and bare
- * autolinks are absent: they get no pack (atomic, or nothing to reveal).
- */
-const PACK_KEY_BY_TYPE_ID: ReadonlyMap<number, string> = new Map([
-  [LEZER_NODE_IDS.Emphasis, 'italic'],
-  [LEZER_NODE_IDS.StrongEmphasis, 'bold'],
-  [LEZER_NODE_IDS.InlineCode, 'code'],
-  [LEZER_NODE_IDS.Strikethrough, 'strike'],
-  [LEZER_NODE_IDS.Autolink, 'autolink'],
-])
+
 
 /**
  * Walk a textblock's inline content and produce a list of mark chunks

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.ts
@@ -44,8 +44,6 @@ const MARK_NAME_BY_TYPE_ID: ReadonlyMap<number, MarkName> = new Map([
   [LEZER_NODE_IDS.WikilinkMark, 'mdMark'],
 ])
 
-
-
 /**
  * Walk a textblock's inline content and produce a list of mark chunks
  * with positions relative to the start of `text` (i.e. zero-based).
@@ -111,20 +109,18 @@ function walk(
         : marks.mdLinkUri.create()
       emit(out, node.from, node.to, [...parentMarks, mark])
     } else {
-
-
-        let packKey: string | undefined
+      let packKey: string | undefined
 
       if (type === LEZER_NODE_IDS.Emphasis) {
-        packKey = "italic"
+        packKey = 'italic'
       } else if (type === LEZER_NODE_IDS.StrongEmphasis) {
-        packKey = "bold"
+        packKey = 'bold'
       } else if (type === LEZER_NODE_IDS.InlineCode) {
-        packKey = "code"
+        packKey = 'code'
       } else if (type === LEZER_NODE_IDS.Strikethrough) {
-        packKey = "strike"
+        packKey = 'strike'
       } else if (type === LEZER_NODE_IDS.Autolink) {
-        packKey = "autolink"
+        packKey = 'autolink'
       }
 
       const base = packKey

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -53,6 +53,12 @@ describe('defineMarkMode', () => {
   })
 
   describe('focus mode', () => {
+    it("sets data-mark-mode attribute to 'focus'", async () => {
+      using fixture = setupFixture()
+      fixture.editor.use(defineMarkMode('focus'))
+      await expect.element(pmRoot).toHaveAttribute('data-mark-mode', 'focus')
+    })
+
     it('reveals both ** when the cursor is inside **bold**', async () => {
       using fixture = setupFixture()
       fixture.editor.use(defineMarkMode('focus'))
@@ -246,6 +252,12 @@ describe('defineMarkMode', () => {
   })
 
   describe('hide mode', () => {
+    it("sets data-mark-mode attribute to 'hide'", async () => {
+      using fixture = setupFixture()
+      fixture.editor.use(defineMarkMode('hide'))
+      await expect.element(pmRoot).toHaveAttribute('data-mark-mode', 'hide')
+    })
+
     it('never reveals markers, even with the cursor inside bold', async () => {
       using fixture = setupFixture()
       fixture.editor.use(defineMarkMode('hide'))
@@ -320,6 +332,13 @@ describe('defineMarkMode', () => {
   })
 
   describe('show mode', () => {
+    it("sets data-mark-mode attribute to 'show'", async () => {
+      using fixture = setupFixture()
+      fixture.editor.use(defineMarkMode('show'))
+      await expect.element(pmRoot).toHaveAttribute('data-mark-mode', 'show')
+    })
+
+
     it('never reveals markers (syntax is always visible via CSS, not decorations)', async () => {
       using fixture = setupFixture()
       fixture.editor.use(defineMarkMode('show'))

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -234,6 +234,15 @@ describe('defineMarkMode', () => {
       // Only the first link's 4 markers; the abutting second link stays hidden.
       await expectRevealedMarkers(4)
     })
+
+    it('strips syntax from the copied text just like hide mode', () => {
+      using fixture = setupFixture()
+      fixture.editor.use(defineMarkMode('focus'))
+      const { n } = fixture
+      const doc = n.doc(n.paragraph('Hello **bold** end'))
+      fixture.set(doc)
+      expect(clipboardText(fixture)).toBe('Hello bold end')
+    })
   })
 
   describe('hide mode', () => {
@@ -330,16 +339,6 @@ describe('defineMarkMode', () => {
     })
   })
 
-  describe('focus mode clipboard', () => {
-    it('strips syntax from the copied text just like hide mode', () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('Hello **bold** end'))
-      fixture.set(doc)
-      expect(clipboardText(fixture)).toBe('Hello bold end')
-    })
-  })
 
   describe('md-pack structure', () => {
     it('wraps a whole link in one pack containing the anchor', async () => {

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -1,10 +1,9 @@
 import { TextSelection } from '@prosekit/pm/state'
-import { formatHTML } from 'diffable-html-snapshot'
 import { describe, expect, it } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 
 import { findText } from '../testing/find-text.ts'
-import { getSelectionSnapshot, setupFixture } from '../testing/index.ts'
+import { setupFixture } from '../testing/index.ts'
 
 import { defineImage } from './image.ts'
 import { defineMarkMode, type MarkMode } from './mark-mode.ts'
@@ -841,18 +840,12 @@ describe('defineMarkMode', () => {
       fixture.set(n.doc(n.paragraph('text **bold** <a>*italic* text')))
       fixture.view.focus()
 
-      expect(fixture.selectionSnapshot).toMatchInlineSnapshot(
-        `"text **bold** ▌*italic* text"`,
-      )
+      expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`"text **bold** ▌*italic* text"`)
       await userEvent.keyboard('{Backspace}')
       // TODO: this is a bug. Pressing backspace should not delete **
-      expect(fixture.selectionSnapshot).toMatchInlineSnapshot(
-        `"text **bold▌*italic* text"`,
-      )
+      expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`"text **bold▌*italic* text"`)
       await userEvent.keyboard('{Backspace}')
-      expect(fixture.selectionSnapshot).toMatchInlineSnapshot(
-        `"text **bol▌*italic* text"`,
-      )
+      expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`"text **bol▌*italic* text"`)
     })
   })
 

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -1,4 +1,5 @@
 import { TextSelection } from '@prosekit/pm/state'
+import { formatHTML } from 'diffable-html-snapshot'
 import { describe, expect, it } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 
@@ -8,26 +9,15 @@ import { getSelectionSnapshot, setupFixture } from '../testing/index.ts'
 import { defineImage } from './image.ts'
 import { defineMarkMode, type MarkMode } from './mark-mode.ts'
 
-const IMAGE_SVG =
-  '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10" fill="pink"/></svg>'
-const IMAGE_URL = `data:image/svg+xml;base64,${btoa(IMAGE_SVG)}`
-
-// A syntax span counts as revealed when the focus decoration (`.show`) lands
-// inside it, which is exactly what the production CSS keys off. One decoration
-// covers the whole `mdPack`, so counting `.show` spans directly would also count
-// the unit's text; scoping to the hidden-syntax spans recovers the marker count.
-const revealedMarkers = page.locate(
-  '.ProseMirror .md-mark:has(.show), .ProseMirror .md-link-uri:has(.show), .ProseMirror .md-image-source:has(.show)',
-)
 const pmRoot = page.locate('.ProseMirror')
 
-/** Mount one paragraph in `mode` (caret at `<a>`) and assert how many syntax markers reveal. */
-async function expectReveal(mode: MarkMode, text: string, count: number): Promise<void> {
+/** Mount one paragraph in `mode` (caret at `<a>`) and freeze the rendered HTML. */
+function renderHTML(mode: MarkMode, text: string): string {
   using fixture = setupFixture()
   fixture.editor.use(defineMarkMode(mode))
   const { n } = fixture
   fixture.set(n.doc(n.paragraph(text)))
-  await expect.element(revealedMarkers).toHaveLength(count)
+  return formatHTML(fixture.view.dom.innerHTML)
 }
 
 /** Mount one paragraph in `mode` and assert what a full-document copy yields (`null` = no serializer). */
@@ -50,130 +40,797 @@ describe('defineMarkMode', () => {
       await expect.element(pmRoot).toHaveAttribute('data-mark-mode', 'focus')
     })
 
-    it('reveals both ** when the cursor is inside **bold**', async () => {
-      await expectReveal('focus', 'Hello **<a>bold** end', 2)
+    it('reveals both ** when the cursor is inside **bold**', () => {
+      expect(renderHTML('focus', 'Hello **<a>bold** end')).toMatchInlineSnapshot(`
+        "
+        <p>
+          Hello
+          <span
+            class="md-pack"
+            data-key="bold"
+          >
+            <strong>
+              <span class="md-mark">
+                <span class="show">
+                  **
+                </span>
+              </span>
+              <span class="show">
+                bold
+              </span>
+              <span class="md-mark">
+                <span class="show">
+                  **
+                </span>
+              </span>
+            </strong>
+          </span>
+          end
+        </p>
+        "
+      `)
     })
 
-    it('reveals nothing when the cursor is in plain text', async () => {
-      await expectReveal('focus', 'Hello<a> **bold** end', 0)
+    it('reveals nothing when the cursor is in plain text', () => {
+      expect(renderHTML('focus', 'Hello<a> **bold** end')).toMatchInlineSnapshot(`
+        "
+        <p>
+          Hello
+          <span
+            class="md-pack"
+            data-key="bold"
+          >
+            <strong>
+              <span class="md-mark">
+                **
+              </span>
+              bold
+              <span class="md-mark">
+                **
+              </span>
+            </strong>
+          </span>
+          end
+        </p>
+        "
+      `)
     })
 
-    it('reveals only the adjacent marker pair, not unrelated bolds', async () => {
-      await expectReveal('focus', '**<a>one** plain **two**', 2)
+    it('reveals only the adjacent marker pair, not unrelated bolds', () => {
+      expect(renderHTML('focus', '**<a>one** plain **two**')).toMatchInlineSnapshot(`
+        "
+        <p>
+          <span
+            class="md-pack"
+            data-key="bold"
+          >
+            <strong>
+              <span class="md-mark">
+                <span class="show">
+                  **
+                </span>
+              </span>
+              <span class="show">
+                one
+              </span>
+              <span class="md-mark">
+                <span class="show">
+                  **
+                </span>
+              </span>
+            </strong>
+          </span>
+          plain
+          <span
+            class="md-pack"
+            data-key="bold"
+          >
+            <strong>
+              <span class="md-mark">
+                **
+              </span>
+              two
+              <span class="md-mark">
+                **
+              </span>
+            </strong>
+          </span>
+        </p>
+        "
+      `)
     })
 
-    it('reveals nested wrappers (***foo***) as 4 markers', async () => {
-      await expectReveal('focus', '***<a>foo***', 4)
+    it('reveals nested wrappers (***foo***)', () => {
+      expect(renderHTML('focus', '***<a>foo***')).toMatchInlineSnapshot(`
+        "
+        <p>
+          <span
+            class="md-pack"
+            data-key="italic"
+          >
+            <em>
+              <span class="md-mark">
+                <span class="show">
+                  *
+                </span>
+              </span>
+            </em>
+            <span
+              class="md-pack"
+              data-key="bold"
+            >
+              <strong>
+                <em>
+                  <span class="md-mark">
+                    <span class="show">
+                      **
+                    </span>
+                  </span>
+                  <span class="show">
+                    foo
+                  </span>
+                  <span class="md-mark">
+                    <span class="show">
+                      **
+                    </span>
+                  </span>
+                </em>
+              </strong>
+            </span>
+            <em>
+              <span class="md-mark">
+                <span class="show">
+                  *
+                </span>
+              </span>
+            </em>
+          </span>
+        </p>
+        "
+      `)
     })
 
-    it('reveals every link marker when the cursor is in the text', async () => {
-      await expectReveal('focus', 'see [<a>docs](http://x.test)', 4)
+    it('reveals every link marker when the cursor is in the text', () => {
+      expect(renderHTML('focus', 'see [<a>docs](http://x.test)')).toMatchInlineSnapshot(`
+        "
+        <p>
+          see
+          <span
+            class="md-pack"
+            data-key="link_http://x.test"
+          >
+            <a
+              class="md-link"
+              href="http://x.test"
+            >
+              <span class="md-mark">
+                <span class="show">
+                  [
+                </span>
+              </span>
+              <span class="show">
+                docs
+              </span>
+            </a>
+            <span class="md-mark">
+              <span class="show">
+                ](
+              </span>
+            </span>
+            <span class="md-link-uri">
+              <span class="show">
+                http://x.test
+              </span>
+            </span>
+            <span class="md-mark">
+              <span class="show">
+                )
+              </span>
+            </span>
+          </span>
+        </p>
+        "
+      `)
     })
 
-    it('reveals every link marker when the cursor is in the url', async () => {
-      await expectReveal('focus', 'see [docs](http<a>://x.test)', 4)
+    it('reveals every link marker when the cursor is in the url', () => {
+      expect(renderHTML('focus', 'see [docs](http<a>://x.test)')).toMatchInlineSnapshot(`
+        "
+        <p>
+          see
+          <span
+            class="md-pack"
+            data-key="link_http://x.test"
+          >
+            <a
+              class="md-link"
+              href="http://x.test"
+            >
+              <span class="md-mark">
+                <span class="show">
+                  [
+                </span>
+              </span>
+              <span class="show">
+                docs
+              </span>
+            </a>
+            <span class="md-mark">
+              <span class="show">
+                ](
+              </span>
+            </span>
+            <span class="md-link-uri">
+              <span class="show">
+                http://x.test
+              </span>
+            </span>
+            <span class="md-mark">
+              <span class="show">
+                )
+              </span>
+            </span>
+          </span>
+        </p>
+        "
+      `)
     })
 
-    it('reveals nothing when the cursor is inside a bare autolink', async () => {
-      await expectReveal('focus', 'visit https://exa<a>mple.com now', 0)
+    it('reveals nothing when the cursor is inside a bare autolink', () => {
+      expect(renderHTML('focus', 'visit https://exa<a>mple.com now')).toMatchInlineSnapshot(`
+        "
+        <p>
+          visit
+          <a
+            class="md-link"
+            href="https://example.com"
+          >
+            https://example.com
+          </a>
+          now
+        </p>
+        "
+      `)
     })
 
-    it('reveals the angle brackets when the cursor is inside <url>', async () => {
-      await expectReveal('focus', 'a <https://<a>example.com> b', 2)
+    it('reveals the angle brackets when the cursor is inside <url>', () => {
+      expect(renderHTML('focus', 'a <https://<a>example.com> b')).toMatchInlineSnapshot(`
+        "
+        <p>
+          a
+          <span
+            class="md-pack"
+            data-key="autolink"
+          >
+            <span class="md-mark">
+              <span class="show">
+                &lt;
+              </span>
+            </span>
+            <a
+              class="md-link"
+              href="https://example.com"
+            >
+              <span class="show">
+                https://example.com
+              </span>
+            </a>
+            <span class="md-mark">
+              <span class="show">
+                &gt;
+              </span>
+            </span>
+          </span>
+          b
+        </p>
+        "
+      `)
     })
 
-    it('reveals when the cursor sits right after the closing **', async () => {
-      await expectReveal('focus', '**bold**<a> rest', 2)
+    it('reveals when the cursor sits right after the closing **', () => {
+      expect(renderHTML('focus', '**bold**<a> rest')).toMatchInlineSnapshot(`
+        "
+        <p>
+          <span
+            class="md-pack"
+            data-key="bold"
+          >
+            <strong>
+              <span class="md-mark">
+                <span class="show">
+                  **
+                </span>
+              </span>
+              <span class="show">
+                bold
+              </span>
+              <span class="md-mark">
+                <span class="show">
+                  **
+                </span>
+              </span>
+            </strong>
+          </span>
+          rest
+        </p>
+        "
+      `)
     })
 
-    it('reveals nothing on a multi-char selection', async () => {
-      await expectReveal('focus', '**<a>bold<b>**', 0)
+    it('reveals nothing on a multi-char selection', () => {
+      expect(renderHTML('focus', '**<a>bold<b>**')).toMatchInlineSnapshot(`
+        "
+        <p>
+          <span
+            class="md-pack"
+            data-key="bold"
+          >
+            <strong>
+              <span class="md-mark">
+                **
+              </span>
+              bold
+              <span class="md-mark">
+                **
+              </span>
+            </strong>
+          </span>
+        </p>
+        "
+      `)
     })
 
-    it('reveals nothing inside a wikilink (the source is atomic, never revealed)', async () => {
-      await expectReveal('focus', 'see [[no<a>te]] end', 0)
+    it('reveals nothing inside a wikilink (the source is atomic, never revealed)', () => {
+      expect(renderHTML('focus', 'see [[no<a>te]] end')).toMatchInlineSnapshot(`
+        "
+        <p>
+          see
+          <span class="md-wikilink-source">
+            <span class="md-mark">
+              [[
+            </span>
+            note
+            <span class="md-mark">
+              ]
+            </span>
+          </span>
+          <span class="md-wikilink-view">
+            <span>
+              <span class="md-wikilink-source">
+                <span class="md-mark">
+                  ]
+                </span>
+              </span>
+            </span>
+            <span
+              class="md-wikilink-label"
+              contenteditable="false"
+              data-testid="wikilink"
+            >
+              note
+            </span>
+          </span>
+          end
+        </p>
+        "
+      `)
     })
 
-    it('reveals nothing inside a wikilink next to a markdown link', async () => {
-      await expectReveal('focus', '[a](http://x)[[no<a>te]]', 0)
+    it('reveals nothing inside a wikilink next to a markdown link', () => {
+      expect(renderHTML('focus', '[a](http://x)[[no<a>te]]')).toMatchInlineSnapshot(`
+        "
+        <p>
+          <span
+            class="md-pack"
+            data-key="link_http://x"
+          >
+            <a
+              class="md-link"
+              href="http://x"
+            >
+              <span class="md-mark">
+                [
+              </span>
+              a
+            </a>
+            <span class="md-mark">
+              ](
+            </span>
+            <span class="md-link-uri">
+              http://x
+            </span>
+            <span class="md-mark">
+              )
+            </span>
+          </span>
+          <span class="md-wikilink-source">
+            <span class="md-mark">
+              [[
+            </span>
+            note
+            <span class="md-mark">
+              ]
+            </span>
+          </span>
+          <span class="md-wikilink-view">
+            <span>
+              <span class="md-wikilink-source">
+                <span class="md-mark">
+                  ]
+                </span>
+              </span>
+            </span>
+            <span
+              class="md-wikilink-label"
+              contenteditable="false"
+              data-testid="wikilink"
+            >
+              note
+            </span>
+          </span>
+        </p>
+        "
+      `)
     })
 
-    it('reveals nothing inside a #tag (tags have no syntax to reveal)', async () => {
-      await expectReveal('focus', 'Hello #me<a>ow end', 0)
+    it('reveals nothing inside a #tag (tags have no syntax to reveal)', () => {
+      expect(renderHTML('focus', 'Hello #me<a>ow end')).toMatchInlineSnapshot(`
+        "
+        <p>
+          Hello
+          <span class="md-tag">
+            #meow
+          </span>
+          end
+        </p>
+        "
+      `)
     })
 
-    it('reveals the whole link when the cursor sits right after the closing )', async () => {
-      // `[`, `](`, the url and `)` all reveal; the trailing-edge caret used to
-      // reveal nothing because `)` carried no triggering mark.
-      await expectReveal('focus', 'ABC[link](https://example.com)<a>DEF', 4)
+    it('reveals the whole link when the cursor sits right after the closing )', () => {
+      expect(renderHTML('focus', 'ABC[link](https://example.com)<a>DEF')).toMatchInlineSnapshot(`
+        "
+        <p>
+          ABC
+          <span
+            class="md-pack"
+            data-key="link_https://example.com"
+          >
+            <a
+              class="md-link"
+              href="https://example.com"
+            >
+              <span class="md-mark">
+                <span class="show">
+                  [
+                </span>
+              </span>
+              <span class="show">
+                link
+              </span>
+            </a>
+            <span class="md-mark">
+              <span class="show">
+                ](
+              </span>
+            </span>
+            <span class="md-link-uri">
+              <span class="show">
+                https://example.com
+              </span>
+            </span>
+            <span class="md-mark">
+              <span class="show">
+                )
+              </span>
+            </span>
+          </span>
+          DEF
+        </p>
+        "
+      `)
     })
 
-    it('reveals the angle autolink when the cursor sits right after the closing >', async () => {
-      await expectReveal('focus', 'a <https://example.com><a> b', 2)
+    it('reveals the angle autolink when the cursor sits right after the closing >', () => {
+      expect(renderHTML('focus', 'a <https://example.com><a> b')).toMatchInlineSnapshot(`
+        "
+        <p>
+          a
+          <span
+            class="md-pack"
+            data-key="autolink"
+          >
+            <span class="md-mark">
+              <span class="show">
+                &lt;
+              </span>
+            </span>
+            <a
+              class="md-link"
+              href="https://example.com"
+            >
+              <span class="show">
+                https://example.com
+              </span>
+            </a>
+            <span class="md-mark">
+              <span class="show">
+                &gt;
+              </span>
+            </span>
+          </span>
+          b
+        </p>
+        "
+      `)
     })
 
-    it('reveals the whole outer unit even when the cursor is in its bold-only region', async () => {
-      // Cursor in the leading `bold`, outside the nested italic; the whole unit
-      // reveals: both `**` and both inner `*`.
-      await expectReveal('focus', '**bo<a>ld *italic* bold**', 4)
+    it('reveals the whole outer unit even when the cursor is in its bold-only region', () => {
+      expect(renderHTML('focus', '**bo<a>ld *italic* bold**')).toMatchInlineSnapshot(`
+        "
+        <p>
+          <span
+            class="md-pack"
+            data-key="bold"
+          >
+            <strong>
+              <span class="md-mark">
+                <span class="show">
+                  **
+                </span>
+              </span>
+              <span class="show">
+                bold
+              </span>
+            </strong>
+            <span
+              class="md-pack"
+              data-key="italic"
+            >
+              <strong>
+                <em>
+                  <span class="md-mark">
+                    <span class="show">
+                      *
+                    </span>
+                  </span>
+                  <span class="show">
+                    italic
+                  </span>
+                  <span class="md-mark">
+                    <span class="show">
+                      *
+                    </span>
+                  </span>
+                </em>
+              </strong>
+            </span>
+            <strong>
+              <span class="show">
+                bold
+              </span>
+              <span class="md-mark">
+                <span class="show">
+                  **
+                </span>
+              </span>
+            </strong>
+          </span>
+        </p>
+        "
+      `)
     })
 
-    it('reveals only the link the cursor is in, not its adjacent neighbor', async () => {
-      await expectReveal('focus', '[a<a>](x)[b](y)', 4)
+    it('reveals only the link the cursor is in, not its adjacent neighbor', () => {
+      expect(renderHTML('focus', '[a<a>](x)[b](y)')).toMatchInlineSnapshot(`
+        "
+        <p>
+          <span
+            class="md-pack"
+            data-key="link_x"
+          >
+            <a
+              class="md-link"
+              href="x"
+            >
+              <span class="md-mark">
+                <span class="show">
+                  [
+                </span>
+              </span>
+              <span class="show">
+                a
+              </span>
+            </a>
+            <span class="md-mark">
+              <span class="show">
+                ](
+              </span>
+            </span>
+            <span class="md-link-uri">
+              <span class="show">
+                x
+              </span>
+            </span>
+            <span class="md-mark">
+              <span class="show">
+                )
+              </span>
+            </span>
+          </span>
+          <span
+            class="md-pack"
+            data-key="link_y"
+          >
+            <a
+              class="md-link"
+              href="y"
+            >
+              <span class="md-mark">
+                [
+              </span>
+              b
+            </a>
+            <span class="md-mark">
+              ](
+            </span>
+            <span class="md-link-uri">
+              y
+            </span>
+            <span class="md-mark">
+              )
+            </span>
+          </span>
+        </p>
+        "
+      `)
     })
 
-    it('reveals nothing when the cursor is inside a code block', async () => {
+    it('reveals nothing when the cursor is inside a code block', () => {
       using fixture = setupFixture()
       fixture.editor.use(defineMarkMode('focus'))
       const { n } = fixture
       fixture.set(n.doc(n.codeBlock({ language: '' }, '*not<a> italic*')))
-      await expect.element(revealedMarkers).toHaveLength(0)
+      expect(formatHTML(fixture.view.dom.innerHTML)).toMatchInlineSnapshot(`
+        "
+        <pre>
+          <code>
+            *not italic*
+          </code>
+        </pre>
+        "
+      `)
     })
 
-    it('updates the reveal as the cursor moves between paragraphs', async () => {
+    it('renders an inline image as a pack wrapping the preview', () => {
+      using fixture = setupFixture()
+      fixture.editor.use(defineImage({ resolveImageUrl: () => 'http://x/p.png' }))
+      fixture.editor.use(defineMarkMode('focus'))
+      const { n } = fixture
+      fixture.set(n.doc(n.paragraph('![alt](pic.png)')))
+      expect(formatHTML(fixture.view.dom.innerHTML)).toMatchInlineSnapshot(`
+        "
+        <p>
+          <span
+            class="md-pack"
+            data-key="image_pic.png"
+          >
+            <span class="md-image-source">
+              <span class="md-mark">
+                <span class="show">
+                  ![
+                </span>
+              </span>
+              <span class="show">
+                alt
+              </span>
+              <span class="md-mark">
+                <span class="show">
+                  ](
+                </span>
+              </span>
+              <span class="md-link-uri">
+                <span class="show">
+                  pic.png
+                </span>
+              </span>
+            </span>
+            <span class="md-image-view">
+              <span class="md-image-view-content">
+                <span class="md-image-source">
+                  <span class="md-mark">
+                    <span class="show">
+                      )
+                    </span>
+                  </span>
+                </span>
+              </span>
+              <span
+                class="md-image-preview md-image-preview-img"
+                contenteditable="false"
+                data-testid="image-preview"
+              >
+                <img
+                  alt="alt"
+                  draggable="false"
+                  src="http://x/p.png"
+                >
+              </span>
+            </span>
+          </span>
+        </p>
+        "
+      `)
+    })
+
+    it('updates the reveal as the cursor moves between paragraphs', () => {
       using fixture = setupFixture()
       fixture.editor.use(defineMarkMode('focus'))
       const { n } = fixture
       fixture.set(n.doc(n.paragraph('**<a>alpha** one'), n.paragraph('beta two')))
-      await expect.element(revealedMarkers).toHaveLength(2)
+      expect(formatHTML(fixture.view.dom.innerHTML)).toMatchInlineSnapshot(`
+        "
+        <p>
+          <span
+            class="md-pack"
+            data-key="bold"
+          >
+            <strong>
+              <span class="md-mark">
+                <span class="show">
+                  **
+                </span>
+              </span>
+              <span class="show">
+                alpha
+              </span>
+              <span class="md-mark">
+                <span class="show">
+                  **
+                </span>
+              </span>
+            </strong>
+          </span>
+          one
+        </p>
+        <p>
+          beta two
+        </p>
+        "
+      `)
 
       const twoPos = findText(fixture.doc, 'two')
       fixture.view.dispatch(
         fixture.state.tr.setSelection(TextSelection.create(fixture.doc, twoPos)),
       )
-      await expect.element(revealedMarkers).toHaveLength(0)
+      expect(formatHTML(fixture.view.dom.innerHTML)).toMatchInlineSnapshot(`
+        "
+        <p>
+          <span
+            class="md-pack"
+            data-key="bold"
+          >
+            <strong>
+              <span class="md-mark">
+                **
+              </span>
+              alpha
+              <span class="md-mark">
+                **
+              </span>
+            </strong>
+          </span>
+          one
+        </p>
+        <p>
+          beta two
+        </p>
+        "
+      `)
     })
 
     it('strips syntax from the copied text just like hide mode', () => {
       expectClipboard('focus', 'Hello **bold** end', 'Hello bold end')
-    })
-
-    it('wraps a whole link in one pack containing the anchor', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      fixture.set(n.doc(n.paragraph('see [docs](http://x.test)')))
-      const pack = pmRoot.locate('.md-pack[data-key="link_http://x.test"]')
-      await expect.element(pack.getByRole('link')).toBeInTheDocument()
-    })
-
-    it('nests an italic pack inside a bold pack', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      fixture.set(n.doc(n.paragraph('**bold *italic* bold**')))
-      const bold = pmRoot.locate('.md-pack[data-key="bold"]')
-      await expect.element(bold.locate('.md-pack[data-key="italic"]')).toBeInTheDocument()
-    })
-
-    it('wraps an image in a pack while its preview still renders', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineImage({ resolveImageUrl: () => IMAGE_URL }))
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      fixture.set(n.doc(n.paragraph('![alt](pic.png)')))
-      const pack = pmRoot.locate('.md-pack[data-key="image_pic.png"]')
-      await expect.element(pack.getByTestId('image-preview')).toBeVisible()
     })
 
     it('preserves marks after pressing backspaces', async () => {
@@ -184,16 +841,16 @@ describe('defineMarkMode', () => {
       fixture.set(n.doc(n.paragraph('text **bold** <a>*italic* text')))
       fixture.view.focus()
 
-      expect(fixture.selectionSnapshot).toMatchInlineSnapshot(
+      expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(
         `"text **bold** ▌*italic* text"`,
       )
       await userEvent.keyboard('{Backspace}')
       // TODO: this is a bug. Pressing backspace should not delete **
-      expect(fixture.selectionSnapshot).toMatchInlineSnapshot(
+      expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(
         `"text **bold▌*italic* text"`,
       )
       await userEvent.keyboard('{Backspace}')
-      expect(fixture.selectionSnapshot).toMatchInlineSnapshot(
+      expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(
         `"text **bol▌*italic* text"`,
       )
     })
@@ -206,12 +863,65 @@ describe('defineMarkMode', () => {
       await expect.element(pmRoot).toHaveAttribute('data-mark-mode', 'hide')
     })
 
-    it('never reveals markers, even with the cursor inside bold', async () => {
-      await expectReveal('hide', 'Hello **<a>bold** end', 0)
+    it('never reveals markers, even with the cursor inside bold', () => {
+      expect(renderHTML('hide', 'Hello **<a>bold** end')).toMatchInlineSnapshot(`
+        "
+        <p>
+          Hello
+          <span
+            class="md-pack"
+            data-key="bold"
+          >
+            <strong>
+              <span class="md-mark">
+                **
+              </span>
+              bold
+              <span class="md-mark">
+                **
+              </span>
+            </strong>
+          </span>
+          end
+        </p>
+        "
+      `)
     })
 
-    it('never reveals markers with the cursor inside a wikilink', async () => {
-      await expectReveal('hide', 'see [[no<a>te]] end', 0)
+    it('never reveals markers with the cursor inside a wikilink', () => {
+      expect(renderHTML('hide', 'see [[no<a>te]] end')).toMatchInlineSnapshot(`
+        "
+        <p>
+          see
+          <span class="md-wikilink-source">
+            <span class="md-mark">
+              [[
+            </span>
+            note
+            <span class="md-mark">
+              ]
+            </span>
+          </span>
+          <span class="md-wikilink-view">
+            <span>
+              <span class="md-wikilink-source">
+                <span class="md-mark">
+                  ]
+                </span>
+              </span>
+            </span>
+            <span
+              class="md-wikilink-label"
+              contenteditable="false"
+              data-testid="wikilink"
+            >
+              note
+            </span>
+          </span>
+          end
+        </p>
+        "
+      `)
     })
 
     it('strips ** from the copied text', () => {
@@ -250,8 +960,29 @@ describe('defineMarkMode', () => {
       await expect.element(pmRoot).toHaveAttribute('data-mark-mode', 'show')
     })
 
-    it('never reveals markers (syntax is always visible via CSS, not decorations)', async () => {
-      await expectReveal('show', 'Hello **<a>bold** end', 0)
+    it('never reveals markers (syntax is always visible via CSS, not decorations)', () => {
+      expect(renderHTML('show', 'Hello **<a>bold** end')).toMatchInlineSnapshot(`
+        "
+        <p>
+          Hello
+          <span
+            class="md-pack"
+            data-key="bold"
+          >
+            <strong>
+              <span class="md-mark">
+                **
+              </span>
+              bold
+              <span class="md-mark">
+                **
+              </span>
+            </strong>
+          </span>
+          end
+        </p>
+        "
+      `)
     })
 
     it('installs no clipboard serializer, so copied text keeps the ** syntax', () => {

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -233,6 +233,57 @@ describe('defineMarkMode', () => {
       fixture.set(doc)
       expect(clipboardText(fixture)).toBe('Hello bold end')
     })
+    describe('md-pack structure', () => {
+      it('wraps a whole link in one pack containing the anchor', async () => {
+        using fixture = setupFixture()
+        fixture.editor.use(defineMarkMode('focus'))
+        const { n } = fixture
+        fixture.set(n.doc(n.paragraph('see [docs](http://x.test)')))
+        const pack = pmRoot.locate('.md-pack[data-key="link_http://x.test"]')
+        await expect.element(pack.getByRole('link')).toBeInTheDocument()
+      })
+
+      it('nests an italic pack inside a bold pack', async () => {
+        using fixture = setupFixture()
+        fixture.editor.use(defineMarkMode('focus'))
+        const { n } = fixture
+        fixture.set(n.doc(n.paragraph('**bold *italic* bold**')))
+        const bold = pmRoot.locate('.md-pack[data-key="bold"]')
+        await expect.element(bold.locate('.md-pack[data-key="italic"]')).toBeInTheDocument()
+      })
+
+      it('wraps an image in a pack while its preview still renders', async () => {
+        using fixture = setupFixture()
+        fixture.editor.use(defineImage({ resolveImageUrl: () => IMAGE_URL }))
+        fixture.editor.use(defineMarkMode('focus'))
+        const { n } = fixture
+        fixture.set(n.doc(n.paragraph('![alt](pic.png)')))
+        const pack = pmRoot.locate('.md-pack[data-key="image_pic.png"]')
+        await expect.element(pack.getByTestId('image-preview')).toBeVisible()
+      })
+    })
+
+    describe('backspace at a **bold** *italic* boundary', () => {
+      it('captures the state after one and two backspaces', async () => {
+        using fixture = setupFixture()
+        fixture.editor.use(defineMarkMode('focus'))
+        const { n } = fixture
+        // Caret sits between the space after `**bold**` and the `*italic*`.
+        const doc = n.doc(n.paragraph('text **bold** <a>*italic* text'))
+        fixture.set(doc)
+        fixture.view.focus()
+
+        await userEvent.keyboard('{Backspace}')
+        expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(
+          `"text **bold▌*italic* text"`,
+        )
+
+        await userEvent.keyboard('{Backspace}')
+        expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(
+          `"text **bol▌*italic* text"`,
+        )
+      })
+    })
   })
 
   describe('hide mode', () => {
@@ -338,58 +389,6 @@ describe('defineMarkMode', () => {
       const doc = n.doc(n.paragraph('Hello **bold** end'))
       fixture.set(doc)
       expect(clipboardText(fixture)).toBeNull()
-    })
-  })
-
-  describe('md-pack structure', () => {
-    it('wraps a whole link in one pack containing the anchor', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      fixture.set(n.doc(n.paragraph('see [docs](http://x.test)')))
-      const pack = pmRoot.locate('.md-pack[data-key="link_http://x.test"]')
-      await expect.element(pack.getByRole('link')).toBeInTheDocument()
-    })
-
-    it('nests an italic pack inside a bold pack', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      fixture.set(n.doc(n.paragraph('**bold *italic* bold**')))
-      const bold = pmRoot.locate('.md-pack[data-key="bold"]')
-      await expect.element(bold.locate('.md-pack[data-key="italic"]')).toBeInTheDocument()
-    })
-
-    it('wraps an image in a pack while its preview still renders', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineImage({ resolveImageUrl: () => IMAGE_URL }))
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      fixture.set(n.doc(n.paragraph('![alt](pic.png)')))
-      const pack = pmRoot.locate('.md-pack[data-key="image_pic.png"]')
-      await expect.element(pack.getByTestId('image-preview')).toBeVisible()
-    })
-  })
-
-  describe('focus mode backspace at a **bold** *italic* boundary', () => {
-    it('captures the state after one and two backspaces', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      // Caret sits between the space after `**bold**` and the `*italic*`.
-      const doc = n.doc(n.paragraph('text **bold** <a>*italic* text'))
-      fixture.set(doc)
-      fixture.view.focus()
-
-      await userEvent.keyboard('{Backspace}')
-      expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(
-        `"text **bold▌*italic* text"`,
-      )
-
-      await userEvent.keyboard('{Backspace}')
-      expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(
-        `"text **bol▌*italic* text"`,
-      )
     })
   })
 })

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -3,10 +3,10 @@ import { describe, expect, it } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 
 import { findText } from '../testing/find-text.ts'
-import { getSelectionSnapshot, setupFixture, type Fixture } from '../testing/index.ts'
+import { getSelectionSnapshot, setupFixture } from '../testing/index.ts'
 
 import { defineImage } from './image.ts'
-import { defineMarkMode } from './mark-mode.ts'
+import { defineMarkMode, type MarkMode } from './mark-mode.ts'
 
 const IMAGE_SVG =
   '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10" fill="pink"/></svg>'
@@ -14,25 +14,32 @@ const IMAGE_URL = `data:image/svg+xml;base64,${btoa(IMAGE_SVG)}`
 
 // A syntax span counts as revealed when the focus decoration (`.show`) lands
 // inside it, which is exactly what the production CSS keys off. One decoration
-// now covers the whole `mdPack`, so counting `.show` spans directly would also
-// count the unit's text; scoping to the hidden-syntax spans recovers the marker
-// count.
+// covers the whole `mdPack`, so counting `.show` spans directly would also count
+// the unit's text; scoping to the hidden-syntax spans recovers the marker count.
 const revealedMarkers = page.locate(
   '.ProseMirror .md-mark:has(.show), .ProseMirror .md-link-uri:has(.show), .ProseMirror .md-image-source:has(.show)',
 )
 const pmRoot = page.locate('.ProseMirror')
 
-/** Asserts how many syntax markers are revealed (made visible by the `.show` decoration). */
-async function expectRevealedMarkers(count: number): Promise<void> {
+/** Mount one paragraph in `mode` (caret at `<a>`) and assert how many syntax markers reveal. */
+async function expectReveal(mode: MarkMode, text: string, count: number): Promise<void> {
+  using fixture = setupFixture()
+  fixture.editor.use(defineMarkMode(mode))
+  const { n } = fixture
+  fixture.set(n.doc(n.paragraph(text)))
   await expect.element(revealedMarkers).toHaveLength(count)
 }
 
-/** What a full-document copy would put on the clipboard, or `null` if the mode installs no serializer. */
-function clipboardText(fixture: Fixture): string | null {
+/** Mount one paragraph in `mode` and assert what a full-document copy yields (`null` = no serializer). */
+function expectClipboard(mode: MarkMode, text: string, expected: string | null): void {
+  using fixture = setupFixture()
+  fixture.editor.use(defineMarkMode(mode))
+  const { n } = fixture
+  fixture.set(n.doc(n.paragraph(text)))
   const serialize = fixture.view.someProp('clipboardTextSerializer')
-  if (!serialize) return null
   const { doc } = fixture
-  return serialize(doc.slice(0, doc.content.size), fixture.view)
+  const actual = serialize ? serialize(doc.slice(0, doc.content.size), fixture.view) : null
+  expect(actual).toBe(expected)
 }
 
 describe('defineMarkMode', () => {
@@ -44,247 +51,152 @@ describe('defineMarkMode', () => {
     })
 
     it('reveals both ** when the cursor is inside **bold**', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('Hello **<a>bold** end'))
-      fixture.set(doc)
-      await expectRevealedMarkers(2)
+      await expectReveal('focus', 'Hello **<a>bold** end', 2)
     })
 
     it('reveals nothing when the cursor is in plain text', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('Hello<a> **bold** end'))
-      fixture.set(doc)
-      await expectRevealedMarkers(0)
+      await expectReveal('focus', 'Hello<a> **bold** end', 0)
     })
 
     it('reveals only the adjacent marker pair, not unrelated bolds', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('**<a>one** plain **two**'))
-      fixture.set(doc)
-      await expectRevealedMarkers(2)
+      await expectReveal('focus', '**<a>one** plain **two**', 2)
     })
 
     it('reveals nested wrappers (***foo***) as 4 markers', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('***<a>foo***'))
-      fixture.set(doc)
-      await expectRevealedMarkers(4)
+      await expectReveal('focus', '***<a>foo***', 4)
     })
 
     it('reveals every link marker when the cursor is in the text', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('see [<a>docs](http://x.test)'))
-      fixture.set(doc)
-      await expectRevealedMarkers(4)
+      await expectReveal('focus', 'see [<a>docs](http://x.test)', 4)
     })
 
     it('reveals every link marker when the cursor is in the url', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('see [docs](http<a>://x.test)'))
-      fixture.set(doc)
-      await expectRevealedMarkers(4)
+      await expectReveal('focus', 'see [docs](http<a>://x.test)', 4)
     })
 
     it('reveals nothing when the cursor is inside a bare autolink', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('visit https://exa<a>mple.com now'))
-      fixture.set(doc)
-      await expectRevealedMarkers(0)
+      await expectReveal('focus', 'visit https://exa<a>mple.com now', 0)
     })
 
     it('reveals the angle brackets when the cursor is inside <url>', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('a <https://<a>example.com> b'))
-      fixture.set(doc)
-      await expectRevealedMarkers(2)
+      await expectReveal('focus', 'a <https://<a>example.com> b', 2)
     })
 
     it('reveals when the cursor sits right after the closing **', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('**bold**<a> rest'))
-      fixture.set(doc)
-      await expectRevealedMarkers(2)
+      await expectReveal('focus', '**bold**<a> rest', 2)
     })
 
     it('reveals nothing on a multi-char selection', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('**<a>bold<b>**'))
-      fixture.set(doc)
-      await expectRevealedMarkers(0)
+      await expectReveal('focus', '**<a>bold<b>**', 0)
     })
 
     it('reveals nothing inside a wikilink (the source is atomic, never revealed)', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('see [[no<a>te]] end'))
-      fixture.set(doc)
-      await expectRevealedMarkers(0)
+      await expectReveal('focus', 'see [[no<a>te]] end', 0)
     })
 
     it('reveals nothing inside a wikilink next to a markdown link', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('[a](http://x)[[no<a>te]]'))
-      fixture.set(doc)
-      await expectRevealedMarkers(0)
+      await expectReveal('focus', '[a](http://x)[[no<a>te]]', 0)
     })
 
     it('reveals nothing inside a #tag (tags have no syntax to reveal)', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('Hello #me<a>ow end'))
-      fixture.set(doc)
-      await expectRevealedMarkers(0)
+      await expectReveal('focus', 'Hello #me<a>ow end', 0)
+    })
+
+    it('reveals the whole link when the cursor sits right after the closing )', async () => {
+      // `[`, `](`, the url and `)` all reveal; the trailing-edge caret used to
+      // reveal nothing because `)` carried no triggering mark.
+      await expectReveal('focus', 'ABC[link](https://example.com)<a>DEF', 4)
+    })
+
+    it('reveals the angle autolink when the cursor sits right after the closing >', async () => {
+      await expectReveal('focus', 'a <https://example.com><a> b', 2)
+    })
+
+    it('reveals the whole outer unit even when the cursor is in its bold-only region', async () => {
+      // Cursor in the leading `bold`, outside the nested italic; the whole unit
+      // reveals: both `**` and both inner `*`.
+      await expectReveal('focus', '**bo<a>ld *italic* bold**', 4)
+    })
+
+    it('reveals only the link the cursor is in, not its adjacent neighbor', async () => {
+      await expectReveal('focus', '[a<a>](x)[b](y)', 4)
     })
 
     it('reveals nothing when the cursor is inside a code block', async () => {
       using fixture = setupFixture()
       fixture.editor.use(defineMarkMode('focus'))
       const { n } = fixture
-      const doc = n.doc(n.codeBlock({ language: '' }, '*not<a> italic*'))
-      fixture.set(doc)
-      await expectRevealedMarkers(0)
+      fixture.set(n.doc(n.codeBlock({ language: '' }, '*not<a> italic*')))
+      await expect.element(revealedMarkers).toHaveLength(0)
     })
 
     it('updates the reveal as the cursor moves between paragraphs', async () => {
       using fixture = setupFixture()
       fixture.editor.use(defineMarkMode('focus'))
       const { n } = fixture
-      const doc = n.doc(n.paragraph('**<a>alpha** one'), n.paragraph('beta two'))
-      fixture.set(doc)
-      await expectRevealedMarkers(2)
+      fixture.set(n.doc(n.paragraph('**<a>alpha** one'), n.paragraph('beta two')))
+      await expect.element(revealedMarkers).toHaveLength(2)
 
       const twoPos = findText(fixture.doc, 'two')
       fixture.view.dispatch(
         fixture.state.tr.setSelection(TextSelection.create(fixture.doc, twoPos)),
       )
-      await expectRevealedMarkers(0)
-    })
-
-    it('reveals the whole link when the cursor sits right after the closing )', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('ABC[link](https://example.com)<a>DEF'))
-      fixture.set(doc)
-      // `[`, `](`, the url and `)` all reveal; the trailing-edge caret used to
-      // reveal nothing because `)` carried no triggering mark.
-      await expectRevealedMarkers(4)
-    })
-
-    it('reveals the angle autolink when the cursor sits right after the closing >', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('a <https://example.com><a> b'))
-      fixture.set(doc)
-      await expectRevealedMarkers(2)
-    })
-
-    it('reveals the whole outer unit even when the cursor is in its bold-only region', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      // Cursor in the leading `bold`, outside the nested italic. The whole unit
-      // reveals: both `**` and both inner `*` (4 markers).
-      const doc = n.doc(n.paragraph('**bo<a>ld *italic* bold**'))
-      fixture.set(doc)
-      await expectRevealedMarkers(4)
-    })
-
-    it('reveals only the link the cursor is in, not its adjacent neighbor', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('focus'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('[a<a>](x)[b](y)'))
-      fixture.set(doc)
-      // Only the first link's 4 markers; the abutting second link stays hidden.
-      await expectRevealedMarkers(4)
+      await expect.element(revealedMarkers).toHaveLength(0)
     })
 
     it('strips syntax from the copied text just like hide mode', () => {
+      expectClipboard('focus', 'Hello **bold** end', 'Hello bold end')
+    })
+
+    it('wraps a whole link in one pack containing the anchor', async () => {
       using fixture = setupFixture()
       fixture.editor.use(defineMarkMode('focus'))
       const { n } = fixture
-      const doc = n.doc(n.paragraph('Hello **bold** end'))
-      fixture.set(doc)
-      expect(clipboardText(fixture)).toBe('Hello bold end')
+      fixture.set(n.doc(n.paragraph('see [docs](http://x.test)')))
+      const pack = pmRoot.locate('.md-pack[data-key="link_http://x.test"]')
+      await expect.element(pack.getByRole('link')).toBeInTheDocument()
     })
 
+    it('nests an italic pack inside a bold pack', async () => {
+      using fixture = setupFixture()
+      fixture.editor.use(defineMarkMode('focus'))
+      const { n } = fixture
+      fixture.set(n.doc(n.paragraph('**bold *italic* bold**')))
+      const bold = pmRoot.locate('.md-pack[data-key="bold"]')
+      await expect.element(bold.locate('.md-pack[data-key="italic"]')).toBeInTheDocument()
+    })
 
-      it('wraps a whole link in one pack containing the anchor', async () => {
-        using fixture = setupFixture()
-        fixture.editor.use(defineMarkMode('focus'))
-        const { n } = fixture
-        fixture.set(n.doc(n.paragraph('see [docs](http://x.test)')))
-        const pack = pmRoot.locate('.md-pack[data-key="link_http://x.test"]')
-        await expect.element(pack.getByRole('link')).toBeInTheDocument()
-      })
+    it('wraps an image in a pack while its preview still renders', async () => {
+      using fixture = setupFixture()
+      fixture.editor.use(defineImage({ resolveImageUrl: () => IMAGE_URL }))
+      fixture.editor.use(defineMarkMode('focus'))
+      const { n } = fixture
+      fixture.set(n.doc(n.paragraph('![alt](pic.png)')))
+      const pack = pmRoot.locate('.md-pack[data-key="image_pic.png"]')
+      await expect.element(pack.getByTestId('image-preview')).toBeVisible()
+    })
 
-      it('nests an italic pack inside a bold pack', async () => {
-        using fixture = setupFixture()
-        fixture.editor.use(defineMarkMode('focus'))
-        const { n } = fixture
-        fixture.set(n.doc(n.paragraph('**bold *italic* bold**')))
-        const bold = pmRoot.locate('.md-pack[data-key="bold"]')
-        await expect.element(bold.locate('.md-pack[data-key="italic"]')).toBeInTheDocument()
-      })
+    it('preserves marks after pressing backspaces', async () => {
+      using fixture = setupFixture()
+      fixture.editor.use(defineMarkMode('focus'))
+      const { n } = fixture
+      // Caret sits between the space after `**bold**` and the `*italic*`.
+      fixture.set(n.doc(n.paragraph('text **bold** <a>*italic* text')))
+      fixture.view.focus()
 
-      it('wraps an image in a pack while its preview still renders', async () => {
-        using fixture = setupFixture()
-        fixture.editor.use(defineImage({ resolveImageUrl: () => IMAGE_URL }))
-        fixture.editor.use(defineMarkMode('focus'))
-        const { n } = fixture
-        fixture.set(n.doc(n.paragraph('![alt](pic.png)')))
-        const pack = pmRoot.locate('.md-pack[data-key="image_pic.png"]')
-        await expect.element(pack.getByTestId('image-preview')).toBeVisible()
-      })
-
-      it('reserves marks after pressing backspaces', async () => {
-        using fixture = setupFixture()
-        fixture.editor.use(defineMarkMode('focus'))
-        const { n } = fixture
-        // Caret sits between the space after `**bold**` and the `*italic*`.
-        const doc = n.doc(n.paragraph('text **bold** <a>*italic* text'))
-        fixture.set(doc)
-        fixture.view.focus()
-
-        expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(
-        )
-        await userEvent.keyboard('{Backspace}')
-        // TODO: this is a bug. Pressing backspace should not delete **
-        expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(
-          `"text **bold▌*italic* text"`,
-        )
-
-        await userEvent.keyboard('{Backspace}')
-        expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(
-          `"text **bol▌*italic* text"`,
-        )
-      })
+      expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(
+        `"text **bold** ▌*italic* text"`,
+      )
+      await userEvent.keyboard('{Backspace}')
+      // TODO: this is a bug. Pressing backspace should not delete **
+      expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(
+        `"text **bold▌*italic* text"`,
+      )
+      await userEvent.keyboard('{Backspace}')
+      expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(
+        `"text **bol▌*italic* text"`,
+      )
+    })
   })
 
   describe('hide mode', () => {
@@ -295,75 +207,39 @@ describe('defineMarkMode', () => {
     })
 
     it('never reveals markers, even with the cursor inside bold', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('hide'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('Hello **<a>bold** end'))
-      fixture.set(doc)
-      await expectRevealedMarkers(0)
+      await expectReveal('hide', 'Hello **<a>bold** end', 0)
     })
 
     it('never reveals markers with the cursor inside a wikilink', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('hide'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('see [[no<a>te]] end'))
-      fixture.set(doc)
-      await expectRevealedMarkers(0)
+      await expectReveal('hide', 'see [[no<a>te]] end', 0)
     })
 
     it('strips ** from the copied text', () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('hide'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('Hello **bold** end'))
-      fixture.set(doc)
-      expect(clipboardText(fixture)).toBe('Hello bold end')
+      expectClipboard('hide', 'Hello **bold** end', 'Hello bold end')
     })
 
     it('strips link [..](..) syntax from the copied text', () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('hide'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('see [docs](http://x.test)'))
-      fixture.set(doc)
-      expect(clipboardText(fixture)).toBe('see docs')
+      expectClipboard('hide', 'see [docs](http://x.test)', 'see docs')
     })
 
     it('keeps a bare autolink in the copied text', () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('hide'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('visit https://example.com now'))
-      fixture.set(doc)
-      expect(clipboardText(fixture)).toBe('visit https://example.com now')
+      expectClipboard('hide', 'visit https://example.com now', 'visit https://example.com now')
     })
 
     it('keeps the whole image source so a copied image stays markdown', () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('hide'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('see ![cat](https://example.com/cat.png) end'))
-      fixture.set(doc)
-      expect(clipboardText(fixture)).toBe('see ![cat](https://example.com/cat.png) end')
+      expectClipboard(
+        'hide',
+        'see ![cat](https://example.com/cat.png) end',
+        'see ![cat](https://example.com/cat.png) end',
+      )
     })
 
     it('keeps the whole [[ ]] source in the copied text', () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('hide'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('see [[note]] end'))
-      fixture.set(doc)
-      expect(clipboardText(fixture)).toBe('see [[note]] end')
+      expectClipboard('hide', 'see [[note]] end', 'see [[note]] end')
     })
 
     it('keeps #tag verbatim in the copied text', () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('hide'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('Hello #meow end'))
-      fixture.set(doc)
-      expect(clipboardText(fixture)).toBe('Hello #meow end')
+      expectClipboard('hide', 'Hello #meow end', 'Hello #meow end')
     })
   })
 
@@ -375,21 +251,11 @@ describe('defineMarkMode', () => {
     })
 
     it('never reveals markers (syntax is always visible via CSS, not decorations)', async () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('show'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('Hello **<a>bold** end'))
-      fixture.set(doc)
-      await expectRevealedMarkers(0)
+      await expectReveal('show', 'Hello **<a>bold** end', 0)
     })
 
     it('installs no clipboard serializer, so copied text keeps the ** syntax', () => {
-      using fixture = setupFixture()
-      fixture.editor.use(defineMarkMode('show'))
-      const { n } = fixture
-      const doc = n.doc(n.paragraph('Hello **bold** end'))
-      fixture.set(doc)
-      expect(clipboardText(fixture)).toBeNull()
+      expectClipboard('show', 'Hello **bold** end', null)
     })
   })
 })

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -15,7 +15,7 @@ const IMAGE_URL = `data:image/svg+xml;base64,${btoa(IMAGE_SVG)}`
 
 // A syntax span counts as revealed when the focus decoration (`.show`) lands
 // inside it, which is exactly what the production CSS keys off. One decoration
-// now covers the whole `mdGroup`, so counting `.show` spans directly would also
+// now covers the whole `mdPack`, so counting `.show` spans directly would also
 // count the unit's text; scoping to the hidden-syntax spans recovers the marker
 // count.
 const revealedMarkers = page.locate(
@@ -341,33 +341,33 @@ describe('defineMarkMode', () => {
     })
   })
 
-  describe('md-m-group structure', () => {
-    it('wraps a whole link in one group containing the anchor', async () => {
+  describe('md-pack structure', () => {
+    it('wraps a whole link in one pack containing the anchor', async () => {
       using fixture = setupFixture()
       fixture.editor.use(defineMarkMode('focus'))
       const { n } = fixture
       fixture.set(n.doc(n.paragraph('see [docs](http://x.test)')))
-      const group = pmRoot.locate('.md-m-group[data-key="link_http://x.test"]')
-      await expect.element(group.getByRole('link')).toBeInTheDocument()
+      const pack = pmRoot.locate('.md-pack[data-key="link_http://x.test"]')
+      await expect.element(pack.getByRole('link')).toBeInTheDocument()
     })
 
-    it('nests an italic group inside a bold group', async () => {
+    it('nests an italic pack inside a bold pack', async () => {
       using fixture = setupFixture()
       fixture.editor.use(defineMarkMode('focus'))
       const { n } = fixture
       fixture.set(n.doc(n.paragraph('**bold *italic* bold**')))
-      const bold = pmRoot.locate('.md-m-group[data-key="bold"]')
-      await expect.element(bold.locate('.md-m-group[data-key="italic"]')).toBeInTheDocument()
+      const bold = pmRoot.locate('.md-pack[data-key="bold"]')
+      await expect.element(bold.locate('.md-pack[data-key="italic"]')).toBeInTheDocument()
     })
 
-    it('wraps an image in a group while its preview still renders', async () => {
+    it('wraps an image in a pack while its preview still renders', async () => {
       using fixture = setupFixture()
       fixture.editor.use(defineImage({ resolveImageUrl: () => IMAGE_URL }))
       fixture.editor.use(defineMarkMode('focus'))
       const { n } = fixture
       fixture.set(n.doc(n.paragraph('![alt](pic.png)')))
-      const group = pmRoot.locate('.md-m-group[data-key="image_pic.png"]')
-      await expect.element(group.getByTestId('image-preview')).toBeVisible()
+      const pack = pmRoot.locate('.md-pack[data-key="image_pic.png"]')
+      await expect.element(pack.getByTestId('image-preview')).toBeVisible()
     })
   })
 

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -233,7 +233,8 @@ describe('defineMarkMode', () => {
       fixture.set(doc)
       expect(clipboardText(fixture)).toBe('Hello bold end')
     })
-    describe('md-pack structure', () => {
+
+
       it('wraps a whole link in one pack containing the anchor', async () => {
         using fixture = setupFixture()
         fixture.editor.use(defineMarkMode('focus'))
@@ -261,10 +262,8 @@ describe('defineMarkMode', () => {
         const pack = pmRoot.locate('.md-pack[data-key="image_pic.png"]')
         await expect.element(pack.getByTestId('image-preview')).toBeVisible()
       })
-    })
 
-    describe('backspace at a **bold** *italic* boundary', () => {
-      it('captures the state after one and two backspaces', async () => {
+      it('reserves marks after pressing backspaces', async () => {
         using fixture = setupFixture()
         fixture.editor.use(defineMarkMode('focus'))
         const { n } = fixture
@@ -273,7 +272,10 @@ describe('defineMarkMode', () => {
         fixture.set(doc)
         fixture.view.focus()
 
+        expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(
+        )
         await userEvent.keyboard('{Backspace}')
+        // TODO: this is a bug. Pressing backspace should not delete **
         expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(
           `"text **bold▌*italic* text"`,
         )
@@ -283,7 +285,6 @@ describe('defineMarkMode', () => {
           `"text **bol▌*italic* text"`,
         )
       })
-    })
   })
 
   describe('hide mode', () => {

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -184,16 +184,16 @@ describe('defineMarkMode', () => {
       fixture.set(n.doc(n.paragraph('text **bold** <a>*italic* text')))
       fixture.view.focus()
 
-      expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(
+      expect(fixture.selectionSnapshot).toMatchInlineSnapshot(
         `"text **bold** ▌*italic* text"`,
       )
       await userEvent.keyboard('{Backspace}')
       // TODO: this is a bug. Pressing backspace should not delete **
-      expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(
+      expect(fixture.selectionSnapshot).toMatchInlineSnapshot(
         `"text **bold▌*italic* text"`,
       )
       await userEvent.keyboard('{Backspace}')
-      expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(
+      expect(fixture.selectionSnapshot).toMatchInlineSnapshot(
         `"text **bol▌*italic* text"`,
       )
     })

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -37,20 +37,7 @@ function clipboardText(fixture: Fixture): string | null {
 }
 
 describe('defineMarkMode', () => {
-  it('set data-mark-mode attribute', async () => {
-    async function expectDataMarkMode(markMode: MarkMode) {
-      using fixture = setupFixture()
-      const { n, editor } = fixture
-      editor.use(defineMarkMode(markMode))
-      const doc = n.doc(n.paragraph('a'))
-      fixture.set(doc)
-      await expect.element(pmRoot).toHaveAttribute('data-mark-mode', markMode)
-    }
 
-    await expectDataMarkMode('focus')
-    await expectDataMarkMode('hide')
-    await expectDataMarkMode('show')
-  })
 
   describe('focus mode', () => {
     it("sets data-mark-mode attribute to 'focus'", async () => {

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -842,10 +842,9 @@ describe('defineMarkMode', () => {
 
       expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`"text **bold** ▌*italic* text"`)
       await userEvent.keyboard('{Backspace}')
-      // TODO: this is a bug. Pressing backspace should not delete **
-      expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`"text **bold▌*italic* text"`)
+      expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`"text **bold**▌*italic* text"`)
       await userEvent.keyboard('{Backspace}')
-      expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`"text **bol▌*italic* text"`)
+      expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`"text **bold*▌*italic* text"`)
     })
   })
 

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -6,7 +6,6 @@ import { findText } from '../testing/find-text.ts'
 import { getSelectionSnapshot, setupFixture, type Fixture } from '../testing/index.ts'
 
 import { defineImage } from './image.ts'
-import type { MarkMode } from './mark-mode.ts'
 import { defineMarkMode } from './mark-mode.ts'
 
 const IMAGE_SVG =
@@ -37,8 +36,6 @@ function clipboardText(fixture: Fixture): string | null {
 }
 
 describe('defineMarkMode', () => {
-
-
   describe('focus mode', () => {
     it("sets data-mark-mode attribute to 'focus'", async () => {
       using fixture = setupFixture()
@@ -324,7 +321,6 @@ describe('defineMarkMode', () => {
       fixture.editor.use(defineMarkMode('show'))
       await expect.element(pmRoot).toHaveAttribute('data-mark-mode', 'show')
     })
-
 
     it('never reveals markers (syntax is always visible via CSS, not decorations)', async () => {
       using fixture = setupFixture()

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -5,8 +5,13 @@ import { page } from 'vitest/browser'
 import { findText } from '../testing/find-text.ts'
 import { setupFixture, type Fixture } from '../testing/index.ts'
 
+import { defineImage } from './image.ts'
 import type { MarkMode } from './mark-mode.ts'
 import { defineMarkMode } from './mark-mode.ts'
+
+const IMAGE_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10" fill="pink"/></svg>'
+const IMAGE_URL = `data:image/svg+xml;base64,${btoa(IMAGE_SVG)}`
 
 // A syntax span counts as revealed when the focus decoration (`.show`) lands
 // inside it, which is exactly what the production CSS keys off. One decoration
@@ -333,6 +338,36 @@ describe('defineMarkMode', () => {
       const doc = n.doc(n.paragraph('Hello **bold** end'))
       fixture.set(doc)
       expect(clipboardText(fixture)).toBe('Hello bold end')
+    })
+  })
+
+  describe('md-m-group structure', () => {
+    it('wraps a whole link in one group containing the anchor', async () => {
+      using fixture = setupFixture()
+      fixture.editor.use(defineMarkMode('focus'))
+      const { n } = fixture
+      fixture.set(n.doc(n.paragraph('see [docs](http://x.test)')))
+      const group = pmRoot.locate('.md-m-group[data-key="link_http://x.test"]')
+      await expect.element(group.getByRole('link')).toBeInTheDocument()
+    })
+
+    it('nests an italic group inside a bold group', async () => {
+      using fixture = setupFixture()
+      fixture.editor.use(defineMarkMode('focus'))
+      const { n } = fixture
+      fixture.set(n.doc(n.paragraph('**bold *italic* bold**')))
+      const bold = pmRoot.locate('.md-m-group[data-key="bold"]')
+      await expect.element(bold.locate('.md-m-group[data-key="italic"]')).toBeInTheDocument()
+    })
+
+    it('wraps an image in a group while its preview still renders', async () => {
+      using fixture = setupFixture()
+      fixture.editor.use(defineImage({ resolveImageUrl: () => IMAGE_URL }))
+      fixture.editor.use(defineMarkMode('focus'))
+      const { n } = fixture
+      fixture.set(n.doc(n.paragraph('![alt](pic.png)')))
+      const group = pmRoot.locate('.md-m-group[data-key="image_pic.png"]')
+      await expect.element(group.getByTestId('image-preview')).toBeVisible()
     })
   })
 })

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -339,7 +339,6 @@ describe('defineMarkMode', () => {
     })
   })
 
-
   describe('md-pack structure', () => {
     it('wraps a whole link in one pack containing the anchor', async () => {
       using fixture = setupFixture()

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -17,7 +17,7 @@ function renderHTML(mode: MarkMode, text: string): string {
   fixture.editor.use(defineMarkMode(mode))
   const { n } = fixture
   fixture.set(n.doc(n.paragraph(text)))
-  return formatHTML(fixture.view.dom.innerHTML)
+  return fixture.htmlSnapshot
 }
 
 /** Mount one paragraph in `mode` and assert what a full-document copy yields (`null` = no serializer). */
@@ -691,7 +691,7 @@ describe('defineMarkMode', () => {
       fixture.editor.use(defineMarkMode('focus'))
       const { n } = fixture
       fixture.set(n.doc(n.codeBlock({ language: '' }, '*not<a> italic*')))
-      expect(formatHTML(fixture.view.dom.innerHTML)).toMatchInlineSnapshot(`
+      expect(fixture.htmlSnapshot).toMatchInlineSnapshot(`
         "
         <pre>
           <code>
@@ -708,7 +708,7 @@ describe('defineMarkMode', () => {
       fixture.editor.use(defineMarkMode('focus'))
       const { n } = fixture
       fixture.set(n.doc(n.paragraph('![alt](pic.png)')))
-      expect(formatHTML(fixture.view.dom.innerHTML)).toMatchInlineSnapshot(`
+      expect(fixture.htmlSnapshot).toMatchInlineSnapshot(`
         "
         <p>
           <span
@@ -768,7 +768,7 @@ describe('defineMarkMode', () => {
       fixture.editor.use(defineMarkMode('focus'))
       const { n } = fixture
       fixture.set(n.doc(n.paragraph('**<a>alpha** one'), n.paragraph('beta two')))
-      expect(formatHTML(fixture.view.dom.innerHTML)).toMatchInlineSnapshot(`
+      expect(fixture.htmlSnapshot).toMatchInlineSnapshot(`
         "
         <p>
           <span
@@ -803,7 +803,7 @@ describe('defineMarkMode', () => {
       fixture.view.dispatch(
         fixture.state.tr.setSelection(TextSelection.create(fixture.doc, twoPos)),
       )
-      expect(formatHTML(fixture.view.dom.innerHTML)).toMatchInlineSnapshot(`
+      expect(fixture.htmlSnapshot).toMatchInlineSnapshot(`
         "
         <p>
           <span
@@ -841,16 +841,16 @@ describe('defineMarkMode', () => {
       fixture.set(n.doc(n.paragraph('text **bold** <a>*italic* text')))
       fixture.view.focus()
 
-      expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(
+      expect(fixture.selectionSnapshot).toMatchInlineSnapshot(
         `"text **bold** ▌*italic* text"`,
       )
       await userEvent.keyboard('{Backspace}')
       // TODO: this is a bug. Pressing backspace should not delete **
-      expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(
+      expect(fixture.selectionSnapshot).toMatchInlineSnapshot(
         `"text **bold▌*italic* text"`,
       )
       await userEvent.keyboard('{Backspace}')
-      expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(
+      expect(fixture.selectionSnapshot).toMatchInlineSnapshot(
         `"text **bol▌*italic* text"`,
       )
     })

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -1,9 +1,9 @@
 import { TextSelection } from '@prosekit/pm/state'
 import { describe, expect, it } from 'vitest'
-import { page } from 'vitest/browser'
+import { page, userEvent } from 'vitest/browser'
 
 import { findText } from '../testing/find-text.ts'
-import { setupFixture, type Fixture } from '../testing/index.ts'
+import { getSelectionSnapshot, setupFixture, type Fixture } from '../testing/index.ts'
 
 import { defineImage } from './image.ts'
 import type { MarkMode } from './mark-mode.ts'
@@ -368,6 +368,28 @@ describe('defineMarkMode', () => {
       fixture.set(n.doc(n.paragraph('![alt](pic.png)')))
       const group = pmRoot.locate('.md-m-group[data-key="image_pic.png"]')
       await expect.element(group.getByTestId('image-preview')).toBeVisible()
+    })
+  })
+
+  describe('focus mode backspace at a **bold** *italic* boundary', () => {
+    it('captures the state after one and two backspaces', async () => {
+      using fixture = setupFixture()
+      fixture.editor.use(defineMarkMode('focus'))
+      const { n } = fixture
+      // Caret sits between the space after `**bold**` and the `*italic*`.
+      const doc = n.doc(n.paragraph('text **bold** <a>*italic* text'))
+      fixture.set(doc)
+      fixture.view.focus()
+
+      await userEvent.keyboard('{Backspace}')
+      expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(
+        `"text **bold▌*italic* text"`,
+      )
+
+      await userEvent.keyboard('{Backspace}')
+      expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(
+        `"text **bol▌*italic* text"`,
+      )
     })
   })
 })

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -8,10 +8,17 @@ import { setupFixture, type Fixture } from '../testing/index.ts'
 import type { MarkMode } from './mark-mode.ts'
 import { defineMarkMode } from './mark-mode.ts'
 
-const revealedMarkers = page.locate('.ProseMirror span.show')
+// A syntax span counts as revealed when the focus decoration (`.show`) lands
+// inside it, which is exactly what the production CSS keys off. One decoration
+// now covers the whole `mdGroup`, so counting `.show` spans directly would also
+// count the unit's text; scoping to the hidden-syntax spans recovers the marker
+// count.
+const revealedMarkers = page.locate(
+  '.ProseMirror .md-mark:has(.show), .ProseMirror .md-link-uri:has(.show), .ProseMirror .md-image-source:has(.show)',
+)
 const pmRoot = page.locate('.ProseMirror')
 
-/** Asserts how many syntax markers are revealed (rendered as `.show` spans). */
+/** Asserts how many syntax markers are revealed (made visible by the `.show` decoration). */
 async function expectRevealedMarkers(count: number): Promise<void> {
   await expect.element(revealedMarkers).toHaveLength(count)
 }
@@ -180,6 +187,47 @@ describe('defineMarkMode', () => {
         fixture.state.tr.setSelection(TextSelection.create(fixture.doc, twoPos)),
       )
       await expectRevealedMarkers(0)
+    })
+
+    it('reveals the whole link when the cursor sits right after the closing )', async () => {
+      using fixture = setupFixture()
+      fixture.editor.use(defineMarkMode('focus'))
+      const { n } = fixture
+      const doc = n.doc(n.paragraph('ABC[link](https://example.com)<a>DEF'))
+      fixture.set(doc)
+      // `[`, `](`, the url and `)` all reveal; the trailing-edge caret used to
+      // reveal nothing because `)` carried no triggering mark.
+      await expectRevealedMarkers(4)
+    })
+
+    it('reveals the angle autolink when the cursor sits right after the closing >', async () => {
+      using fixture = setupFixture()
+      fixture.editor.use(defineMarkMode('focus'))
+      const { n } = fixture
+      const doc = n.doc(n.paragraph('a <https://example.com><a> b'))
+      fixture.set(doc)
+      await expectRevealedMarkers(2)
+    })
+
+    it('reveals the whole outer unit even when the cursor is in its bold-only region', async () => {
+      using fixture = setupFixture()
+      fixture.editor.use(defineMarkMode('focus'))
+      const { n } = fixture
+      // Cursor in the leading `bold`, outside the nested italic. The whole unit
+      // reveals: both `**` and both inner `*` (4 markers).
+      const doc = n.doc(n.paragraph('**bo<a>ld *italic* bold**'))
+      fixture.set(doc)
+      await expectRevealedMarkers(4)
+    })
+
+    it('reveals only the link the cursor is in, not its adjacent neighbor', async () => {
+      using fixture = setupFixture()
+      fixture.editor.use(defineMarkMode('focus'))
+      const { n } = fixture
+      const doc = n.doc(n.paragraph('[a<a>](x)[b](y)'))
+      fixture.set(doc)
+      // Only the first link's 4 markers; the abutting second link stays hidden.
+      await expectRevealedMarkers(4)
     })
   })
 

--- a/packages/core/src/extensions/mark-mode.ts
+++ b/packages/core/src/extensions/mark-mode.ts
@@ -80,12 +80,12 @@ function cleanCopySerializer(slice: Slice): string {
  * In focus mode, reveal the markdown syntax of the inline unit under the caret.
  *
  * Every revealable unit (emphasis, strong, code, strikethrough, link, autolink,
- * image) carries one `mdGroup` mark spanning it, so a single boundary-inclusive
+ * image) carries one `mdPack` mark spanning it, so a single boundary-inclusive
  * `getMarkRange` finds the unit, returning the outermost when units nest. One
  * decoration over its range flips the hidden punctuation/url/source visible via
  * the `.show` CSS rule. Because the range covers the whole unit, a caret at
  * either edge (e.g. right after a link's `)`) still reveals it. Wikilink and
- * `#tag` carry no `mdGroup`, so they never reveal.
+ * `#tag` carry no `mdPack`, so they never reveal.
  */
 function computeFocusDecorations(state: EditorState): DecorationSet {
   const { selection } = state
@@ -94,7 +94,7 @@ function computeFocusDecorations(state: EditorState): DecorationSet {
   const $pos = selection.$head
   if (!$pos.parent.isTextblock || $pos.parent.type.spec.code) return DecorationSet.empty
 
-  const range = getMarkRange($pos, getMarkType(state.schema, 'mdGroup'))
+  const range = getMarkRange($pos, getMarkType(state.schema, 'mdPack'))
   if (!range) return DecorationSet.empty
 
   return DecorationSet.create(state.doc, [

--- a/packages/core/src/extensions/mark-mode.ts
+++ b/packages/core/src/extensions/mark-mode.ts
@@ -1,5 +1,5 @@
-import { definePlugin, type PlainExtension } from '@prosekit/core'
-import type { EditorNode, Mark, Slice } from '@prosekit/pm/model'
+import { definePlugin, getMarkRange, getMarkType, type PlainExtension } from '@prosekit/core'
+import type { Mark, Slice } from '@prosekit/pm/model'
 import type { EditorState } from '@prosekit/pm/state'
 import { Plugin, PluginKey } from '@prosekit/pm/state'
 import { Decoration, DecorationSet } from '@prosekit/pm/view'
@@ -16,24 +16,6 @@ import type { MarkName } from './mark-names.ts'
  */
 export type MarkMode = 'hide' | 'focus' | 'show'
 
-// Marks whose presence at the caret reveals the surrounding markdown syntax in
-// focus mode.
-const REVEAL_TRIGGERING_MARKS: ReadonlySet<MarkName> = new Set<MarkName>([
-  'mdStrong',
-  'mdEm',
-  'mdCode',
-  'mdDel',
-  'mdLinkText',
-  'mdLinkUri',
-  // Reveals the raw `![alt](url)` when the caret is anywhere in the image
-  // source, including its plain alt text (which carries only mdImageSource).
-  'mdImageSource',
-])
-
-// The hidden marks individually decorated `.show` within a revealed range: the
-// syntax punctuation and the bare URL.
-const REVEALABLE_MARK_NAMES: ReadonlySet<MarkName> = new Set<MarkName>(['mdMark', 'mdLinkUri'])
-
 // Marks whose text is dropped from a clean clipboard copy, so copied markdown
 // omits the rendered syntax. Source marks are exempt (see `cleanCopySerializer`).
 const CLIPBOARD_STRIP_MARK_NAMES: ReadonlySet<MarkName> = new Set<MarkName>(['mdMark', 'mdLinkUri'])
@@ -43,20 +25,6 @@ const CLIPBOARD_STRIP_MARK_NAMES: ReadonlySet<MarkName> = new Set<MarkName>(['md
 // though their punctuation/url carry otherwise-stripped marks.
 const CLIPBOARD_KEEP_SOURCE_MARK_NAMES: ReadonlySet<MarkName> = new Set<MarkName>([
   'mdImageSource',
-  'mdWikilinkSource',
-])
-
-// Marks that make a text node part of a link; revealing one reveals the whole
-// link (text + URL) envelope.
-const LINK_BEARING_MARKS: ReadonlySet<MarkName> = new Set<MarkName>(['mdLinkText', 'mdLinkUri'])
-
-// Marks that carry their own inline formatting (not bare punctuation), used to
-// test link-envelope membership.
-const SYNTAX_BEARING_MARKS: ReadonlySet<MarkName> = new Set<MarkName>([
-  'mdStrong',
-  'mdEm',
-  'mdCode',
-  'mdDel',
   'mdWikilinkSource',
 ])
 
@@ -108,170 +76,28 @@ function cleanCopySerializer(slice: Slice): string {
   return blocks.join('\n')
 }
 
-function computeFocusDecorations(state: EditorState): DecorationSet | undefined {
-  const { $anchor, empty } = state.selection
-  if (!empty) return DecorationSet.empty
+/**
+ * In focus mode, reveal the markdown syntax of the inline unit under the caret.
+ *
+ * Every revealable unit (emphasis, strong, code, strikethrough, link, autolink,
+ * image) carries one `mdGroup` mark spanning it, so a single boundary-inclusive
+ * `getMarkRange` finds the unit, returning the outermost when units nest. One
+ * decoration over its range flips the hidden punctuation/url/source visible via
+ * the `.show` CSS rule. Because the range covers the whole unit, a caret at
+ * either edge (e.g. right after a link's `)`) still reveals it. Wikilink and
+ * `#tag` carry no `mdGroup`, so they never reveal.
+ */
+function computeFocusDecorations(state: EditorState): DecorationSet {
+  const { selection } = state
+  if (!selection.empty) return DecorationSet.empty
 
-  const textblock = $anchor.parent
-  if (!textblock.isTextblock) return undefined
+  const $pos = selection.$head
+  if (!$pos.parent.isTextblock || $pos.parent.type.spec.code) return DecorationSet.empty
 
-  const textblockStart = $anchor.start()
-  const parentOffset = $anchor.parentOffset
-  const triggeringMarks = collectAdjacentTriggeringMarks(textblock, parentOffset)
-  if (triggeringMarks.size === 0) return DecorationSet.empty
+  const range = getMarkRange($pos, getMarkType(state.schema, 'mdGroup'))
+  if (!range) return DecorationSet.empty
 
-  const ranges: Array<[number, number]> = []
-  const seen = new Set<string>()
-  let didLinkEnvelope = false
-  for (const mark of triggeringMarks) {
-    if (LINK_BEARING_MARKS.has(mark)) {
-      if (didLinkEnvelope) continue
-      didLinkEnvelope = true
-      expandLinkEnvelope(textblock, textblockStart, parentOffset, ranges, seen)
-    } else {
-      expandRangeAndCollect(textblock, textblockStart, mark, parentOffset, ranges, seen)
-    }
-  }
-  const decorations = ranges.map(([from, to]) => Decoration.inline(from, to, { class: 'show' }))
-  return DecorationSet.create(state.doc, decorations)
-}
-
-function collectAdjacentTriggeringMarks(
-  textblock: EditorNode,
-  parentOffset: number,
-): Set<MarkName> {
-  const out = new Set<MarkName>()
-  let pos = 0
-  textblock.forEach((child: EditorNode) => {
-    const childEnd = pos + child.nodeSize
-    if (parentOffset >= pos && parentOffset <= childEnd) {
-      for (const mark of child.marks) {
-        const name = mark.type.name as MarkName
-        if (REVEAL_TRIGGERING_MARKS.has(name)) out.add(name)
-      }
-    }
-    pos = childEnd
-  })
-  return out
-}
-
-function expandRangeAndCollect(
-  textblock: EditorNode,
-  textblockStart: number,
-  triggerMark: MarkName,
-  parentOffset: number,
-  out: Array<[number, number]>,
-  seen: Set<string>,
-): void {
-  let pos = textblockStart
-  let parentPos = 0
-  let runStart = -1
-  let runStartParent = -1
-  textblock.forEach((child: EditorNode) => {
-    const has = child.marks.some((m: Mark) => m.type.name === triggerMark)
-    if (has && runStart === -1) {
-      runStart = pos
-      runStartParent = parentPos
-    }
-    if (!has && runStart !== -1) {
-      if (parentOffset >= runStartParent && parentOffset <= parentPos) {
-        decorateMarkersInRange(textblock, textblockStart, runStart, pos, out, seen)
-      }
-      runStart = -1
-      runStartParent = -1
-    }
-    pos += child.nodeSize
-    parentPos += child.nodeSize
-  })
-  if (runStart !== -1) {
-    if (parentOffset >= runStartParent && parentOffset <= parentPos) {
-      decorateMarkersInRange(textblock, textblockStart, runStart, pos, out, seen)
-    }
-  }
-}
-
-function expandLinkEnvelope(
-  textblock: EditorNode,
-  textblockStart: number,
-  parentOffset: number,
-  out: Array<[number, number]>,
-  seen: Set<string>,
-): void {
-  const childCount = textblock.childCount
-  if (childCount === 0) return
-
-  let triggerIdx = -1
-  let pos = 0
-  for (let i = 0; i < childCount; i++) {
-    const child = textblock.child(i)
-    const childEnd = pos + child.nodeSize
-    if (parentOffset >= pos && parentOffset <= childEnd) {
-      if (child.marks.some((m: Mark) => LINK_BEARING_MARKS.has(m.type.name as MarkName))) {
-        triggerIdx = i
-        break
-      }
-    }
-    pos = childEnd
-  }
-  if (triggerIdx === -1) return
-
-  let left = triggerIdx
-  while (left > 0 && isLinkEnvelopeMember(textblock.child(left - 1))) {
-    left--
-  }
-  let right = triggerIdx
-  while (right < childCount - 1 && isLinkEnvelopeMember(textblock.child(right + 1))) {
-    right++
-  }
-
-  let envStart = textblockStart
-  for (let i = 0; i < left; i++) envStart += textblock.child(i).nodeSize
-  let envEnd = envStart
-  for (let i = left; i <= right; i++) envEnd += textblock.child(i).nodeSize
-
-  decorateMarkersInRange(textblock, textblockStart, envStart, envEnd, out, seen)
-}
-
-function isLinkEnvelopeMember(child: EditorNode): boolean {
-  let hasMdMark = false
-  let hasLinkMark = false
-  let hasOtherSemantic = false
-  for (const mark of child.marks) {
-    const name = mark.type.name as MarkName
-    if (name === 'mdMark') hasMdMark = true
-    else if (LINK_BEARING_MARKS.has(name)) hasLinkMark = true
-    else if (SYNTAX_BEARING_MARKS.has(name)) hasOtherSemantic = true
-  }
-  if (hasLinkMark) return true
-  if (hasMdMark && !hasOtherSemantic) return true
-  return false
-}
-
-function decorateMarkersInRange(
-  textblock: EditorNode,
-  textblockStart: number,
-  rangeFrom: number,
-  rangeTo: number,
-  out: Array<[number, number]>,
-  seen: Set<string>,
-): void {
-  let pos = textblockStart
-  textblock.forEach((child: EditorNode) => {
-    const childStart = pos
-    const childEnd = pos + child.nodeSize
-    if (childStart >= rangeFrom && childEnd <= rangeTo) {
-      for (const mark of child.marks) {
-        const name = mark.type.name as MarkName
-        if (REVEALABLE_MARK_NAMES.has(name)) {
-          const key = `${childStart}_${childEnd}`
-          if (!seen.has(key)) {
-            seen.add(key)
-            out.push([childStart, childEnd])
-          }
-          break
-        }
-      }
-    }
-    pos = childEnd
-  })
+  return DecorationSet.create(state.doc, [
+    Decoration.inline(range.from, range.to, { class: 'show' }),
+  ])
 }

--- a/packages/core/src/extensions/mark-mode.ts
+++ b/packages/core/src/extensions/mark-mode.ts
@@ -92,9 +92,10 @@ function computeFocusDecorations(state: EditorState): DecorationSet {
   if (!selection.empty) return DecorationSet.empty
 
   const $pos = selection.$head
-  if (!$pos.parent.isTextblock || $pos.parent.type.spec.code) return DecorationSet.empty
+  const { parent } = $pos
+  if (! parent.isTextblock ||  parent.type.spec.code) return DecorationSet.empty
 
-  const range = getMarkRange($pos, getMarkType(state.schema, 'mdPack'))
+  const range = getMarkRange($pos, getMarkType(state.schema, 'mdPack' satisfies MarkName))
   if (!range) return DecorationSet.empty
 
   return DecorationSet.create(state.doc, [

--- a/packages/core/src/extensions/mark-mode.ts
+++ b/packages/core/src/extensions/mark-mode.ts
@@ -93,7 +93,7 @@ function computeFocusDecorations(state: EditorState): DecorationSet {
 
   const $pos = selection.$head
   const { parent } = $pos
-  if (! parent.isTextblock ||  parent.type.spec.code) return DecorationSet.empty
+  if (!parent.isTextblock || parent.type.spec.code) return DecorationSet.empty
 
   const range = getMarkRange($pos, getMarkType(state.schema, 'mdPack' satisfies MarkName))
   if (!range) return DecorationSet.empty

--- a/packages/core/src/extensions/mark-names.ts
+++ b/packages/core/src/extensions/mark-names.ts
@@ -11,6 +11,7 @@ export const MARK_NAMES = [
   'mdTag',
   'mdWikilinkSource',
   'mdWikilinkView',
+  'mdGroup',
 ] as const
 
 export type MarkName = (typeof MARK_NAMES)[number]

--- a/packages/core/src/extensions/mark-names.ts
+++ b/packages/core/src/extensions/mark-names.ts
@@ -11,7 +11,7 @@ export const MARK_NAMES = [
   'mdTag',
   'mdWikilinkSource',
   'mdWikilinkView',
-  'mdGroup',
+  'mdPack',
 ] as const
 
 export type MarkName = (typeof MARK_NAMES)[number]

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -393,17 +393,12 @@
   display: contents;
 }
 
-/* Syntax hidden as a unit in hide and focus modes. Covers the punctuation
- * (`md-mark`), the link/image URL (`md-link-uri`), and the whole image/wikilink
- * source whose rendered preview/label stands in for it (incl. the image alt
- * text). In focus mode all but the atomic wikilink source reveal near the caret
- * via the `.show` decoration. */
 .ProseMirror[data-mark-mode='hide'] {
   .md-mark,
   .md-link-uri,
   .md-image-source,
   .md-wikilink-source {
-    display: none;
+      display: none;
   }
 }
 

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -415,21 +415,14 @@
   .md-mark,
   .md-link-uri,
   .md-image-source {
-    /*display: none;*/
-
     overflow: hidden;
-    visibility: hidden;
-    letter-spacing: -2em;
     display: inline-block;
     vertical-align: bottom;
 
-    &:has(.show) {
-      /*display: inline;*/
+    letter-spacing: -2em;
 
+    &:has(.show) {
       letter-spacing: 0;
-      width: auto;
-      height: auto;
-      visibility: visible;
     }
   }
 }

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -398,18 +398,20 @@
  * source whose rendered preview/label stands in for it (incl. the image alt
  * text). In focus mode all but the atomic wikilink source reveal near the caret
  * via the `.show` decoration. */
-.ProseMirror[data-mark-mode='hide'] .md-mark,
-.ProseMirror[data-mark-mode='hide'] .md-link-uri,
-.ProseMirror[data-mark-mode='hide'] .md-image-source,
-.ProseMirror[data-mark-mode='hide'] .md-wikilink-source,
-.ProseMirror[data-mark-mode='focus'] .md-mark,
-.ProseMirror[data-mark-mode='focus'] .md-link-uri,
-.ProseMirror[data-mark-mode='focus'] .md-image-source,
-.ProseMirror[data-mark-mode='focus'] .md-wikilink-source {
-  display: none;
+.ProseMirror[data-mark-mode='hide'] {
+    .md-mark, .md-link-uri, .md-image-source, .md-wikilink-source {
+          display: none;
+    }
 }
-.ProseMirror[data-mark-mode='focus'] .md-mark:has(.show),
-.ProseMirror[data-mark-mode='focus'] .md-link-uri:has(.show),
-.ProseMirror[data-mark-mode='focus'] .md-image-source:has(.show) {
-  display: inline;
+
+.ProseMirror[data-mark-mode='focus'] {
+    .md-mark, .md-link-uri, .md-image-source, .md-wikilink-source {
+        display: none;
+    }
+
+    .md-mark, .md-link-uri, .md-image-source {
+        &:has(.show) {
+            display: inline;
+        }
+    }
 }

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -398,7 +398,7 @@
   .md-link-uri,
   .md-image-source,
   .md-wikilink-source {
-      display: none;
+    display: none;
   }
 }
 

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -399,19 +399,37 @@
  * text). In focus mode all but the atomic wikilink source reveal near the caret
  * via the `.show` decoration. */
 .ProseMirror[data-mark-mode='hide'] {
-    .md-mark, .md-link-uri, .md-image-source, .md-wikilink-source {
-          display: none;
-    }
+  .md-mark,
+  .md-link-uri,
+  .md-image-source,
+  .md-wikilink-source {
+    display: none;
+  }
 }
 
 .ProseMirror[data-mark-mode='focus'] {
-    .md-mark, .md-link-uri, .md-image-source, .md-wikilink-source {
-        display: none;
-    }
+  .md-wikilink-source {
+    display: none;
+  }
 
-    .md-mark, .md-link-uri, .md-image-source {
-        &:has(.show) {
-            display: inline;
-        }
+  .md-mark,
+  .md-link-uri,
+  .md-image-source {
+    /*display: none;*/
+
+    overflow: hidden;
+    visibility: hidden;
+    letter-spacing: -2em;
+    display: inline-block;
+    vertical-align: bottom;
+
+    &:has(.show) {
+      /*display: inline;*/
+
+      letter-spacing: 0;
+      width: auto;
+      height: auto;
+      visibility: visible;
     }
+  }
 }

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -385,11 +385,11 @@
   opacity: 0.7;
 }
 
-/* The mdGroup mark wraps a whole inline unit so focus mode can reveal it with one
+/* The mdPack mark wraps a whole inline unit so focus mode can reveal it with one
  * range lookup. It is layout-only: `display: contents` keeps it out of the box
  * tree, so it never affects flow or an inner image mark view, while still being a
  * real element a `.show` decoration can land inside. */
-.ProseMirror .md-m-group {
+.ProseMirror .md-pack {
   display: contents;
 }
 

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -385,6 +385,14 @@
   opacity: 0.7;
 }
 
+/* The mdGroup mark wraps a whole inline unit so focus mode can reveal it with one
+ * range lookup. It is layout-only: `display: contents` keeps it out of the box
+ * tree, so it never affects flow or an inner image mark view, while still being a
+ * real element a `.show` decoration can land inside. */
+.ProseMirror .md-m-group {
+  display: contents;
+}
+
 /* Syntax hidden as a unit in hide and focus modes. Covers the punctuation
  * (`md-mark`), the link/image URL (`md-link-uri`), and the whole image/wikilink
  * source whose rendered preview/label stands in for it (incl. the image alt

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -6,6 +6,8 @@ import { createTestEditor } from '@prosekit/core/test'
 import type { EditorNode } from '@prosekit/pm/model'
 
 import { defineEditorExtension } from '../extensions/extension.ts'
+import { getSelectionSnapshot } from './selection-snapshot.ts'
+import   { formatHTML } from 'diffable-html-snapshot'
 
 export { getSelectionSnapshot } from './selection-snapshot.ts'
 export { setCaret, traceKeySelection, traceKeyAt } from './caret.ts'
@@ -56,6 +58,14 @@ export function setupFixture({ mount = true }: SetupFixtureOptions = {}) {
 
     get dom() {
       return editor.view.dom
+    },
+
+    get selectionSnapshot() {
+      return getSelectionSnapshot(editor.view.state)
+    },
+
+    get htmlSnapshot() {
+      return formatHTML(editor.view.dom.innerHTML)
     },
 
     set(doc: EditorNode) {

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -4,10 +4,11 @@ import './locator.ts'
 
 import { createTestEditor } from '@prosekit/core/test'
 import type { EditorNode } from '@prosekit/pm/model'
+import { formatHTML } from 'diffable-html-snapshot'
 
 import { defineEditorExtension } from '../extensions/extension.ts'
+
 import { getSelectionSnapshot } from './selection-snapshot.ts'
-import   { formatHTML } from 'diffable-html-snapshot'
 
 export { getSelectionSnapshot } from './selection-snapshot.ts'
 export { setCaret, traceKeySelection, traceKeyAt } from './caret.ts'


### PR DESCRIPTION
Wrap every revealable inline unit (emphasis, strong, code, strikethrough, link, autolink, image) in one content-keyed `mdGroup` mark in the walk, so focus-mode reveal collapses from four mark-name sets and five range-stitching helpers to a single boundary-inclusive `getMarkRange` lookup. This also fixes the caret-after-`)` (and after-`>`) bug where a link/autolink would not reveal at its trailing edge. Behavior change: placing the caret anywhere inside a nested unit now reveals the whole outer unit (see plan §8.1).