### PR TITLE
fix(core): preserve setext heading underline

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -28,7 +28,7 @@ Heading shortcuts toggle the current block to a heading of that level (or back t
 
 ## Round-trip fidelity
 
-`checkRoundTrip(markdown)` reports how faithfully markdown survives a parse-then-serialize round trip: `'exact'` (byte-identical modulo the trailing newline), `'normalizing'` (same non-blank lines, only blank-line layout differs), or `'lossy'` (a non-blank line changed, e.g. setext headings or raw HTML blocks). Hosts that keep markdown on disk can gate saves on it, opening lossy files read-only so a save never rewrites content.
+`checkRoundTrip(markdown)` reports how faithfully markdown survives a parse-then-serialize round trip: `'exact'` (byte-identical modulo the trailing newline), `'normalizing'` (same non-blank lines, only blank-line layout differs), or `'lossy'` (a non-blank line changed, e.g. a closing ATX hash sequence or unaligned table columns). Hosts that keep markdown on disk can gate saves on it, opening lossy files read-only so a save never rewrites content.
 
 ## Styling
 

--- a/packages/core/src/converters/check-roundtrip.test.ts
+++ b/packages/core/src/converters/check-roundtrip.test.ts
@@ -30,6 +30,10 @@ describe('checkRoundTrip', () => {
       | --- | --- | --- |
       |  | b |  |
     `,
+    dedent`
+      Hello
+      =====
+    `, // setext heading keeps its text and underline length
   ])('reports exact for %j', (markdown) => {
     expect(checkRoundTrip(markdown)).toBe('exact')
   })
@@ -42,10 +46,7 @@ describe('checkRoundTrip', () => {
   })
 
   it.each([
-    dedent`
-      Hello
-      =====
-    `, // setext heading
+    '# Hello #', // a closing ATX hash sequence is dropped
   ])('reports lossy for %j', (markdown) => {
     expect(checkRoundTrip(markdown)).toBe('lossy')
   })

--- a/packages/core/src/converters/md-to-pm.test.ts
+++ b/packages/core/src/converters/md-to-pm.test.ts
@@ -27,7 +27,7 @@ describe('markdownToDoc', () => {
       content: [
         {
           type: 'heading',
-          attrs: { level: 1 },
+          attrs: { level: 1, setextUnderline: null },
           content: [{ type: 'text', text: 'Hello' }],
         },
       ],
@@ -517,7 +517,7 @@ describe('markdownToDoc', () => {
     expect(markdownToDoc('# ').toJSON()).toEqual({
       type: 'doc',
       attrs: { frontmatter: null },
-      content: [{ type: 'heading', attrs: { level: 1 } }],
+      content: [{ type: 'heading', attrs: { level: 1, setextUnderline: null } }],
     })
   })
 
@@ -540,12 +540,30 @@ describe('markdownToDoc', () => {
     })
   })
 
-  it.fails('keeps setext text', () => {
+  it('keeps setext text', () => {
     expect(markdownToDoc('Setext1\n===').toJSON()).toEqual({
       type: 'doc',
       attrs: { frontmatter: null },
       content: [
-        { type: 'heading', attrs: { level: 1 }, content: [{ type: 'text', text: 'Setext1' }] },
+        {
+          type: 'heading',
+          attrs: { level: 1, setextUnderline: 3 },
+          content: [{ type: 'text', text: 'Setext1' }],
+        },
+      ],
+    })
+  })
+
+  it('keeps setext text (level 2)', () => {
+    expect(markdownToDoc('Setext2\n---').toJSON()).toEqual({
+      type: 'doc',
+      attrs: { frontmatter: null },
+      content: [
+        {
+          type: 'heading',
+          attrs: { level: 2, setextUnderline: 3 },
+          content: [{ type: 'text', text: 'Setext2' }],
+        },
       ],
     })
   })
@@ -595,7 +613,11 @@ describe('markdownToDoc', () => {
       type: 'doc',
       attrs: { frontmatter: 'title: x\ntags: [a, b]' },
       content: [
-        { type: 'heading', attrs: { level: 1 }, content: [{ type: 'text', text: 'heading' }] },
+        {
+          type: 'heading',
+          attrs: { level: 1, setextUnderline: null },
+          content: [{ type: 'text', text: 'heading' }],
+        },
       ],
     })
   })

--- a/packages/core/src/converters/md-to-pm.ts
+++ b/packages/core/src/converters/md-to-pm.ts
@@ -8,6 +8,8 @@ import { gfmBlockOnlyParser } from '../lezer/parser.ts'
 import {
   CHAR_ASTERISK,
   CHAR_DOT,
+  CHAR_EQUAL,
+  CHAR_HYPHEN_MINUS,
   CHAR_LOWERCASE_X,
   CHAR_PLUS,
   CHAR_RIGHT_PARENTHESIS,
@@ -89,21 +91,21 @@ function convertBlock(
 ): ProseMirrorNode[] {
   switch (cursor.type.id) {
     case LEZER_NODE_IDS.ATXHeading1:
-      return [convertHeading(nodes, cursor, text, 1)]
+      return [convertHeading(nodes, cursor, text, 1, false)]
     case LEZER_NODE_IDS.ATXHeading2:
-      return [convertHeading(nodes, cursor, text, 2)]
+      return [convertHeading(nodes, cursor, text, 2, false)]
     case LEZER_NODE_IDS.ATXHeading3:
-      return [convertHeading(nodes, cursor, text, 3)]
+      return [convertHeading(nodes, cursor, text, 3, false)]
     case LEZER_NODE_IDS.ATXHeading4:
-      return [convertHeading(nodes, cursor, text, 4)]
+      return [convertHeading(nodes, cursor, text, 4, false)]
     case LEZER_NODE_IDS.ATXHeading5:
-      return [convertHeading(nodes, cursor, text, 5)]
+      return [convertHeading(nodes, cursor, text, 5, false)]
     case LEZER_NODE_IDS.ATXHeading6:
-      return [convertHeading(nodes, cursor, text, 6)]
+      return [convertHeading(nodes, cursor, text, 6, false)]
     case LEZER_NODE_IDS.SetextHeading1:
-      return [convertHeading(nodes, cursor, text, 1)]
+      return [convertHeading(nodes, cursor, text, 1, true)]
     case LEZER_NODE_IDS.SetextHeading2:
-      return [convertHeading(nodes, cursor, text, 2)]
+      return [convertHeading(nodes, cursor, text, 2, true)]
     case LEZER_NODE_IDS.Paragraph:
       return [convertParagraph(nodes, cursor, text)]
     case LEZER_NODE_IDS.HTMLBlock:
@@ -147,29 +149,55 @@ function convertHeading(
   cursor: TreeCursor,
   text: string,
   level: number,
+  isSetext: boolean,
 ): ProseMirrorNode {
   // Strip the opening HeaderMark (the "#" run + following space) and any
-  // optional closing HeaderMark used in "# foo #" style.
+  // optional closing HeaderMark used in "# foo #" style. A setext heading's
+  // only HeaderMark is the trailing underline, so guard on the mark starting
+  // at the heading's left edge before treating it as the opening mark.
+  const headingFrom = cursor.from
   let contentStart = cursor.from
   let contentEnd = cursor.to
+  let underlineFrom = -1
+  let underlineTo = -1
   if (cursor.firstChild()) {
-    if (cursor.type.id === LEZER_NODE_IDS.HeaderMark) {
+    if (cursor.type.id === LEZER_NODE_IDS.HeaderMark && cursor.from === headingFrom) {
       contentStart = cursor.to
     }
     let lastId = -1
     let lastFrom = -1
+    let lastTo = -1
     do {
       lastId = cursor.type.id
       lastFrom = cursor.from
+      lastTo = cursor.to
     } while (cursor.nextSibling())
     if (lastId === LEZER_NODE_IDS.HeaderMark && lastFrom > contentStart) {
       contentEnd = lastFrom
+      underlineFrom = lastFrom
+      underlineTo = lastTo
     }
     cursor.parent()
   }
 
   const content = text.slice(contentStart, contentEnd).trim()
-  return nodes.heading({ level }, content)
+  // CommonMark setext underlines may be any length; keep the source count so
+  // the round-trip is lossless. Fall back to 1 if lezer reported no run.
+  const setextUnderline = isSetext
+    ? countUnderlineChars(text, underlineFrom, underlineTo) || 1
+    : null
+  return nodes.heading({ level, setextUnderline }, content)
+}
+
+/** Count the `=` / `-` characters in a setext underline run. */
+function countUnderlineChars(text: string, from: number, to: number): number {
+  if (from < 0) return 0
+  let count = 0
+  for (let i = from; i < to; i++) {
+    const code = text.charCodeAt(i)
+    if (code === CHAR_EQUAL || code === CHAR_HYPHEN_MINUS) count++
+  }
+  return count
 }
 
 function convertParagraph(

--- a/packages/core/src/converters/pm-to-md.test.ts
+++ b/packages/core/src/converters/pm-to-md.test.ts
@@ -34,6 +34,33 @@ describe('docToMarkdown', () => {
     expect(markdown).toBe('###### Level 6\n')
   })
 
+  it('emits a setext level-1 heading', () => {
+    const doc = n.doc(n.heading({ level: 1, setextUnderline: 3 }, 'Title'))
+    expect(docToMarkdown(doc)).toBe('Title\n===\n')
+  })
+
+  it('emits a setext level-2 heading', () => {
+    const doc = n.doc(n.heading({ level: 2, setextUnderline: 3 }, 'Title'))
+    expect(docToMarkdown(doc)).toBe('Title\n---\n')
+  })
+
+  it('keeps the setext underline length', () => {
+    const long = n.doc(n.heading({ level: 1, setextUnderline: 9 }, 'Title'))
+    expect(docToMarkdown(long)).toBe('Title\n=========\n')
+    const short = n.doc(n.heading({ level: 2, setextUnderline: 1 }, 'Title'))
+    expect(docToMarkdown(short)).toBe('Title\n-\n')
+  })
+
+  it('emits a setext heading deeper than level 2 as ATX', () => {
+    const doc = n.doc(n.heading({ level: 3, setextUnderline: 3 }, 'Title'))
+    expect(docToMarkdown(doc)).toBe('### Title\n')
+  })
+
+  it('emits an empty setext heading as ATX', () => {
+    const doc = n.doc(n.heading({ level: 1, setextUnderline: 3 }))
+    expect(docToMarkdown(doc)).toBe('#\n')
+  })
+
   it('keeps a blockquote', () => {
     const doc = n.doc(n.blockquote(n.paragraph('quoted text')))
     const markdown = docToMarkdown(doc)

--- a/packages/core/src/converters/pm-to-md.ts
+++ b/packages/core/src/converters/pm-to-md.ts
@@ -1,8 +1,8 @@
 import type { CodeBlockAttrs } from '@prosekit/extensions/code-block'
-import type { HeadingAttrs } from '@prosekit/extensions/heading'
 import type { ProseMirrorNode } from '@prosekit/pm/model'
 
 import type { Frontmatter } from '../extensions/frontmatter.ts'
+import type { MeowdownHeadingAttrs } from '../extensions/heading.ts'
 import type { MeowdownListAttrs } from '../extensions/list.ts'
 import type { NodeName } from '../extensions/node-names.ts'
 import { longestBacktickRun } from '../utils/backticks.ts'
@@ -56,6 +56,23 @@ const HEADING_PREFIX: ReadonlyArray<string> = [
   '##### ',
   '###### ',
 ]
+
+function emitHeading(node: ProseMirrorNode, out: MdOut): void {
+  const attrs = node.attrs as MeowdownHeadingAttrs
+  const underline = attrs.setextUnderline
+  // Setext exists only for levels 1-2 and needs a content line to underline;
+  // an empty or deeper heading falls back to ATX.
+  if (underline != null && node.content.size > 0 && attrs.level <= 2) {
+    emitInlineChildren(node, out)
+    const underlineChar = attrs.level === 1 ? '=' : '-'
+    out.write('\n' + underlineChar.repeat(Math.max(1, underline)))
+    out.closeBlock()
+    return
+  }
+  out.write(HEADING_PREFIX[attrs.level] ?? '# ')
+  emitInlineChildren(node, out)
+  out.closeBlock()
+}
 
 // ─────────────────────────────────────────────────────────────────────
 // Output buffer
@@ -179,13 +196,9 @@ function emit(node: ProseMirrorNode, out: MdOut): void {
       emitInlineChildren(node, out)
       out.closeBlock()
       return
-    case 'heading': {
-      const attrs = node.attrs as HeadingAttrs
-      out.write(HEADING_PREFIX[attrs.level] ?? '# ')
-      emitInlineChildren(node, out)
-      out.closeBlock()
+    case 'heading':
+      emitHeading(node, out)
       return
-    }
     case 'blockquote':
       out.withPrefix('> ', '> ', () => emitBlockChildren(node, out))
       out.closeBlock()

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -212,12 +212,28 @@ describe('headings', () => {
     expect(roundtrip('# ')).toBe('# \n')
   })
 
-  it.fails('keeps setext text (level 1)', () => {
+  it('keeps setext text (level 1)', () => {
     expect(roundtrip('Setext1\n===')).toBe('Setext1\n===\n')
   })
 
-  it.fails('keeps setext text (level 2)', () => {
+  it('keeps setext text (level 2)', () => {
     expect(roundtrip('Setext2\n---')).toBe('Setext2\n---\n')
+  })
+
+  it('keeps setext roundtrip stable', () => {
+    expect(roundtrip('Setext1\n===\n')).toBe('Setext1\n===\n')
+    expect(roundtrip('Setext2\n---\n')).toBe('Setext2\n---\n')
+  })
+
+  it('keeps the setext underline length', () => {
+    // CommonMark allows any underline length, so it must survive a round-trip.
+    expect(roundtrip('Foo\n=========')).toBe('Foo\n=========\n')
+    expect(roundtrip('Foo\n-------------------------')).toBe('Foo\n-------------------------\n')
+    expect(roundtrip('Foo\n=')).toBe('Foo\n=\n')
+  })
+
+  it('keeps multi-line setext content', () => {
+    expect(roundtrip('Foo bar\nbaz qux\n===')).toBe('Foo bar\nbaz qux\n===\n')
   })
 })
 

--- a/packages/core/src/converters/sample-content.ts
+++ b/packages/core/src/converters/sample-content.ts
@@ -6,7 +6,7 @@ export const sampleContent: NodeJSON = {
   content: [
     {
       type: 'heading',
-      attrs: { level: 1 },
+      attrs: { level: 1, setextUnderline: null },
       content: [{ type: 'text', text: 'Meowdown' }],
     },
     {
@@ -29,17 +29,17 @@ export const sampleContent: NodeJSON = {
     },
     {
       type: 'heading',
-      attrs: { level: 2 },
+      attrs: { level: 2, setextUnderline: null },
       content: [{ type: 'text', text: 'Headings' }],
     },
     {
       type: 'heading',
-      attrs: { level: 3 },
+      attrs: { level: 3, setextUnderline: null },
       content: [{ type: 'text', text: 'This is an H3' }],
     },
     {
       type: 'heading',
-      attrs: { level: 2 },
+      attrs: { level: 2, setextUnderline: null },
       content: [{ type: 'text', text: 'Blockquote' }],
     },
     {
@@ -58,7 +58,7 @@ export const sampleContent: NodeJSON = {
     },
     {
       type: 'heading',
-      attrs: { level: 2 },
+      attrs: { level: 2, setextUnderline: null },
       content: [{ type: 'text', text: 'Bullet list' }],
     },
     {
@@ -114,7 +114,7 @@ export const sampleContent: NodeJSON = {
     },
     {
       type: 'heading',
-      attrs: { level: 2 },
+      attrs: { level: 2, setextUnderline: null },
       content: [{ type: 'text', text: 'Ordered list' }],
     },
     {
@@ -153,7 +153,7 @@ export const sampleContent: NodeJSON = {
     },
     {
       type: 'heading',
-      attrs: { level: 2 },
+      attrs: { level: 2, setextUnderline: null },
       content: [{ type: 'text', text: 'Code block' }],
     },
     {
@@ -168,7 +168,7 @@ export const sampleContent: NodeJSON = {
     },
     {
       type: 'heading',
-      attrs: { level: 2 },
+      attrs: { level: 2, setextUnderline: null },
       content: [{ type: 'text', text: 'Table' }],
     },
     {

--- a/packages/core/src/extensions/extension.test.ts
+++ b/packages/core/src/extensions/extension.test.ts
@@ -33,6 +33,7 @@ describe('defineEditorExtension', () => {
           {
             "attrs": {
               "level": 1,
+              "setextUnderline": null,
             },
             "content": [
               {

--- a/packages/core/src/extensions/heading.ts
+++ b/packages/core/src/extensions/heading.ts
@@ -1,20 +1,55 @@
 import {
   defineKeymap,
+  defineNodeAttr,
   isAtBlockStart,
   toggleNode,
   union,
   unsetBlockType,
   withSkipCodeBlock,
+  type Extension,
   type PlainExtension,
 } from '@prosekit/core'
 import {
   defineHeadingCommands,
   defineHeadingInputRule,
   defineHeadingSpec,
+  type HeadingAttrs,
 } from '@prosekit/extensions/heading'
 import type { Command } from '@prosekit/pm/state'
 
 import type { NodeName } from './node-names.ts'
+
+export interface MeowdownHeadingAttrs extends HeadingAttrs {
+  /**
+   * For a setext heading, the number of underline characters (`=` for level 1,
+   * `-` for level 2) that followed the text in the source. CommonMark allows
+   * any underline length, so keeping the count makes the round-trip lossless.
+   * `null` (the default) marks an ATX heading (`# foo`); only levels 1 and 2
+   * can be setext, and the level alone decides the underline character.
+   */
+  setextUnderline?: number | null
+}
+
+type SetextUnderlineExtension = Extension<{
+  Nodes: { heading: { setextUnderline?: number | null } }
+}>
+
+function defineSetextUnderlineAttr(): SetextUnderlineExtension {
+  return defineNodeAttr<'heading', 'setextUnderline', number | null>({
+    type: 'heading' satisfies NodeName,
+    attr: 'setextUnderline',
+    default: null,
+    // A heading split or created in the editor is ATX; only a parsed setext
+    // heading carries a length, which must survive an editor DOM re-parse.
+    toDOM: (value) => (value != null ? ['data-setext-underline', String(value)] : null),
+    parseDOM: (node) => {
+      const raw = node.getAttribute('data-setext-underline')
+      if (raw == null) return null
+      const length = Number.parseInt(raw, 10)
+      return Number.isSafeInteger(length) && length > 0 ? length : null
+    },
+  })
+}
 
 function toggleHeading(level: number): Command {
   return withSkipCodeBlock(toggleNode({ type: 'heading' satisfies NodeName, attrs: { level } }))
@@ -43,6 +78,7 @@ function defineHeadingKeymap(): PlainExtension {
 export function defineHeading() {
   return union(
     defineHeadingSpec(),
+    defineSetextUnderlineAttr(),
     defineHeadingInputRule(),
     defineHeadingCommands(),
     defineHeadingKeymap(),


### PR DESCRIPTION
Setext headings (`Foo\n===`) previously parsed to an empty heading, dropping all text; the underline was also normalized so any-length underlines were lost. `convertHeading` now keeps the text and records the underline length in a new `setextUnderline` heading attr, and the serializer re-emits the exact `=`/`-` run, so setext headings round-trip byte-for-byte per CommonMark (which allows any underline length). ATX headings are unchanged (`setextUnderline: null`); empty or level 3-6 headings fall back to ATX.