### PR TITLE
fix: treat blockquote-marker-only lines as blank

### DIFF
--- a/packages/core/src/converters/check-roundtrip.test.ts
+++ b/packages/core/src/converters/check-roundtrip.test.ts
@@ -61,6 +61,8 @@ describe('checkRoundTrip', () => {
     '- a\n\n- b', // a loose list serializes tight
     '- [ ] Asdf\n- [ ]\n- [ ] ', // a trailing space on an empty task is normalized away
     'trailing spaces   ', // trailing whitespace is insignificant
+    '> text\n> - item', // a blockquote gains an empty `>` line before a following list
+    '> a\n> - x\n> - y', // same, with a multi-item list inside the blockquote
   ])('reports normalizing for %j', (markdown) => {
     expect(checkRoundTrip(markdown)).toBe('normalizing')
   })

--- a/packages/core/src/converters/check-roundtrip.ts
+++ b/packages/core/src/converters/check-roundtrip.ts
@@ -5,7 +5,8 @@ import { docToMarkdown } from './pm-to-md.ts'
  * How faithfully markdown survives a parse-then-serialize round trip:
  * - `exact`: byte-identical (modulo the trailing newline).
  * - `normalizing`: same non-blank lines ignoring trailing whitespace; only
- *   blank-line layout or insignificant trailing whitespace differs.
+ *   blank-line layout (including empty `>` lines inside a blockquote) or
+ *   insignificant trailing whitespace differs.
  * - `lossy`: a non-blank line changed, so content would be lost or altered.
  */
 export type RoundTripFidelity = 'exact' | 'normalizing' | 'lossy'
@@ -14,8 +15,15 @@ function trimTrailingNewlines(text: string): string {
   return text.replace(/\n+$/u, '')
 }
 
+// A line carries no content when it is empty, whitespace, or holds only
+// blockquote markers (`>`). An empty `>` is the blockquote form of a blank
+// line, so the serializer inserting one between blocks is layout, not content.
+function isBlankLine(line: string): boolean {
+  return /^[\s>]*$/u.test(line)
+}
+
 function nonBlankLines(text: string): string[] {
-  return text.split('\n').filter((line) => line.trim() !== '')
+  return text.split('\n').filter((line) => !isBlankLine(line))
 }
 
 /** Options for {@link checkRoundTrip}. */


### PR DESCRIPTION
An empty `>` line is the blockquote form of a blank line, but `checkRoundTrip` counted it as content, so a note where the serializer inserts a `>` separator between a paragraph and a following list (e.g. a real daily note) was misclassified `lossy` and opened read-only in reflect-open. Treat blockquote-marker-only lines as blank so the same blank-line layout that is `normalizing` at top level is also `normalizing` inside a blockquote.