### PR TITLE
fix: stop block handle drag preview inheriting gutter padding

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -46,7 +46,7 @@ Heading shortcuts toggle the current block to a heading of that level (or back t
 - `--meowdown-image-radius`: corner radius of rendered inline images.
 - `--meowdown-placeholder`: placeholder text color (defaults to `--meowdown-muted`).
 - `--meowdown-font-mono`: monospace font stack.
-- `--meowdown-gutter`: horizontal editor padding. Floating UI such as the block handle (in `@meowdown/react`) lives inside it; keep it at least `3.5rem`.
+- `--meowdown-gutter`: horizontal editor padding. Applied to the editable root's `.meowdown-content` class (set by `@meowdown/react`), not `.ProseMirror`, so the block handle's drag preview stays unpadded. Floating UI such as the block handle lives inside it; keep it at least `3.5rem`.
 - `--meowdown-selection`: text `::selection` background.
 - `--meowdown-node-outline`: outline of a selected node; border color of selected tables and cells.
 - `--meowdown-node-selection`: background wash of a selected node or selected cells.

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -40,13 +40,19 @@
  * ------------------------------------------------------------------------- */
 .ProseMirror {
   box-sizing: border-box;
-  padding: 1.25rem var(--meowdown-gutter) 1.75rem;
   outline: none;
   font-size: 1.0625rem;
   line-height: 1.7;
   color: var(--meowdown-text);
   caret-color: var(--meowdown-accent);
   -webkit-font-smoothing: antialiased;
+}
+
+/* Surface padding stays on a meowdown-owned class, not `.ProseMirror`: the block
+ * handle's drag preview clones a block into a bare `.ProseMirror` container, which
+ * must not pick up the gutter padding. */
+.meowdown-content {
+  padding: 1.25rem var(--meowdown-gutter) 1.75rem;
 }
 
 .ProseMirror > * + * {

--- a/packages/react/src/components/block-handle.test.tsx
+++ b/packages/react/src/components/block-handle.test.tsx
@@ -71,6 +71,26 @@ describe('BlockHandle', () => {
     expect(ref.current?.getMarkdown()).toBe('Alpha\n\nInserted\n\nBravo\n')
   })
 
+  it('keeps the gutter padding on the editor but off a bare ProseMirror drag preview', async () => {
+    await renderEditor()
+    // The editor's gutter padding lives on `.meowdown-content`, not `.ProseMirror`.
+    await expect.element(pmRoot).not.toHaveStyle({ paddingLeft: '0px' })
+
+    // The block handle builds its drag preview as a bare `.ProseMirror.prosekit-dragging`
+    // container appended to <body>; it must not inherit that gutter padding.
+    const preview = document.createElement('div')
+    preview.className = 'ProseMirror prosekit-dragging'
+    preview.dataset.testid = 'drag-preview-probe'
+    document.body.append(preview)
+    try {
+      await expect
+        .element(page.getByTestId('drag-preview-probe'))
+        .toHaveStyle({ paddingLeft: '0px' })
+    } finally {
+      preview.remove()
+    }
+  })
+
   it('selects the hovered block when pressing the drag handle', async () => {
     await renderEditor()
     await hover(pmRoot.getByText('Bravo'))

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -16,6 +16,7 @@ import { createEditor, type SelectionJSON, union } from '@prosekit/core'
 import type { EditorNode } from '@prosekit/pm/model'
 import { Selection, TextSelection } from '@prosekit/pm/state'
 import { ProseKit } from '@prosekit/react'
+import { clsx } from 'clsx/lite'
 import { useImperativeHandle, useMemo, useRef, useState, type ReactNode, type Ref } from 'react'
 
 import { defineCodeBlockView } from '../extensions/code-block-view.ts'
@@ -219,7 +220,11 @@ export function ProseKitEditor({
 
   return (
     <ProseKit editor={editor}>
-      <div ref={editor.mount} spellCheck={spellCheck} className={editorClassName}></div>
+      <div
+        ref={editor.mount}
+        spellCheck={spellCheck}
+        className={clsx('meowdown-content', editorClassName)}
+      ></div>
       <EditorExtensions
         markMode={markMode}
         onDocChange={handleDocChange}


### PR DESCRIPTION
The block handle's drag preview reuses the bare `.ProseMirror` class, so meowdown's gutter padding on `.ProseMirror` leaked onto the preview as a left gap. Move the surface padding to a new `.meowdown-content` class on the editable root so the preview stays flush.