### PR TITLE
fix(core): avoid double-escaping pipes in table cells

### DIFF
--- a/packages/core/src/converters/md-to-pm.test.ts
+++ b/packages/core/src/converters/md-to-pm.test.ts
@@ -336,6 +336,24 @@ describe('markdownToDoc', () => {
     ])
   })
 
+  it('unescapes an escaped pipe in a cell', () => {
+    const md = dedent`
+      | a \| b | c   |
+      | ------- | --- |
+      | 1       | 2   |
+    `
+    expect(tableShape(md)).toEqual([
+      [
+        { type: 'tableHeaderCell', text: 'a | b' },
+        { type: 'tableHeaderCell', text: 'c' },
+      ],
+      [
+        { type: 'tableCell', text: '1' },
+        { type: 'tableCell', text: '2' },
+      ],
+    ])
+  })
+
   it('keeps a short row padded', () => {
     const md = dedent`
       | a   | b   | c   |

--- a/packages/core/src/converters/md-to-pm.ts
+++ b/packages/core/src/converters/md-to-pm.ts
@@ -358,7 +358,11 @@ function convertTableRow(
       } else if (cursor.type.id === LEZER_NODE_IDS.TableCell) {
         const column = delimiterCount - (hasLeadingPipe ? 1 : 0)
         if (column >= 0 && column < columnCount) {
-          cellTexts[column] = text.slice(cursor.from, cursor.to).trim()
+          // Unescape `\|` to a logical `|`; the serializer re-escapes it.
+          cellTexts[column] = text
+            .slice(cursor.from, cursor.to)
+            .trim()
+            .replaceAll(String.raw`\|`, '|')
         }
       }
     } while (cursor.nextSibling())

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -488,7 +488,7 @@ describe('tables', () => {
     )
   })
 
-  it.fails('keeps an escaped pipe', () => {
+  it('keeps an escaped pipe', () => {
     expect(roundtrip('| a \\| b | c |\n| --- | --- |\n| 1 | 2 |')).toBe(
       '| a \\| b | c |\n| --- | --- |\n| 1 | 2 |\n',
     )


### PR DESCRIPTION
Table cells with an escaped pipe (`| a \| b |`) round-tripped to a double-escaped `\\|` because the parser stored `\|` literally and the serializer escaped it again. Now `convertTableRow` unescapes `\|` to a logical `|` on parse, so the serializer's existing escape makes the round-trip symmetric. Closes A7 from the converter roundtrip fidelity plan.