### PR TITLE
feat: make YAML frontmatter handling opt-in

### DIFF
--- a/packages/core/src/converters/check-roundtrip.ts
+++ b/packages/core/src/converters/check-roundtrip.ts
@@ -17,9 +17,19 @@ function nonBlankLines(text: string): string[] {
   return text.split('\n').filter((line) => line.trim() !== '')
 }
 
+/** Options for {@link checkRoundTrip}. */
+export interface CheckRoundTripOptions {
+  /** Whether to handle a leading `---` frontmatter block. Off by default. */
+  frontmatter?: boolean
+}
+
 /** Classify how `markdown` survives the editor's parse-then-serialize round trip. */
-export function checkRoundTrip(markdown: string): RoundTripFidelity {
-  const serialized = docToMarkdown(markdownToDoc(markdown))
+export function checkRoundTrip(
+  markdown: string,
+  options: CheckRoundTripOptions = {},
+): RoundTripFidelity {
+  const doc = markdownToDoc(markdown, { frontmatter: options.frontmatter })
+  const serialized = docToMarkdown(doc, { frontmatter: options.frontmatter })
   if (trimTrailingNewlines(serialized) === trimTrailingNewlines(markdown)) return 'exact'
   const before = nonBlankLines(markdown)
   const after = nonBlankLines(serialized)

--- a/packages/core/src/converters/md-to-pm.test.ts
+++ b/packages/core/src/converters/md-to-pm.test.ts
@@ -600,7 +600,7 @@ describe('markdownToDoc', () => {
   it('keeps YAML frontmatter as a doc attribute', () => {
     // The whole input is the frontmatter block, so the only content is the
     // empty paragraph the schema fills in (it serializes back to nothing).
-    expect(markdownToDoc('---\ntitle: x\n---').toJSON()).toEqual({
+    expect(markdownToDoc('---\ntitle: x\n---', { frontmatter: true }).toJSON()).toEqual({
       type: 'doc',
       attrs: { frontmatter: 'title: x' },
       content: [{ type: 'paragraph' }],
@@ -609,7 +609,7 @@ describe('markdownToDoc', () => {
 
   it('keeps a multi-line frontmatter body literal before content', () => {
     const md = '---\ntitle: x\ntags: [a, b]\n---\n\n# heading'
-    expect(markdownToDoc(md).toJSON()).toEqual({
+    expect(markdownToDoc(md, { frontmatter: true }).toJSON()).toEqual({
       type: 'doc',
       attrs: { frontmatter: 'title: x\ntags: [a, b]' },
       content: [
@@ -623,7 +623,7 @@ describe('markdownToDoc', () => {
   })
 
   it('keeps an empty frontmatter block as an empty string', () => {
-    expect(markdownToDoc('---\n---').toJSON()).toEqual({
+    expect(markdownToDoc('---\n---', { frontmatter: true }).toJSON()).toEqual({
       type: 'doc',
       attrs: { frontmatter: '' },
       content: [{ type: 'paragraph' }],
@@ -631,10 +631,14 @@ describe('markdownToDoc', () => {
   })
 
   it('keeps a lone dashes line as a thematic break, not frontmatter', () => {
-    expect(markdownToDoc('---').toJSON()).toEqual({
+    expect(markdownToDoc('---', { frontmatter: true }).toJSON()).toEqual({
       type: 'doc',
       attrs: { frontmatter: null },
       content: [{ type: 'horizontalRule', attrs: { marker: null } }],
     })
+  })
+
+  it('leaves a frontmatter block as content when frontmatter is off (default)', () => {
+    expect(markdownToDoc('---\ntitle: x\n---').attrs.frontmatter).toBe(null)
   })
 })

--- a/packages/core/src/converters/md-to-pm.ts
+++ b/packages/core/src/converters/md-to-pm.ts
@@ -17,6 +17,15 @@ import {
   isSpaceChar,
 } from '../unicode.ts'
 
+/** Options for {@link markdownToDoc}. */
+export interface MarkdownToDocOptions {
+  /** Node builders to build the document with. Defaults to the shared schema's builders. */
+  nodes?: TypedNodeBuilders
+
+  /** Whether to peel a leading `---` frontmatter block onto the doc's `frontmatter` attribute. Off by default. */
+  frontmatter?: boolean
+}
+
 /**
  * Convert a markdown string into a ProseMirror document node.
  *
@@ -33,17 +42,24 @@ import {
  */
 export function markdownToDoc(
   markdown: string,
-  nodes: TypedNodeBuilders = getNodeBuilders(),
+  options: MarkdownToDocOptions = {},
 ): ProseMirrorNode {
-  // Peel off a leading YAML frontmatter block (`---\n...\n---`) before lezer
-  const [frontmatterBody, frontmatterMatchLength] = matchFrontmatter(markdown)
-  const rest = frontmatterMatchLength ? markdown.slice(frontmatterMatchLength) : markdown
+  const { nodes = getNodeBuilders(), frontmatter = false } = options
+
+  // Optionally peel a leading `---` frontmatter block off before lezer.
+  let frontmatterBody: string | undefined
+  let rest = markdown
+  if (frontmatter) {
+    const [body, matchLength] = matchFrontmatter(markdown)
+    frontmatterBody = body
+    if (matchLength) rest = markdown.slice(matchLength)
+  }
 
   const tree = gfmBlockOnlyParser.parse(rest)
   const cursor = tree.cursor()
   const blocks = collectBlocks(nodes, cursor, rest)
 
-  return nodes.doc({ frontmatter: frontmatterBody }, blocks)
+  return nodes.doc(frontmatterBody === undefined ? {} : { frontmatter: frontmatterBody }, blocks)
 }
 
 /**

--- a/packages/core/src/converters/pm-to-md.test.ts
+++ b/packages/core/src/converters/pm-to-md.test.ts
@@ -238,19 +238,24 @@ describe('docToMarkdown', () => {
 
   it('keeps a frontmatter-only document', () => {
     const doc = n.doc({ frontmatter: 'title: x' })
-    const markdown = docToMarkdown(doc)
+    const markdown = docToMarkdown(doc, { frontmatter: true })
     expect(markdown).toBe('---\ntitle: x\n---\n')
   })
 
   it('keeps frontmatter before content', () => {
     const doc = n.doc({ frontmatter: 'title: x' }, n.heading({ level: 1 }, 'heading'))
-    const markdown = docToMarkdown(doc)
+    const markdown = docToMarkdown(doc, { frontmatter: true })
     expect(markdown).toBe('---\ntitle: x\n---\n\n# heading\n')
   })
 
   it('keeps an empty frontmatter block', () => {
     const doc = n.doc({ frontmatter: '' }, n.paragraph('body'))
-    const markdown = docToMarkdown(doc)
+    const markdown = docToMarkdown(doc, { frontmatter: true })
     expect(markdown).toBe('---\n---\n\nbody\n')
+  })
+
+  it('ignores the frontmatter attribute by default', () => {
+    const doc = n.doc({ frontmatter: 'title: x' }, n.paragraph('body'))
+    expect(docToMarkdown(doc)).toBe('body\n')
   })
 })

--- a/packages/core/src/converters/pm-to-md.ts
+++ b/packages/core/src/converters/pm-to-md.ts
@@ -8,6 +8,12 @@ import type { MeowdownListAttrs } from '../extensions/list.ts'
 import type { NodeName } from '../extensions/node-names.ts'
 import { longestBacktickRun } from '../utils/backticks.ts'
 
+/** Options for {@link docToMarkdown}. */
+export interface DocToMarkdownOptions {
+  /** Whether to serialize the doc's `frontmatter` attribute as a leading `---` block. Off by default. */
+  frontmatter?: boolean
+}
+
 /**
  * Convert a ProseMirror document into a Markdown string.
  *
@@ -23,9 +29,11 @@ import { longestBacktickRun } from '../utils/backticks.ts'
  * - Backtick fence width and cell escaping use single linear loops, no
  *   regex on the hot path.
  */
-export function docToMarkdown(node: ProseMirrorNode): string {
+export function docToMarkdown(node: ProseMirrorNode, options: DocToMarkdownOptions = {}): string {
   const out = new MdOut()
-  emitFrontmatter(node.attrs.frontmatter as Frontmatter, out)
+  if (options.frontmatter) {
+    emitFrontmatter(node.attrs.frontmatter as Frontmatter, out)
+  }
   emit(node, out)
   return out.finish()
 }

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from 'vitest'
 import { markdownToDoc } from './md-to-pm.ts'
 import { docToMarkdown } from './pm-to-md.ts'
 
-function roundtrip(markdown: string): string {
-  return docToMarkdown(markdownToDoc(markdown))
+function roundtrip(markdown: string, options?: { frontmatter?: boolean }): string {
+  return docToMarkdown(markdownToDoc(markdown, options), options)
 }
 
 describe('text', () => {
@@ -545,15 +545,23 @@ describe('escapes and whitespace', () => {
   })
 
   it('keeps YAML frontmatter', () => {
-    expect(roundtrip('---\ntitle: x\n---')).toBe('---\ntitle: x\n---\n')
+    expect(roundtrip('---\ntitle: x\n---', { frontmatter: true })).toBe('---\ntitle: x\n---\n')
   })
 
   it('keeps YAML frontmatter before content', () => {
-    expect(roundtrip('---\ntitle: x\n---\n\n# heading')).toBe('---\ntitle: x\n---\n\n# heading\n')
+    expect(roundtrip('---\ntitle: x\n---\n\n# heading', { frontmatter: true })).toBe(
+      '---\ntitle: x\n---\n\n# heading\n',
+    )
   })
 
   it('normalizes a missing blank line after frontmatter', () => {
-    expect(roundtrip('---\ntitle: x\n---\n# heading')).toBe('---\ntitle: x\n---\n\n# heading\n')
+    expect(roundtrip('---\ntitle: x\n---\n# heading', { frontmatter: true })).toBe(
+      '---\ntitle: x\n---\n\n# heading\n',
+    )
+  })
+
+  it('renders a frontmatter block as content when frontmatter is off (default)', () => {
+    expect(roundtrip('---\ntitle: x\n---')).toContain('title: x')
   })
 })
 
@@ -636,8 +644,8 @@ describe('idempotency', () => {
   })
 
   it('keeps frontmatter stable', () => {
-    const once = roundtrip('---\ntitle: x\n---')
-    expect(roundtrip(once)).toBe(once)
+    const once = roundtrip('---\ntitle: x\n---', { frontmatter: true })
+    expect(roundtrip(once, { frontmatter: true })).toBe(once)
   })
 
   it('keeps a two-line quote stable', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,7 +27,11 @@ export { definePlaceholder, type PlaceholderOptions } from '@prosekit/extensions
 export { defineReadonly } from '@prosekit/extensions/readonly'
 export { Priority, withPriority } from '@prosekit/core'
 export { codeBlockLanguages } from './extensions/code-block-languages.ts'
-export { docToMarkdown } from './converters/pm-to-md.ts'
-export { markdownToDoc } from './converters/md-to-pm.ts'
-export { checkRoundTrip, type RoundTripFidelity } from './converters/check-roundtrip.ts'
+export { docToMarkdown, type DocToMarkdownOptions } from './converters/pm-to-md.ts'
+export { markdownToDoc, type MarkdownToDocOptions } from './converters/md-to-pm.ts'
+export {
+  checkRoundTrip,
+  type CheckRoundTripOptions,
+  type RoundTripFidelity,
+} from './converters/check-roundtrip.ts'
 export type { CodeBlockAttrs } from '@prosekit/extensions/code-block'

--- a/packages/react/src/components/editor.tsx
+++ b/packages/react/src/components/editor.tsx
@@ -112,6 +112,9 @@ export interface EditorProps {
    */
   bulletAfterHeading?: boolean
 
+  /** Handles a leading `---` frontmatter block in the rich modes (off by default, ignored in source mode). */
+  frontmatter?: boolean
+
   /**
    * Shows the per-block gutter handle in the rich modes: a drag grip for
    * reordering blocks and a "+" add button, plus the drop indicator that
@@ -163,6 +166,7 @@ export function MeowdownEditor({
   onImageClick,
   embedPaste = true,
   bulletAfterHeading = false,
+  frontmatter = false,
   blockHandle = true,
   placeholder,
   readOnly,
@@ -244,6 +248,7 @@ export function MeowdownEditor({
           onImageClick={onImageClick}
           embedPaste={embedPaste}
           bulletAfterHeading={bulletAfterHeading}
+          frontmatter={frontmatter}
           blockHandle={blockHandle}
           placeholder={placeholder}
           readOnly={readOnly}

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -93,6 +93,9 @@ export interface ProseKitEditorProps {
   /** Starts a bullet on Enter after a heading. See `EditorProps.bulletAfterHeading`. */
   bulletAfterHeading?: boolean
 
+  /** Handles a leading YAML frontmatter block. See `EditorProps.frontmatter`. */
+  frontmatter?: boolean
+
   /** Shows the per-block gutter handle. See `EditorProps.blockHandle`. */
   blockHandle?: boolean
 
@@ -129,6 +132,7 @@ export function ProseKitEditor({
   onImageClick,
   embedPaste,
   bulletAfterHeading,
+  frontmatter = false,
   blockHandle = true,
   placeholder,
   readOnly,
@@ -142,7 +146,7 @@ export function ProseKitEditor({
     const extension = union(baseExtension, defineCodeBlockView())
     const editor: TypedEditor = createEditor({ extension })
     if (initialMarkdown) {
-      editor.setContent(markdownToDoc(initialMarkdown, editor.nodes))
+      editor.setContent(markdownToDoc(initialMarkdown, { nodes: editor.nodes, frontmatter }))
     }
     return editor
   })
@@ -153,7 +157,7 @@ export function ProseKitEditor({
 
   useImperativeHandle(ref, () => {
     function getMarkdown(): string {
-      return docToMarkdown(editor.state.doc)
+      return docToMarkdown(editor.state.doc, { frontmatter })
     }
     function getSelection(): SelectionJSON {
       return editor.state.selection.toJSON() as SelectionJSON
@@ -165,7 +169,7 @@ export function ProseKitEditor({
       if (markdown == null && !selection) return
       const transaction = editor.state.tr
       if (markdown != null) {
-        const doc = markdownToDoc(markdown, editor.nodes)
+        const doc = markdownToDoc(markdown, { nodes: editor.nodes, frontmatter })
         transaction.replaceWith(0, transaction.doc.content.size, doc.content)
       }
       if (selection) {
@@ -201,7 +205,7 @@ export function ProseKitEditor({
       scrollIntoView,
       editor,
     }
-  }, [editor])
+  }, [editor, frontmatter])
 
   // Guard the host callback so programmatic setState/setMarkdown stays silent.
   // Stable per `onDocChange` identity, so the extension is not rebuilt every render.


### PR DESCRIPTION
## What

Makes the editor's YAML frontmatter handling **opt-in**, off by default.

`@meowdown/core` 0.16.x always peels a leading `---\n...\n---` block off the markdown, stores it on the `doc` node's `frontmatter` attribute, and re-emits it on serialize. That round trip is *normalizing*, not byte-exact (it rewrites CRLF to LF, drops fence whitespace, and forces a blank line after the block). A host that wants byte-exact control over its own frontmatter (e.g. preserving exact header bytes and minimal git diffs) is better off owning the `---` block itself and never letting the editor touch it.

This PR keeps the feature available but turns it **off by default**, so a leading `---` is left in the document and parsed as ordinary markdown unless the host opts in.

## Behavior change

- `markdownToDoc` / `docToMarkdown` no longer handle frontmatter by default. Pass `{ frontmatter: true }` to restore the previous behavior.
- `markdownToDoc`'s second parameter is now an options object: the old positional `nodes` argument moves to `options.nodes`. `markdownToDoc(md, nodes)` becomes `markdownToDoc(md, { nodes })`.
- `<MeowdownEditor>` / `ProseKitEditor` no longer peel frontmatter by default. Pass `frontmatter` to opt in.

Released as a `feat` (minor) bump. The `frontmatter` doc attribute stays in the schema regardless, so no schema migration is needed.

## API

```ts
markdownToDoc(md, { nodes?, frontmatter? })   // both default: shared schema, frontmatter off
docToMarkdown(doc, { frontmatter? })          // default false
checkRoundTrip(md, { frontmatter? })          // default false
```

```tsx
<MeowdownEditor frontmatter />   // opt in (off by default)
```

New exported types: `MarkdownToDocOptions` (`{ nodes?, frontmatter? }`), `DocToMarkdownOptions`, `CheckRoundTripOptions`.

## Design

Converter-level switch only; the `frontmatter` `doc` attribute is left in the shared schema (it is non-rendered and defaults to `null`, so it costs nothing when unused). This avoids any change to the `once()`-cached shared schema and keeps the public node types stable. `CheckRoundTripOptions` is its own literal (not `extends MarkdownToDocOptions, DocToMarkdownOptions`) so the two option sets can diverge without colliding; `checkRoundTrip` distributes `frontmatter` to each converter explicitly.

## Tests

- Existing frontmatter parse/serialize/roundtrip tests now pass `{ frontmatter: true }` explicitly.
- Added default-off coverage: `markdownToDoc` leaves the attribute `null`, `docToMarkdown` ignores it, and a frontmatter block round-trips as visible content.
- `pnpm typecheck`, `pnpm lint` (eslint + oxfmt + knip), and the core converter + react editor test suites all pass.