### PR TITLE
feat: add highlight mark syntax

### DIFF
--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -63,6 +63,14 @@ describe('inline', () => {
     expect(roundtrip('~~strike~~')).toBe('~~strike~~\n')
   })
 
+  it('keeps highlight markers', () => {
+    expect(roundtrip('==highlight==')).toBe('==highlight==\n')
+  })
+
+  it('keeps a highlight inside a list item', () => {
+    expect(roundtrip('- a ==hi== b')).toBe('- a ==hi== b\n')
+  })
+
   it('keeps inline code', () => {
     expect(roundtrip('`inline`')).toBe('`inline`\n')
   })

--- a/packages/core/src/extensions/inline-mark-plugin.test.ts
+++ b/packages/core/src/extensions/inline-mark-plugin.test.ts
@@ -40,6 +40,28 @@ describe('inlineMarkPlugin', () => {
     expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdCode', 'mdPack'])
   })
 
+  it('applies mdHighlight inside ==text==', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    const doc = n.doc(n.paragraph('pre ==hi== post'))
+    fixture.set(doc)
+
+    const pos = findText(fixture.doc, 'hi')
+    expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdHighlight', 'mdPack'])
+    // The `==` syntax markers carry the pack, mdHighlight + mdMark.
+    expect(marksAt(fixture.doc, pos - 1)).toEqual(['mdHighlight', 'mdMark', 'mdPack'])
+  })
+
+  it('keeps nested mdStrong inside ==**bold**==', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    const doc = n.doc(n.paragraph('x ==**bold**== y'))
+    fixture.set(doc)
+
+    const pos = findText(fixture.doc, 'bold')
+    expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdHighlight', 'mdPack', 'mdPack', 'mdStrong'])
+  })
+
   it('applies mdLinkText with href attr inside [text](url)', () => {
     using fixture = setupFixture()
     const { n } = fixture

--- a/packages/core/src/extensions/inline-marks.ts
+++ b/packages/core/src/extensions/inline-marks.ts
@@ -120,6 +120,14 @@ function defineMdDel() {
   })
 }
 
+function defineMdHighlight() {
+  return defineMarkSpec({
+    name: 'mdHighlight' satisfies MarkName,
+    toDOM: () => ['mark', 0],
+    parseDOM: [{ tag: 'mark' }],
+  })
+}
+
 /**
  * Covers the whole `#tag`, `#` included: the `#` is tag content, not
  * removable syntax, so it never carries `mdMark`.
@@ -180,7 +188,7 @@ export interface MdPackAttrs {
    * same kind are kept apart by it (so they do not merge into one mark run), and
    * it stays stable when unrelated text in the block is edited, so editing one
    * unit never re-marks the others. Values: `bold` | `italic` | `code` |
-   * `strike` | `autolink` | `link_${href}` | `image_${src}`.
+   * `strike` | `highlight` | `autolink` | `link_${href}` | `image_${src}`.
    */
   key: string
 }
@@ -215,6 +223,7 @@ export function defineInlineMarks() {
     defineMdLinkText(),
     defineMdLinkUri(),
     defineMdDel(),
+    defineMdHighlight(),
     defineMdTag(),
 
     defineMdWikilinkSource(),

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.ts
@@ -35,10 +35,12 @@ const MARK_NAME_BY_TYPE_ID: ReadonlyMap<number, MarkName> = new Map([
   [LEZER_NODE_IDS.StrongEmphasis, 'mdStrong'],
   [LEZER_NODE_IDS.InlineCode, 'mdCode'],
   [LEZER_NODE_IDS.Strikethrough, 'mdDel'],
+  [LEZER_NODE_IDS.Highlight, 'mdHighlight'],
   [LEZER_NODE_IDS.EmphasisMark, 'mdMark'],
   [LEZER_NODE_IDS.CodeMark, 'mdMark'],
   [LEZER_NODE_IDS.LinkMark, 'mdMark'],
   [LEZER_NODE_IDS.StrikethroughMark, 'mdMark'],
+  [LEZER_NODE_IDS.HighlightMark, 'mdMark'],
   [LEZER_NODE_IDS.URL, 'mdLinkUri'],
   [LEZER_NODE_IDS.Hashtag, 'mdTag'],
   [LEZER_NODE_IDS.WikilinkMark, 'mdMark'],
@@ -119,6 +121,8 @@ function walk(
         packKey = 'code'
       } else if (type === LEZER_NODE_IDS.Strikethrough) {
         packKey = 'strike'
+      } else if (type === LEZER_NODE_IDS.Highlight) {
+        packKey = 'highlight'
       } else if (type === LEZER_NODE_IDS.Autolink) {
         packKey = 'autolink'
       }

--- a/packages/core/src/extensions/inline-toggle-commands.test.ts
+++ b/packages/core/src/extensions/inline-toggle-commands.test.ts
@@ -191,14 +191,31 @@ describe('keymap', () => {
     await userEvent.keyboard(`{ControlOrMeta>}{Shift>}x{/Shift}{/ControlOrMeta}`)
     expect(docToMarkdown(fixture.doc)).toBe('~~bold~~\n')
   })
+
+  it('Mod-Shift-h wraps the selection in ==', async () => {
+    using fixture = setupFixture()
+    fixture.set(fixture.n.doc(fixture.n.paragraph('<a>bold<b>')))
+    fixture.view.focus()
+    await userEvent.keyboard(`{ControlOrMeta>}{Shift>}h{/Shift}{/ControlOrMeta}`)
+    expect(docToMarkdown(fixture.doc)).toBe('==bold==\n')
+  })
+
+  it('Mod-Shift-h unwraps an existing highlight', async () => {
+    using fixture = setupFixture()
+    fixture.set(fixture.n.doc(fixture.n.paragraph('==<a>bold<b>==')))
+    fixture.view.focus()
+    await userEvent.keyboard(`{ControlOrMeta>}{Shift>}h{/Shift}{/ControlOrMeta}`)
+    expect(docToMarkdown(fixture.doc)).toBe('bold\n')
+  })
 })
 
 describe('other constructs', () => {
-  it('toggleEm, toggleCode, toggleDel wrap with their delimiters', () => {
+  it('toggleEm, toggleCode, toggleDel, toggleHighlight wrap with their delimiters', () => {
     for (const [command, expected] of [
       ['toggleEm', '*hello*'],
       ['toggleCode', '`hello`'],
       ['toggleDel', '~~hello~~'],
+      ['toggleHighlight', '==hello=='],
     ] as const) {
       using fixture = setupFixture()
       const { editor, n } = fixture

--- a/packages/core/src/extensions/inline-toggle-commands.ts
+++ b/packages/core/src/extensions/inline-toggle-commands.ts
@@ -112,6 +112,7 @@ function defineInlineToggleCommands() {
     toggleStrong: () => toggleInline(TOGGLE_SPECS.strong),
     toggleCode: () => toggleInline(TOGGLE_SPECS.code),
     toggleDel: () => toggleInline(TOGGLE_SPECS.del),
+    toggleHighlight: () => toggleInline(TOGGLE_SPECS.highlight),
   })
 }
 
@@ -121,6 +122,7 @@ function defineInlineToggleKeymap() {
     'Mod-i': toggleInline(TOGGLE_SPECS.em),
     'Mod-e': toggleInline(TOGGLE_SPECS.code),
     'Mod-Shift-x': toggleInline(TOGGLE_SPECS.del),
+    'Mod-Shift-h': toggleInline(TOGGLE_SPECS.highlight),
   })
 }
 

--- a/packages/core/src/extensions/inline-toggle.test.ts
+++ b/packages/core/src/extensions/inline-toggle.test.ts
@@ -167,6 +167,18 @@ describe('toggle del', () => {
   })
 })
 
+describe('toggle highlight', () => {
+  it.each([
+    ['<a>x<b>', '==x=='],
+    ['<a>==hi==<b>', 'hi'],
+    ['==a <a>b<b> c==', '==a== b ==c=='],
+    // other constructs inside survive; same-type spans dissolve
+    ['<a>**a** ==b==<b>', '==**a** b=='],
+  ])('%j -> %j', (input, expected) => {
+    expect(toggle('highlight', input)).toBe(expected)
+  })
+})
+
 describe('isInlineActive', () => {
   it.each([
     ['**<a>bold<b>**', 'strong', true],

--- a/packages/core/src/extensions/inline-toggle.ts
+++ b/packages/core/src/extensions/inline-toggle.ts
@@ -23,6 +23,7 @@ export const TOGGLE_SPECS = {
   strong: { node: LEZER_NODE_IDS.StrongEmphasis, delim: '**' },
   code: { node: LEZER_NODE_IDS.InlineCode, delim: '`' },
   del: { node: LEZER_NODE_IDS.Strikethrough, delim: '~~' },
+  highlight: { node: LEZER_NODE_IDS.Highlight, delim: '==' },
 } as const satisfies Record<string, ToggleSpec>
 
 export type ToggleName = keyof typeof TOGGLE_SPECS
@@ -32,6 +33,7 @@ const MARKER_IDS: ReadonlySet<number> = new Set([
   LEZER_NODE_IDS.CodeMark,
   LEZER_NODE_IDS.LinkMark,
   LEZER_NODE_IDS.StrikethroughMark,
+  LEZER_NODE_IDS.HighlightMark,
 ])
 
 /** The opening and closing delimiter tokens of a toggleable node. */
@@ -50,7 +52,8 @@ function nestableContent(node: InlineElement): [number, number] | null {
   if (
     type === LEZER_NODE_IDS.Emphasis ||
     type === LEZER_NODE_IDS.StrongEmphasis ||
-    type === LEZER_NODE_IDS.Strikethrough
+    type === LEZER_NODE_IDS.Strikethrough ||
+    type === LEZER_NODE_IDS.Highlight
   ) {
     return [children[0].to, children.at(-1)!.from]
   }

--- a/packages/core/src/extensions/key-bindings.test.ts
+++ b/packages/core/src/extensions/key-bindings.test.ts
@@ -12,6 +12,7 @@ describe('EDITOR_KEY_BINDINGS', () => {
         "Mod-4": "Heading 4",
         "Mod-5": "Heading 5",
         "Mod-6": "Heading 6",
+        "Mod-Shift-h": "Highlight",
         "Mod-Shift-x": "Strikethrough",
         "Mod-b": "Bold",
         "Mod-e": "Inline code",

--- a/packages/core/src/extensions/key-bindings.ts
+++ b/packages/core/src/extensions/key-bindings.ts
@@ -4,6 +4,7 @@ export const EDITOR_KEY_BINDINGS = {
   'Mod-i': 'Italic',
   'Mod-e': 'Inline code',
   'Mod-Shift-x': 'Strikethrough',
+  'Mod-Shift-h': 'Highlight',
   'Mod-1': 'Heading 1',
   'Mod-2': 'Heading 2',
   'Mod-3': 'Heading 3',

--- a/packages/core/src/extensions/mark-names.ts
+++ b/packages/core/src/extensions/mark-names.ts
@@ -8,6 +8,7 @@ export const MARK_NAMES = [
   'mdLinkText',
   'mdLinkUri',
   'mdDel',
+  'mdHighlight',
   'mdTag',
   'mdWikilinkSource',
   'mdWikilinkView',

--- a/packages/core/src/lezer/highlight.ts
+++ b/packages/core/src/lezer/highlight.ts
@@ -1,0 +1,50 @@
+import type { MarkdownConfig } from '@lezer/markdown'
+
+import { CHAR_EQUAL } from '../unicode.ts'
+
+const HighlightDelim = { resolve: 'Highlight', mark: 'HighlightMark' }
+
+/**
+ * CommonMark punctuation class, copied from `@lezer/markdown`'s own
+ * `Punctuation` regex so highlight flanking decisions match GFM strikethrough.
+ */
+const PUNCTUATION = /[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~\u{A1}\u{2010}-\u{2027}]/u
+
+/**
+ * Inline parser for `==text==` highlight. Emits a `Highlight` node wrapping the
+ * content, with `HighlightMark` runs for the `==` delimiters, mirroring GFM
+ * `Strikethrough`. It reuses strikethrough's whitespace/punctuation flanking
+ * rules so a space-flanked `== ` never opens a highlight (a lone `a == b` stays
+ * literal), and refuses a third `=` so `===` runs are not consumed.
+ */
+export const highlight: MarkdownConfig = {
+  defineNodes: [{ name: 'Highlight' }, { name: 'HighlightMark' }],
+  parseInline: [
+    {
+      name: 'Highlight',
+      after: 'Emphasis',
+      parse(cx, next, pos) {
+        if (
+          next !== CHAR_EQUAL ||
+          cx.char(pos + 1) !== CHAR_EQUAL ||
+          cx.char(pos + 2) === CHAR_EQUAL
+        ) {
+          return -1
+        }
+        const before = cx.slice(pos - 1, pos)
+        const after = cx.slice(pos + 2, pos + 3)
+        const spaceBefore = /\s|^$/.test(before)
+        const spaceAfter = /\s|^$/.test(after)
+        const punctBefore = PUNCTUATION.test(before)
+        const punctAfter = PUNCTUATION.test(after)
+        return cx.addDelimiter(
+          HighlightDelim,
+          pos,
+          pos + 2,
+          !spaceAfter && (!punctAfter || spaceBefore || punctBefore),
+          !spaceBefore && (!punctBefore || spaceAfter || punctAfter),
+        )
+      },
+    },
+  ],
+}

--- a/packages/core/src/lezer/node-ids.test.ts
+++ b/packages/core/src/lezer/node-ids.test.ts
@@ -33,6 +33,8 @@ describe('LEZER_NODE_IDS', () => {
         "HardBreak": 24,
         "Hashtag": 54,
         "HeaderMark": 34,
+        "Highlight": 57,
+        "HighlightMark": 58,
         "HorizontalRule": 5,
         "Image": 28,
         "InlineCode": 29,

--- a/packages/core/src/lezer/node-names.ts
+++ b/packages/core/src/lezer/node-names.ts
@@ -71,6 +71,8 @@ export const LEZER_NODE_NAMES = [
   'Hashtag',
   'Wikilink',
   'WikilinkMark',
+  'Highlight',
+  'HighlightMark',
 ] as const
 
 export type LezerNodeName = (typeof LEZER_NODE_NAMES)[number]

--- a/packages/core/src/lezer/parser.test.ts
+++ b/packages/core/src/lezer/parser.test.ts
@@ -569,3 +569,59 @@ describe('gfmBlockOnlyParser', () => {
     `)
   })
 })
+
+/** Flatten an inline parse to `Name[from,to]` tokens for compact assertions. */
+function inlineTokens(src: string): string[] {
+  const tokens: string[] = []
+  gfmParser.parse(src).iterate({
+    enter: (node) => {
+      if (node.name !== 'Document' && node.name !== 'Paragraph') {
+        tokens.push(`${node.name}[${node.from},${node.to}]`)
+      }
+    },
+  })
+  return tokens
+}
+
+describe('highlight (==text==)', () => {
+  it('wraps the run in Highlight with HighlightMark delimiters', () => {
+    expect(inlineTokens('==hi==')).toEqual([
+      'Highlight[0,6]',
+      'HighlightMark[0,2]',
+      'HighlightMark[4,6]',
+    ])
+  })
+
+  it('finds a highlight surrounded by text', () => {
+    expect(inlineTokens('a ==hi== b')).toEqual([
+      'Highlight[2,8]',
+      'HighlightMark[2,4]',
+      'HighlightMark[6,8]',
+    ])
+  })
+
+  it('allows nested inline syntax inside a highlight', () => {
+    expect(inlineTokens('==**bold**==')).toEqual([
+      'Highlight[0,12]',
+      'HighlightMark[0,2]',
+      'StrongEmphasis[2,10]',
+      'EmphasisMark[2,4]',
+      'EmphasisMark[8,10]',
+      'HighlightMark[10,12]',
+    ])
+  })
+
+  it('nests with strikethrough both ways', () => {
+    expect(inlineTokens('~~==hi==~~')).toContain('Highlight[2,8]')
+    expect(inlineTokens('==~~hi~~==')).toContain('Strikethrough[2,8]')
+  })
+
+  it('does not highlight space-flanked equals runs', () => {
+    expect(inlineTokens('a == b == c').some((token) => token.startsWith('Highlight'))).toBe(false)
+    expect(inlineTokens('== x ==').some((token) => token.startsWith('Highlight'))).toBe(false)
+  })
+
+  it('does not consume a third equals as a delimiter', () => {
+    expect(inlineTokens('foo === bar').some((token) => token.startsWith('Highlight'))).toBe(false)
+  })
+})

--- a/packages/core/src/lezer/parser.ts
+++ b/packages/core/src/lezer/parser.ts
@@ -2,6 +2,7 @@ import { GFM, type InlineContext, parser as defaultParser } from '@lezer/markdow
 
 import { bareAutolink } from './bare-autolink.ts'
 import { hashtag } from './hashtag.ts'
+import { highlight } from './highlight.ts'
 import { wikilink } from './wikilink.ts'
 
 /**
@@ -17,11 +18,11 @@ function consumeAllInline(cx: InlineContext): number {
 
 /**
  * `@lezer/markdown` parser configured with GFM (table, strikethrough,
- * task list, autolink) plus meowdown's `Hashtag`, `Wikilink`, and bare
- * domain autolink inline syntax. Use when both block and inline structure
- * must be recognized.
+ * task list, autolink) plus meowdown's `Hashtag`, `Wikilink`, bare
+ * domain autolink, and `==Highlight==` inline syntax. Use when both block
+ * and inline structure must be recognized.
  */
-export const gfmParser = defaultParser.configure([GFM, hashtag, wikilink, bareAutolink])
+export const gfmParser = defaultParser.configure([GFM, hashtag, wikilink, bareAutolink, highlight])
 
 /**
  * `@lezer/markdown` parser configured with GFM plus a `SkipInline`

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -15,6 +15,7 @@
   --meowdown-muted: light-dark(#52525b, #a1a1aa);
   --meowdown-accent: light-dark(#7c3aed, #c084fc);
   --meowdown-mark: light-dark(#a78bfa, #8b5cf6);
+  --meowdown-highlight: light-dark(#fef08a, #854d0e);
   --meowdown-border: light-dark(#e4e4e7, #3f3f46);
   --meowdown-code-bg: light-dark(#f4f4f5, #18181b);
   --meowdown-table-header-bg: light-dark(#fafafa, #27272a);
@@ -105,6 +106,15 @@
   text-decoration-thickness: 1px;
   text-underline-offset: 2px;
   cursor: pointer;
+}
+
+.ProseMirror mark {
+  background: var(--meowdown-highlight);
+  color: inherit;
+  border-radius: 2px;
+  padding: 0 1px;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
 }
 
 .ProseMirror code {


### PR DESCRIPTION
Adds the `==highlight==` Markdown syntax: a custom lezer inline parser modeled on GFM strikethrough renders it as a live `<mark>` preview that round-trips losslessly. `Mod-Shift-H` toggles it, the same shape as `Mod-B` for bold.