### PR TITLE
fix(core): preserve thematic break marker on round-trip

### DIFF
--- a/packages/core/src/converters/md-to-pm.test.ts
+++ b/packages/core/src/converters/md-to-pm.test.ts
@@ -234,7 +234,7 @@ describe('markdownToDoc', () => {
     expect(markdownToDoc('---').toJSON()).toEqual({
       type: 'doc',
       attrs: { frontmatter: null },
-      content: [{ type: 'horizontalRule' }],
+      content: [{ type: 'horizontalRule', attrs: { marker: null } }],
     })
   })
 
@@ -634,7 +634,7 @@ describe('markdownToDoc', () => {
     expect(markdownToDoc('---').toJSON()).toEqual({
       type: 'doc',
       attrs: { frontmatter: null },
-      content: [{ type: 'horizontalRule' }],
+      content: [{ type: 'horizontalRule', attrs: { marker: null } }],
     })
   })
 })

--- a/packages/core/src/converters/md-to-pm.ts
+++ b/packages/core/src/converters/md-to-pm.ts
@@ -123,8 +123,12 @@ function convertBlock(
     case LEZER_NODE_IDS.FencedCode:
     case LEZER_NODE_IDS.CodeBlock:
       return [convertCodeBlock(nodes, cursor, text)]
-    case LEZER_NODE_IDS.HorizontalRule:
-      return [nodes.horizontalRule()]
+    case LEZER_NODE_IDS.HorizontalRule: {
+      // Keep the source marker (`***`, `___`, `- - -`, ...); `---` is canonical
+      // and stays null. Trailing spaces are insignificant, so drop them.
+      const marker = text.slice(cursor.from, cursor.to).trimEnd()
+      return [nodes.horizontalRule({ marker: marker === '---' ? null : marker })]
+    }
     case LEZER_NODE_IDS.Table:
       return [convertTable(nodes, cursor, text)]
     case LEZER_NODE_IDS.Task:

--- a/packages/core/src/converters/pm-to-md.ts
+++ b/packages/core/src/converters/pm-to-md.ts
@@ -3,6 +3,7 @@ import type { ProseMirrorNode } from '@prosekit/pm/model'
 
 import type { Frontmatter } from '../extensions/frontmatter.ts'
 import type { MeowdownHeadingAttrs } from '../extensions/heading.ts'
+import type { MeowdownHorizontalRuleAttrs } from '../extensions/horizontal-rule.ts'
 import type { MeowdownListAttrs } from '../extensions/list.ts'
 import type { NodeName } from '../extensions/node-names.ts'
 import { longestBacktickRun } from '../utils/backticks.ts'
@@ -215,10 +216,12 @@ function emit(node: ProseMirrorNode, out: MdOut): void {
     case 'codeBlock':
       emitCodeBlock(node, out)
       return
-    case 'horizontalRule':
-      out.write('---')
+    case 'horizontalRule': {
+      const { marker } = node.attrs as MeowdownHorizontalRuleAttrs
+      out.write(marker || '---')
       out.closeBlock()
       return
+    }
     case 'table':
       emitTable(node, out)
       return

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -464,15 +464,15 @@ describe('thematic breaks', () => {
     expect(roundtrip('---\n\nafter')).toBe('---\n\nafter\n')
   })
 
-  it.fails('keeps an asterisk rule', () => {
+  it('keeps an asterisk rule', () => {
     expect(roundtrip('***')).toBe('***\n')
   })
 
-  it.fails('keeps an underscore rule', () => {
+  it('keeps an underscore rule', () => {
     expect(roundtrip('___')).toBe('___\n')
   })
 
-  it.fails('keeps a spaced rule', () => {
+  it('keeps a spaced rule', () => {
     expect(roundtrip('- - -')).toBe('- - -\n')
   })
 })

--- a/packages/core/src/converters/sample-content.ts
+++ b/packages/core/src/converters/sample-content.ts
@@ -253,6 +253,7 @@ export const sampleContent: NodeJSON = {
     },
     {
       type: 'horizontalRule',
+      attrs: { marker: null },
     },
     {
       type: 'paragraph',

--- a/packages/core/src/extensions/extension.test.ts
+++ b/packages/core/src/extensions/extension.test.ts
@@ -236,6 +236,9 @@ describe('defineEditorExtension', () => {
             "type": "table",
           },
           {
+            "attrs": {
+              "marker": null,
+            },
             "type": "horizontalRule",
           },
         ],

--- a/packages/core/src/extensions/extension.ts
+++ b/packages/core/src/extensions/extension.ts
@@ -9,7 +9,6 @@ import { defineBlockquote } from '@prosekit/extensions/blockquote'
 import { defineCodeBlock } from '@prosekit/extensions/code-block'
 import { defineDoc } from '@prosekit/extensions/doc'
 import { defineGapCursor } from '@prosekit/extensions/gap-cursor'
-import { defineHorizontalRule } from '@prosekit/extensions/horizontal-rule'
 import { defineModClickPrevention } from '@prosekit/extensions/mod-click-prevention'
 import { defineParagraph } from '@prosekit/extensions/paragraph'
 import { defineText } from '@prosekit/extensions/text'
@@ -19,6 +18,7 @@ import { defineAtomicMarkNavigation } from './atomic-mark-navigation.ts'
 import { defineCodeBlockSyntaxHighlight } from './code-block-highlight.ts'
 import { defineDocFrontmatterAttr } from './frontmatter.ts'
 import { defineHeading } from './heading.ts'
+import { defineMeowdownHorizontalRule } from './horizontal-rule.ts'
 import { defineInlineMarkPlugin } from './inline-mark-plugin.ts'
 import { defineInlineMarks } from './inline-marks.ts'
 import { defineInlineToggle } from './inline-toggle-commands.ts'
@@ -38,7 +38,7 @@ function defineEditorExtensionImpl() {
     defineHeading(),
     defineTable(),
     defineCodeBlock(),
-    defineHorizontalRule(),
+    defineMeowdownHorizontalRule(),
 
     // marks
     defineInlineMarks(),

--- a/packages/core/src/extensions/horizontal-rule.test.ts
+++ b/packages/core/src/extensions/horizontal-rule.test.ts
@@ -1,0 +1,34 @@
+import { createEditor } from '@prosekit/core'
+import { DOMParser, DOMSerializer } from '@prosekit/pm/model'
+import { describe, expect, it } from 'vitest'
+
+import { defineEditorExtension } from './extension.ts'
+
+function setupEditor() {
+  const editor = createEditor({ extension: defineEditorExtension() })
+  return { editor, schema: editor.schema, n: editor.nodes }
+}
+
+describe('horizontal rule marker', () => {
+  it('keeps a non-canonical marker through a DOM round-trip', () => {
+    const { schema, n } = setupEditor()
+    const doc = n.doc(n.horizontalRule({ marker: '***' }))
+
+    const dom = DOMSerializer.fromSchema(schema).serializeFragment(doc.content)
+    const container = document.createElement('div')
+    container.appendChild(dom)
+
+    const parsed = DOMParser.fromSchema(schema).parse(container)
+    expect(parsed.child(0).attrs.marker).toBe('***')
+  })
+
+  it('parses a bare foreign hr as a default rule', () => {
+    const { schema } = setupEditor()
+    const container = document.createElement('div')
+    container.innerHTML = '<hr>'
+
+    const parsed = DOMParser.fromSchema(schema).parse(container)
+    expect(parsed.child(0).type.name).toBe('horizontalRule')
+    expect(parsed.child(0).attrs.marker).toBe(null)
+  })
+})

--- a/packages/core/src/extensions/horizontal-rule.ts
+++ b/packages/core/src/extensions/horizontal-rule.ts
@@ -1,0 +1,40 @@
+import { defineNodeAttr, union, type Extension, type Union } from '@prosekit/core'
+import {
+  defineHorizontalRule,
+  type HorizontalRuleExtension,
+} from '@prosekit/extensions/horizontal-rule'
+
+import type { NodeName } from './node-names.ts'
+
+export interface MeowdownHorizontalRuleAttrs {
+  /**
+   * The literal markdown marker of a thematic break, e.g. `***`, `___`, or
+   * `- - -`. Defaults to null, which the serializer emits as the canonical `---`.
+   */
+  marker?: string | null
+}
+
+type HorizontalRuleMarkerExtension = Extension<{
+  Nodes: { horizontalRule: MeowdownHorizontalRuleAttrs }
+}>
+
+function defineHorizontalRuleMarkerAttr(): HorizontalRuleMarkerExtension {
+  return defineNodeAttr<'horizontalRule', 'marker', string | null>({
+    type: 'horizontalRule' satisfies NodeName,
+    attr: 'marker',
+    default: null,
+    // Persist only a non-canonical marker; `---` is the serializer default
+    // anyway. The marker rides on the wrapper `<div>` (which `parseDOM` now
+    // matches) so an editor DOM re-parse keeps it.
+    toDOM: (value) => (value ? ['data-hr-marker', value] : null),
+    parseDOM: (node) => node.getAttribute('data-hr-marker'),
+  })
+}
+
+export type MeowdownHorizontalRuleExtension = Union<
+  [HorizontalRuleExtension, HorizontalRuleMarkerExtension]
+>
+
+export function defineMeowdownHorizontalRule(): MeowdownHorizontalRuleExtension {
+  return union(defineHorizontalRule(), defineHorizontalRuleMarkerAttr())
+}


### PR DESCRIPTION
Adds a `marker` attr to the `horizontalRule` node so `***`, `___`, and `- - -` survive a markdown round-trip instead of all normalizing to `---` (the canonical `---` stays null). A meowdown horizontal-rule extension declares the attr and persists a non-canonical marker as `data-hr-marker` for DOM re-parse, reusing ProseKit's input rule and commands. Implements B3 from the converter round-trip fidelity plan.