### PR TITLE
feat: delete table on Backspace over full cell selection

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,8 @@
     "@prosekit/core": "^0.13.0-beta.3",
     "@prosekit/extensions": "^0.17.5-beta.5",
     "@prosekit/pm": "^0.1.19-beta.0",
-    "prosemirror-highlight": "^0.15.2"
+    "prosemirror-highlight": "^0.15.2",
+    "prosemirror-tables": "^1.8.5"
   },
   "devDependencies": {
     "@meowdown/vitest": "workspace:*",

--- a/packages/core/src/extensions/table.test.ts
+++ b/packages/core/src/extensions/table.test.ts
@@ -27,7 +27,74 @@ describe('table', () => {
     await userEvent.keyboard('{Backspace}')
     expect(hasTable(fixture.doc)).toBe(false)
   })
+
+  it('clears only the selected cells when Backspace over a partial cell selection', async () => {
+    using fixture = setupFixture()
+    const { editor, n, view } = fixture
+    const doc = n.doc(
+      n.paragraph('before'),
+      n.table(
+        n.tableRow(n.tableHeaderCell(n.paragraph('a')), n.tableHeaderCell(n.paragraph('b'))),
+        n.tableRow(n.tableCell(n.paragraph('1')), n.tableCell(n.paragraph('2'))),
+      ),
+    )
+    fixture.set(doc)
+
+    const [headerA, headerB] = cellHitPositions(fixture.doc)
+    editor.commands.selectTableRow({ anchor: headerA, head: headerB })
+
+    view.focus()
+    await userEvent.keyboard('{Backspace}')
+
+    expect(hasTable(fixture.doc)).toBe(true)
+    expect(cellTexts(fixture.doc)).toEqual(['', '', '1', '2'])
+  })
+
+  it('deletes the whole table when Backspace over a full cell selection', async () => {
+    using fixture = setupFixture()
+    const { editor, n, view } = fixture
+    const doc = n.doc(
+      n.paragraph('before'),
+      n.table(
+        n.tableRow(n.tableHeaderCell(n.paragraph('a')), n.tableHeaderCell(n.paragraph('b'))),
+        n.tableRow(n.tableCell(n.paragraph('1')), n.tableCell(n.paragraph('2'))),
+      ),
+    )
+    fixture.set(doc)
+
+    const [headerA] = cellHitPositions(fixture.doc)
+    editor.commands.selectTable({ pos: headerA })
+
+    view.focus()
+    expect(hasTable(fixture.doc)).toBe(true)
+    await userEvent.keyboard('{Backspace}')
+    expect(hasTable(fixture.doc)).toBe(false)
+  })
 })
+
+function cellTexts(doc: EditorNode): string[] {
+  const texts: string[] = []
+  doc.descendants((node) => {
+    if (node.type.name === 'tableCell' || node.type.name === 'tableHeaderCell') {
+      texts.push(node.textContent)
+      return false
+    }
+    return true
+  })
+  return texts
+}
+
+function cellHitPositions(doc: EditorNode): number[] {
+  const positions: number[] = []
+  doc.descendants((node, pos) => {
+    if (node.type.name === 'tableCell' || node.type.name === 'tableHeaderCell') {
+      positions.push(pos + 1)
+      return false
+    }
+    return true
+  })
+  return positions
+}
 
 function hasTable(doc: EditorNode): boolean {
   return getTablePos(doc) > -1

--- a/packages/core/src/extensions/table.test.ts
+++ b/packages/core/src/extensions/table.test.ts
@@ -40,14 +40,14 @@ describe('table', () => {
     )
     fixture.set(doc)
 
-    const [headerA, headerB] = cellHitPositions(fixture.doc)
+    const [headerA, headerB] = getCellHitPositions(fixture.doc)
     editor.commands.selectTableRow({ anchor: headerA, head: headerB })
 
     view.focus()
     await userEvent.keyboard('{Backspace}')
 
     expect(hasTable(fixture.doc)).toBe(true)
-    expect(cellTexts(fixture.doc)).toEqual(['', '', '1', '2'])
+    expect(getCellTexts(fixture.doc)).toEqual(['', '', '1', '2'])
   })
 
   it('deletes the whole table when Backspace over a full cell selection', async () => {
@@ -62,7 +62,7 @@ describe('table', () => {
     )
     fixture.set(doc)
 
-    const [headerA] = cellHitPositions(fixture.doc)
+    const [headerA] = getCellHitPositions(fixture.doc)
     editor.commands.selectTable({ pos: headerA })
 
     view.focus()
@@ -72,7 +72,7 @@ describe('table', () => {
   })
 })
 
-function cellTexts(doc: EditorNode): string[] {
+function getCellTexts(doc: EditorNode): string[] {
   const texts: string[] = []
   doc.descendants((node) => {
     if (node.type.name === 'tableCell' || node.type.name === 'tableHeaderCell') {
@@ -84,7 +84,7 @@ function cellTexts(doc: EditorNode): string[] {
   return texts
 }
 
-function cellHitPositions(doc: EditorNode): number[] {
+function getCellHitPositions(doc: EditorNode): number[] {
   const positions: number[] = []
   doc.descendants((node, pos) => {
     if (node.type.name === 'tableCell' || node.type.name === 'tableHeaderCell') {

--- a/packages/core/src/extensions/table.ts
+++ b/packages/core/src/extensions/table.ts
@@ -1,4 +1,4 @@
-import { union } from '@prosekit/core'
+import { defineKeymap, Priority, union, withPriority, type PlainExtension } from '@prosekit/core'
 import {
   defineTableCellSpec,
   defineTableCommands,
@@ -7,7 +7,32 @@ import {
   defineTableHeaderCellSpec,
   defineTableRowSpec,
   defineTableSpec,
+  isCellSelection,
 } from '@prosekit/extensions/table'
+import type { Command } from '@prosekit/pm/state'
+
+// When a cell selection covers the whole table, Backspace and Delete remove the
+// entire table instead of only clearing the cell contents.
+const deleteTableOnFullCellSelection: Command = (state, dispatch) => {
+  const { selection } = state
+  if (!isCellSelection(selection)) return false
+  if (!selection.isColSelection() || !selection.isRowSelection()) return false
+  if (dispatch) {
+    const $cell = selection.$anchorCell
+    dispatch(state.tr.delete($cell.before(-1), $cell.after(-1)).scrollIntoView())
+  }
+  return true
+}
+
+function defineTableKeymap(): PlainExtension {
+  return withPriority(
+    defineKeymap({
+      Backspace: deleteTableOnFullCellSelection,
+      Delete: deleteTableOnFullCellSelection,
+    }),
+    Priority.high,
+  )
+}
 
 export function defineTable() {
   return union(
@@ -18,5 +43,6 @@ export function defineTable() {
     defineTableEditingPlugin({ allowTableNodeSelection: true }),
     defineTableCommands(),
     defineTableDropIndicator(),
+    defineTableKeymap(),
   )
 }

--- a/packages/core/src/extensions/table.ts
+++ b/packages/core/src/extensions/table.ts
@@ -10,6 +10,7 @@ import {
   isCellSelection,
 } from '@prosekit/extensions/table'
 import type { Command } from '@prosekit/pm/state'
+import { deleteTable } from 'prosemirror-tables'
 
 // When a cell selection covers the whole table, Backspace and Delete remove the
 // entire table instead of only clearing the cell contents.
@@ -17,11 +18,7 @@ const deleteTableOnFullCellSelection: Command = (state, dispatch) => {
   const { selection } = state
   if (!isCellSelection(selection)) return false
   if (!selection.isColSelection() || !selection.isRowSelection()) return false
-  if (dispatch) {
-    const $cell = selection.$anchorCell
-    dispatch(state.tr.delete($cell.before(-1), $cell.after(-1)).scrollIntoView())
-  }
-  return true
+  return deleteTable(state, dispatch)
 }
 
 function defineTableKeymap(): PlainExtension {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       prosemirror-highlight:
         specifier: ^0.15.2
         version: 0.15.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.2.0)(@types/hast@3.0.4)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
+      prosemirror-tables:
+        specifier: ^1.8.5
+        version: 1.8.5
     devDependencies:
       '@meowdown/vitest':
         specifier: workspace:*


### PR DESCRIPTION
When a cell selection covers the whole table, Backspace and Delete now remove the entire table instead of only clearing the cell contents. Partial cell selections still just clear the selected cells, and the `deleteCellSelection` command (the table menu's "Delete cells") is unchanged.