### PR TITLE
test: enable clipboard tests on Safari

### DIFF
--- a/packages/react/src/components/code-block-view.test.tsx
+++ b/packages/react/src/components/code-block-view.test.tsx
@@ -1,6 +1,5 @@
 import '../testing/index.ts'
 
-import { isSafari } from '@meowdown/vitest/helpers'
 import { createRef } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
@@ -70,10 +69,7 @@ describe('code block language selector', () => {
     })
   })
 
-  it.skipIf(
-    // Safari doesn't support `navigator.clipboard.readText()`
-    isSafari(),
-  )('copies the code block contents to the clipboard', async () => {
+  it('copies the code block contents to the clipboard', async () => {
     await render(<ProseKitEditor initialMarkdown={CODE_BLOCK_MD} />)
     await expect.element(copyButton).toBeInTheDocument()
 

--- a/packages/vitest/src/config.ts
+++ b/packages/vitest/src/config.ts
@@ -25,8 +25,6 @@ export function defineSharedConfig() {
         ? ['clipboard-read']
         : undefined
 
-  console.error('[meowdown][debug] clipboardPermissions', browserName, clipboardPermissions)
-
   return defineProject({
     plugins: [playwrightCommands()],
     oxc:

--- a/packages/vitest/src/config.ts
+++ b/packages/vitest/src/config.ts
@@ -16,6 +16,17 @@ export function defineSharedConfig() {
     return 'chromium'
   })()
 
+  // WebKit and Chromium reject navigator.clipboard.readText() unless 'clipboard-read'
+  // is granted. Chromium also needs 'clipboard-write'. Firefox reads without a grant.
+  const clipboardPermissions =
+    browserName === 'chromium'
+      ? ['clipboard-read', 'clipboard-write']
+      : browserName === 'webkit'
+        ? ['clipboard-read']
+        : undefined
+
+  console.error('[meowdown][debug] clipboardPermissions', browserName, clipboardPermissions)
+
   return defineProject({
     plugins: [playwrightCommands()],
     oxc:
@@ -39,8 +50,7 @@ export function defineSharedConfig() {
             reducedMotion: 'reduce',
             hasTouch: true,
             // A list of permissions to grant to all pages in this context. See https://playwright.dev/docs/api/class-browsercontext#browser-context-grant-permissions
-            permissions:
-              browserName === 'chromium' ? ['clipboard-read', 'clipboard-write'] : undefined,
+            permissions: clipboardPermissions,
           },
         }),
         headless: true,


### PR DESCRIPTION
Blocked by https://github.com/vitest-dev/vitest/issues/10623 