### PR TITLE
feat: convert pasted `<mark>` HTML to `==highlight==`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,9 +42,12 @@
     "@meowdown/vitest": "workspace:*",
     "@ocavue/tsconfig": "^0.7.1",
     "@tsdown/css": "^0.22.3",
+    "@types/mdast": "^4.0.4",
     "@vitest/browser-playwright": "^4.1.9",
     "dedent": "^1.7.2",
     "diffable-html-snapshot": "^0.3.0",
+    "hast-util-to-mdast": "^10.1.2",
+    "mdast-util-to-markdown": "^2.1.2",
     "tsdown": "^0.22.3",
     "vitest": "^4.1.9"
   },

--- a/packages/core/src/converters/html-to-md.test.ts
+++ b/packages/core/src/converters/html-to-md.test.ts
@@ -23,6 +23,24 @@ describe('htmlToMarkdown', () => {
     expect(htmlToMarkdown('<del>gone</del>').trim()).toBe('~~gone~~')
   })
 
+  it('converts a mark element to ==highlight==', () => {
+    expect(htmlToMarkdown('<mark>highlighted</mark>').trim()).toBe('==highlighted==')
+    expect(htmlToMarkdown('<p>hi <mark>there</mark> end</p>').trim()).toBe('hi ==there== end')
+  })
+
+  it('keeps a line-leading mark unescaped', () => {
+    // A literal leading `==` would be escaped to `\==` to guard a setext
+    // heading; writing it through the highlight construct must not be.
+    expect(htmlToMarkdown('<p><mark>start</mark> rest</p>').trim()).toBe('==start== rest')
+  })
+
+  it('keeps nested formatting inside a mark', () => {
+    expect(htmlToMarkdown('<p><mark><strong>bold</strong></mark></p>').trim()).toBe('==**bold**==')
+    expect(htmlToMarkdown('<p>a <mark>x</mark> and <del>y</del></p>').trim()).toBe(
+      'a ==x== and ~~y~~',
+    )
+  })
+
   it('converts a heading and a blockquote', () => {
     expect(htmlToMarkdown('<h2>Title</h2><blockquote><p>q</p></blockquote>').trim()).toBe(
       '## Title\n\n> q',

--- a/packages/core/src/converters/html-to-md.ts
+++ b/packages/core/src/converters/html-to-md.ts
@@ -1,14 +1,66 @@
 import { once } from '@ocavue/utils'
+import type { Handle as HastToMdastHandle } from 'hast-util-to-mdast'
+import type { Parent, PhrasingContent } from 'mdast'
+import type { Handle as MdastToMarkdownHandle } from 'mdast-util-to-markdown'
 import rehypeParse from 'rehype-parse'
 import rehypeRemark from 'rehype-remark'
 import remarkGfm from 'remark-gfm'
 import remarkStringify from 'remark-stringify'
 import { unified } from 'unified'
 
+/**
+ * Inline highlight node for `==text==`. Standard mdast has no such node, so it
+ * is registered here and serialized by `highlightToMarkdown`.
+ */
+interface Highlight extends Parent {
+  type: 'highlight'
+  children: PhrasingContent[]
+}
+
+declare module 'mdast' {
+  interface PhrasingContentMap {
+    highlight: Highlight
+  }
+  interface RootContentMap {
+    highlight: Highlight
+  }
+}
+
+/**
+ * Convert a `<mark>` element into a `highlight` node. There is no built-in
+ * `hast-util-to-mdast` handler for `<mark>`, so without this the highlight is
+ * dropped and only its text survives.
+ */
+const markToHighlight: HastToMdastHandle = (state, element) => {
+  const result: Highlight = {
+    type: 'highlight',
+    children: state.all(element) as PhrasingContent[],
+  }
+  state.patch(element, result)
+  return result
+}
+
+/**
+ * Serialize a `highlight` node as `==text==`. The `==` delimiters are written
+ * through the construct machinery (not as plain text) so they are never
+ * escaped: a leading `=` written as text would otherwise become `\=` to guard
+ * against a setext heading underline. Mirrors `mdast-util-gfm-strikethrough`.
+ */
+const highlightToMarkdown: MdastToMarkdownHandle = (node, _parent, state, info) => {
+  const highlight = node as Highlight
+  const tracker = state.createTracker(info)
+  let value = tracker.move('==')
+  value += tracker.move(
+    state.containerPhrasing(highlight, { ...tracker.current(), before: value, after: '=' }),
+  )
+  value += tracker.move('==')
+  return value
+}
+
 function createProcessor() {
   return unified()
     .use(rehypeParse)
-    .use(rehypeRemark)
+    .use(rehypeRemark, { handlers: { mark: markToHighlight } })
     .use(remarkGfm)
     .use(remarkStringify, {
       bullet: '-',
@@ -19,6 +71,7 @@ function createProcessor() {
       rule: '-',
       ruleRepetition: 3,
       listItemIndent: 'one',
+      handlers: { highlight: highlightToMarkdown },
     })
     .freeze()
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       '@tsdown/css':
         specifier: ^0.22.3
         version: 0.22.3(jiti@2.7.0)(postcss@8.5.15)(tsdown@0.22.3)(yaml@2.9.0)
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@vitest/browser-playwright':
         specifier: ^4.1.9
         version: 4.1.9(playwright@1.61.0)(vite@8.1.0)(vitest@4.1.9)
@@ -118,6 +121,12 @@ importers:
       diffable-html-snapshot:
         specifier: ^0.3.0
         version: 0.3.0
+      hast-util-to-mdast:
+        specifier: ^10.1.2
+        version: 10.1.2
+      mdast-util-to-markdown:
+        specifier: ^2.1.2
+        version: 2.1.2
       tsdown:
         specifier: ^0.22.3
         version: 0.22.3(@tsdown/css@0.22.3)(oxc-resolver@11.20.0)(typescript@6.0.3)


### PR DESCRIPTION
Teaches `htmlToMarkdown` to convert `<mark>` elements into the `==highlight==` syntax via a custom mdast `highlight` node and a stringify handler, so pasting highlighted rich text (or copy/paste within meowdown) round-trips instead of dropping the highlight. Complements #141, which adds the highlight mark itself.