### PR TITLE
fix(core): stop emitting junk marker lines after nested blocks

### DIFF
--- a/packages/core/src/converters/pm-to-md.test.ts
+++ b/packages/core/src/converters/pm-to-md.test.ts
@@ -197,7 +197,7 @@ describe('docToMarkdown', () => {
     expect(markdownToDoc(markdown).toJSON()).toEqual(doc.toJSON())
   })
 
-  it.fails('keeps a list in a quote clean', () => {
+  it('keeps a list in a quote clean', () => {
     const doc = n.doc(n.blockquote(n.list({ kind: 'bullet' }, n.paragraph('item'))))
     const markdown = docToMarkdown(doc)
     expect(markdown).toBe('> - item\n')

--- a/packages/core/src/converters/pm-to-md.ts
+++ b/packages/core/src/converters/pm-to-md.ts
@@ -127,7 +127,13 @@ class MdOut {
     }
     fn()
     this.linePrefix = savedLine
-    this.pendingFirst = savedFirst
+    // When `firstLine` is set we folded the outer one-shot marker (`savedFirst`,
+    // e.g. a blockquote's "> ") into this block's first-line marker, which `fn`
+    // has by now written or flushed. Restoring `savedFirst` would re-introduce
+    // that already-consumed marker, which `closeBlock` then dumps as a bare junk
+    // line ("> - item\n>\n>\n"). A following sibling rebuilds its marker from
+    // `savedLine` anyway, so dropping it here is safe.
+    this.pendingFirst = firstLine !== null ? null : savedFirst
   }
 
   finish(): string {

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -262,8 +262,12 @@ describe('blockquotes', () => {
     expect(roundtrip('> a\n>> b')).toBe('> a\n>> b\n')
   })
 
-  it.fails('keeps a nested list in a quote', () => {
+  it('keeps a nested list in a quote', () => {
     expect(roundtrip('> - item')).toBe('> - item\n')
+  })
+
+  it('keeps a two-item list in a quote', () => {
+    expect(roundtrip('> - a\n> - b')).toBe('> - a\n> - b\n')
   })
 })
 
@@ -278,6 +282,10 @@ describe('bullet lists', () => {
 
   it('keeps a nested bullet', () => {
     expect(roundtrip('- a\n  - nested')).toBe('- a\n  - nested\n')
+  })
+
+  it('keeps an immediately nested bullet', () => {
+    expect(roundtrip('- - a')).toBe('- - a\n')
   })
 
   it('keeps a loose two-block item', () => {


### PR DESCRIPTION
A blockquote or list item with a block child (e.g. `> - item`) was serializing trailing junk lines (`> - item\n>\n>\n`) because `withPrefix` restored an outer one-shot marker that had already been folded into the child's first-line marker and consumed, which `closeBlock` then dumped as a bare marker line. Restore `pendingFirst` to null once it has been folded into a child marker; a following sibling rebuilds its marker from the line prefix anyway. Also fixes immediately-nested bullets (`- - a`) and multi-item lists in a quote (implements A5 from the converter roundtrip fidelity plan).