### PR TITLE
fix(core): preserve multi-line code blocks in list items

### DIFF
--- a/packages/core/src/converters/md-to-pm.test.ts
+++ b/packages/core/src/converters/md-to-pm.test.ts
@@ -230,6 +230,37 @@ describe('markdownToDoc', () => {
     })
   })
 
+  it('keeps every line of a fenced block nested in a list item', () => {
+    // lezer emits one CodeText per line for a code block inside a container, so
+    // the converter must accumulate them; overwriting drops all but the last.
+    const md = ['- a', '', '  ```', '  l1', '  l2', '  l3', '  ```'].join('\n')
+    expect(markdownToDoc(md).toJSON()).toEqual({
+      type: 'doc',
+      attrs: { frontmatter: null },
+      content: [
+        {
+          type: 'list',
+          attrs: {
+            kind: 'bullet',
+            order: null,
+            checked: false,
+            collapsed: false,
+            marker: '-',
+            taskMarker: null,
+          },
+          content: [
+            { type: 'paragraph', content: [{ type: 'text', text: 'a' }] },
+            {
+              type: 'codeBlock',
+              attrs: { language: '' },
+              content: [{ type: 'text', text: 'l1\nl2\nl3' }],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
   it('keeps a horizontal rule', () => {
     expect(markdownToDoc('---').toJSON()).toEqual({
       type: 'doc',

--- a/packages/core/src/converters/md-to-pm.test.ts
+++ b/packages/core/src/converters/md-to-pm.test.ts
@@ -217,7 +217,14 @@ describe('markdownToDoc', () => {
   })
 
   it('keeps a fenced block with language', () => {
-    expect(markdownToDoc('```js\nconsole.log(1)\n```').toJSON()).toEqual({
+    const md = [
+      // A code block
+      '```js',
+      'console.log(1)',
+      '```',
+    ].join('\n')
+
+    expect(markdownToDoc(md).toJSON()).toEqual({
       type: 'doc',
       attrs: { frontmatter: null },
       content: [
@@ -230,10 +237,17 @@ describe('markdownToDoc', () => {
     })
   })
 
-  it('keeps every line of a fenced block nested in a list item', () => {
-    // lezer emits one CodeText per line for a code block inside a container, so
-    // the converter must accumulate them; overwriting drops all but the last.
-    const md = ['- a', '', '  ```', '  l1', '  l2', '  l3', '  ```'].join('\n')
+  it('keeps a multiple-line fenced block nested in a list item', () => {
+    const md = [
+      // A code block inside a list item
+      '- x',
+      '',
+      '  ```',
+      '  line1',
+      '  line2',
+      '  line3',
+      '  ```',
+    ].join('\n')
     expect(markdownToDoc(md).toJSON()).toEqual({
       type: 'doc',
       attrs: { frontmatter: null },

--- a/packages/core/src/converters/md-to-pm.test.ts
+++ b/packages/core/src/converters/md-to-pm.test.ts
@@ -263,11 +263,11 @@ describe('markdownToDoc', () => {
             taskMarker: null,
           },
           content: [
-            { type: 'paragraph', content: [{ type: 'text', text: 'a' }] },
+            { type: 'paragraph', content: [{ type: 'text', text: 'x' }] },
             {
               type: 'codeBlock',
               attrs: { language: '' },
-              content: [{ type: 'text', text: 'l1\nl2\nl3' }],
+              content: [{ type: 'text', text: 'line1\nline2\nline3' }],
             },
           ],
         },

--- a/packages/core/src/converters/md-to-pm.ts
+++ b/packages/core/src/converters/md-to-pm.ts
@@ -439,7 +439,12 @@ function convertCodeBlock(
           language = text.slice(cursor.from, cursor.to)
           break
         case LEZER_NODE_IDS.CodeText:
-          code = text.slice(cursor.from, cursor.to)
+          // Inside a container (list item, blockquote) lezer scrubs each line's
+          // structural indent and emits one `CodeText` per line, the stripped
+          // indent living in the gaps between them; each slice already carries
+          // its own trailing newline. Accumulate so every line survives - a
+          // top-level block is the single-`CodeText` case of the same loop.
+          code += text.slice(cursor.from, cursor.to)
           break
       }
     } while (cursor.nextSibling())

--- a/packages/core/src/converters/md-to-pm.ts
+++ b/packages/core/src/converters/md-to-pm.ts
@@ -439,11 +439,6 @@ function convertCodeBlock(
           language = text.slice(cursor.from, cursor.to)
           break
         case LEZER_NODE_IDS.CodeText:
-          // Inside a container (list item, blockquote) lezer scrubs each line's
-          // structural indent and emits one `CodeText` per line, the stripped
-          // indent living in the gaps between them; each slice already carries
-          // its own trailing newline. Accumulate so every line survives - a
-          // top-level block is the single-`CodeText` case of the same loop.
           code += text.slice(cursor.from, cursor.to)
           break
       }

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -609,6 +609,13 @@ describe('mixed structures', () => {
     expect(roundtrip(md)).toBe(md + '\n')
   })
 
+  it('keeps every line of a multi-line code block in a list item', () => {
+    // Regression: lezer emits one CodeText per line inside a container, so a
+    // converter that overwrites instead of accumulating drops all but the last.
+    const md = ['- a', '', '  ```', '  l1', '  l2', '  l3', '  ```'].join('\n')
+    expect(roundtrip(md)).toBe(md + '\n')
+  })
+
   it('keeps a table then a list', () => {
     const md = ['| a | b |', '| --- | --- |', '| 1 | 2 |', '', '- list'].join('\n')
     expect(roundtrip(md)).toBe(md + '\n')

--- a/packages/core/src/lezer/parser.test.ts
+++ b/packages/core/src/lezer/parser.test.ts
@@ -495,20 +495,20 @@ describe('gfmBlockOnlyParser', () => {
       "{
         "name": "Document",
         "from": 0,
-        "to": 33,
-        "text": "- x\\n\\n  \`\`\`\\n  line1\\n  line2\\n  \`\`\`\\n",
+        "to": 40,
+        "text": "- x\\n\\n  \`\`\`\\n  line1\\n  line2\\n  line3\\n  \`\`\`",
         "children": [
           {
             "name": "BulletList",
             "from": 0,
-            "to": 32,
-            "text": "- x\\n\\n  \`\`\`\\n  line1\\n  line2\\n  \`\`\`",
+            "to": 40,
+            "text": "- x\\n\\n  \`\`\`\\n  line1\\n  line2\\n  line3\\n  \`\`\`",
             "children": [
               {
                 "name": "ListItem",
                 "from": 0,
-                "to": 32,
-                "text": "- x\\n\\n  \`\`\`\\n  line1\\n  line2\\n  \`\`\`",
+                "to": 40,
+                "text": "- x\\n\\n  \`\`\`\\n  line1\\n  line2\\n  line3\\n  \`\`\`",
                 "children": [
                   {
                     "name": "ListMark",
@@ -525,8 +525,8 @@ describe('gfmBlockOnlyParser', () => {
                   {
                     "name": "FencedCode",
                     "from": 7,
-                    "to": 32,
-                    "text": "\`\`\`\\n  line1\\n  line2\\n  \`\`\`",
+                    "to": 40,
+                    "text": "\`\`\`\\n  line1\\n  line2\\n  line3\\n  \`\`\`",
                     "children": [
                       {
                         "name": "CodeMark",
@@ -543,13 +543,19 @@ describe('gfmBlockOnlyParser', () => {
                       {
                         "name": "CodeText",
                         "from": 21,
-                        "to": 26,
-                        "text": "line2"
+                        "to": 27,
+                        "text": "line2\\n"
+                      },
+                      {
+                        "name": "CodeText",
+                        "from": 29,
+                        "to": 34,
+                        "text": "line3"
                       },
                       {
                         "name": "CodeMark",
-                        "from": 29,
-                        "to": 32,
+                        "from": 37,
+                        "to": 40,
                         "text": "\`\`\`"
                       }
                     ]

--- a/packages/core/src/lezer/parser.test.ts
+++ b/packages/core/src/lezer/parser.test.ts
@@ -481,7 +481,16 @@ describe('gfmBlockOnlyParser', () => {
     // container indent and emits one CodeText per line, the stripped indent
     // living in the gaps between the nodes. Each CodeText slice already carries
     // its own trailing newline, so concatenating them rebuilds the code text.
-    const input = ['- x', '', '  ```', '  line1', '  line2', '  ```\n'].join('\n')
+    const input = [
+      // A code block inside a list item
+      '- x',
+      '',
+      '  ```',
+      '  line1',
+      '  line2',
+      '  line3',
+      '  ```',
+    ].join('\n')
     expect(show(buildAst(gfmBlockOnlyParser.parse(input).cursor(), input))).toMatchInlineSnapshot(`
       "{
         "name": "Document",

--- a/packages/core/src/lezer/parser.test.ts
+++ b/packages/core/src/lezer/parser.test.ts
@@ -481,7 +481,7 @@ describe('gfmBlockOnlyParser', () => {
     // container indent and emits one CodeText per line, the stripped indent
     // living in the gaps between the nodes. Each CodeText slice already carries
     // its own trailing newline, so concatenating them rebuilds the code text.
-    const input = '- x\n\n  ```\n  line1\n  line2\n  ```\n'
+    const input = ['- x', '', '  ```', '  line1', '  line2', '  ```\n'].join('\n')
     expect(show(buildAst(gfmBlockOnlyParser.parse(input).cursor(), input))).toMatchInlineSnapshot(`
       "{
         "name": "Document",

--- a/packages/core/src/lezer/parser.test.ts
+++ b/packages/core/src/lezer/parser.test.ts
@@ -474,4 +474,83 @@ describe('gfmBlockOnlyParser', () => {
       }"
     `)
   })
+
+  it('emits one CodeText per line for a fenced code block inside a list item', () => {
+    // A multi-line fenced code block inside a list item. Unlike a top-level
+    // block (one CodeText spanning every line), lezer scrubs each line's 2-space
+    // container indent and emits one CodeText per line, the stripped indent
+    // living in the gaps between the nodes. Each CodeText slice already carries
+    // its own trailing newline, so concatenating them rebuilds the code text.
+    const input = '- x\n\n  ```\n  line1\n  line2\n  ```\n'
+    expect(show(buildAst(gfmBlockOnlyParser.parse(input).cursor(), input))).toMatchInlineSnapshot(`
+      "{
+        "name": "Document",
+        "from": 0,
+        "to": 33,
+        "text": "- x\\n\\n  \`\`\`\\n  line1\\n  line2\\n  \`\`\`\\n",
+        "children": [
+          {
+            "name": "BulletList",
+            "from": 0,
+            "to": 32,
+            "text": "- x\\n\\n  \`\`\`\\n  line1\\n  line2\\n  \`\`\`",
+            "children": [
+              {
+                "name": "ListItem",
+                "from": 0,
+                "to": 32,
+                "text": "- x\\n\\n  \`\`\`\\n  line1\\n  line2\\n  \`\`\`",
+                "children": [
+                  {
+                    "name": "ListMark",
+                    "from": 0,
+                    "to": 1,
+                    "text": "-"
+                  },
+                  {
+                    "name": "Paragraph",
+                    "from": 2,
+                    "to": 3,
+                    "text": "x"
+                  },
+                  {
+                    "name": "FencedCode",
+                    "from": 7,
+                    "to": 32,
+                    "text": "\`\`\`\\n  line1\\n  line2\\n  \`\`\`",
+                    "children": [
+                      {
+                        "name": "CodeMark",
+                        "from": 7,
+                        "to": 10,
+                        "text": "\`\`\`"
+                      },
+                      {
+                        "name": "CodeText",
+                        "from": 13,
+                        "to": 19,
+                        "text": "line1\\n"
+                      },
+                      {
+                        "name": "CodeText",
+                        "from": 21,
+                        "to": 26,
+                        "text": "line2"
+                      },
+                      {
+                        "name": "CodeMark",
+                        "from": 29,
+                        "to": 32,
+                        "text": "\`\`\`"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }"
+    `)
+  })
 })


### PR DESCRIPTION
A multi-line fenced code block inside a list item (or blockquote) lost all lines but the last: lezer emits one `CodeText` node per line inside a container, and `convertCodeBlock` overwrote `code` on each instead of accumulating. This made such notes fail reflect-open's round-trip data-loss gate and open read-only.
 