### PR TITLE
feat(core): render block HTML comments as an invisible node

### DIFF
--- a/packages/core/src/converters/md-to-pm.test.ts
+++ b/packages/core/src/converters/md-to-pm.test.ts
@@ -677,6 +677,36 @@ describe('markdownToDoc', () => {
     })
   })
 
+  it('maps an HTML comment onto an invisible htmlComment node', () => {
+    expect(markdownToDoc('<!-- a comment -->').toJSON()).toEqual({
+      type: 'doc',
+      attrs: { frontmatter: null },
+      content: [{ type: 'htmlComment', attrs: { content: '<!-- a comment -->' } }],
+    })
+  })
+
+  it('keeps a multi-line HTML comment verbatim on the node', () => {
+    expect(markdownToDoc('<!-- line one\nline two -->').toJSON()).toEqual({
+      type: 'doc',
+      attrs: { frontmatter: null },
+      content: [{ type: 'htmlComment', attrs: { content: '<!-- line one\nline two -->' } }],
+    })
+  })
+
+  it('separates a comment from adjacent paragraph text', () => {
+    // The shape tools rely on: a sentinel comment, body text, and a closing
+    // sentinel, with no blank lines between them.
+    expect(markdownToDoc('<!-- start -->\nbody text\n<!-- end -->').toJSON()).toEqual({
+      type: 'doc',
+      attrs: { frontmatter: null },
+      content: [
+        { type: 'htmlComment', attrs: { content: '<!-- start -->' } },
+        { type: 'paragraph', content: [{ type: 'text', text: 'body text' }] },
+        { type: 'htmlComment', attrs: { content: '<!-- end -->' } },
+      ],
+    })
+  })
+
   it('keeps a two-line quote clean', () => {
     expect(markdownToDoc('> l1\n> l2').toJSON()).toEqual({
       type: 'doc',

--- a/packages/core/src/converters/md-to-pm.ts
+++ b/packages/core/src/converters/md-to-pm.ts
@@ -126,11 +126,16 @@ function convertBlock(
       return [convertHeading(nodes, cursor, text, 2, true)]
     case LEZER_NODE_IDS.Paragraph:
       return [convertParagraph(nodes, cursor, text)]
-    case LEZER_NODE_IDS.HTMLBlock:
     case LEZER_NODE_IDS.CommentBlock:
+      // A comment is not rendered output: map it onto the invisible `htmlComment`
+      // node so it stays in the document (and round-trips) without reading as
+      // body text. Raw HTML / processing-instruction blocks fall through to a
+      // paragraph - they can carry content a reader expects to see.
+      return [convertHtmlComment(nodes, cursor, text)]
+    case LEZER_NODE_IDS.HTMLBlock:
     case LEZER_NODE_IDS.ProcessingInstructionBlock:
-      // The schema has no HTML / comment node, so keep the raw block as
-      // literal paragraph text; it survives verbatim through a round-trip.
+      // The schema has no HTML node, so keep the raw block as literal paragraph
+      // text; it survives verbatim through a round-trip.
       return [convertParagraph(nodes, cursor, text)]
     case LEZER_NODE_IDS.Blockquote:
       return [convertBlockquote(nodes, cursor, text)]
@@ -314,6 +319,22 @@ function convertParagraph(
     return buildParagraph(nodes, content, column)
   }
   return buildParagraph(nodes, text.slice(from, to), column)
+}
+
+/**
+ * Build the invisible `htmlComment` node from a `CommentBlock`. The raw comment
+ * (delimiters included) is kept verbatim on the node's `content` attribute;
+ * continuation lines are dedented like a paragraph's so the serializer's own
+ * line prefix re-applies the container indent instead of doubling it.
+ */
+function convertHtmlComment(
+  nodes: TypedNodeBuilders,
+  cursor: TreeCursor,
+  text: string,
+): ProseMirrorNode {
+  const column = measureContentColumn(text, cursor.from)
+  const content = dedentContinuation(text.slice(cursor.from, cursor.to), column)
+  return nodes.htmlComment({ content })
 }
 
 function convertBlockquote(

--- a/packages/core/src/converters/pm-to-md.ts
+++ b/packages/core/src/converters/pm-to-md.ts
@@ -4,6 +4,7 @@ import type { ProseMirrorNode } from '@prosekit/pm/model'
 import type { Frontmatter } from '../extensions/frontmatter.ts'
 import type { MeowdownHeadingAttrs } from '../extensions/heading.ts'
 import type { MeowdownHorizontalRuleAttrs } from '../extensions/horizontal-rule.ts'
+import type { MeowdownHtmlCommentAttrs } from '../extensions/html-comment.ts'
 import type { MeowdownListAttrs } from '../extensions/list.ts'
 import type { NodeName } from '../extensions/node-names.ts'
 import { longestBacktickRun } from '../utils/backticks.ts'
@@ -227,6 +228,12 @@ function emit(node: ProseMirrorNode, out: MdOut): void {
     case 'horizontalRule': {
       const { marker } = node.attrs as MeowdownHorizontalRuleAttrs
       out.write(marker || '---')
+      out.closeBlock()
+      return
+    }
+    case 'htmlComment': {
+      const { content } = node.attrs as MeowdownHtmlCommentAttrs
+      out.write(content)
       out.closeBlock()
       return
     }

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -179,6 +179,18 @@ describe('inline', () => {
     expect(roundtrip('<!-- comment -->')).toBe('<!-- comment -->\n')
   })
 
+  it('keeps a multi-line HTML comment', () => {
+    expect(roundtrip('<!-- line one\nline two -->')).toBe('<!-- line one\nline two -->\n')
+  })
+
+  it('keeps sentinel comments around body text', () => {
+    // The serializer separates a run of blocks with blank lines (as it does for
+    // any adjacent blocks, comment or not); both sentinels and the body survive.
+    expect(roundtrip('<!-- start -->\nbody text\n<!-- end -->')).toBe(
+      '<!-- start -->\n\nbody text\n\n<!-- end -->\n',
+    )
+  })
+
   it('keeps a processing instruction', () => {
     expect(roundtrip('<?php echo 1; ?>')).toBe('<?php echo 1; ?>\n')
   })

--- a/packages/core/src/extensions/extension.test.ts
+++ b/packages/core/src/extensions/extension.test.ts
@@ -22,6 +22,7 @@ describe('defineEditorExtension', () => {
         n.tableRow(n.tableCell(n.paragraph('A1')), n.tableCell(n.paragraph('B1'))),
       ),
       n.horizontalRule(),
+      n.htmlComment({ content: '<!-- a comment -->' }),
     )
 
     expect(doc.toJSON()).toMatchInlineSnapshot(`
@@ -243,6 +244,12 @@ describe('defineEditorExtension', () => {
               "marker": null,
             },
             "type": "horizontalRule",
+          },
+          {
+            "attrs": {
+              "content": "<!-- a comment -->",
+            },
+            "type": "htmlComment",
           },
         ],
         "type": "doc",

--- a/packages/core/src/extensions/extension.ts
+++ b/packages/core/src/extensions/extension.ts
@@ -18,6 +18,7 @@ import { defineCodeBlockSyntaxHighlight } from './code-block-highlight.ts'
 import { defineDocFrontmatterAttr } from './frontmatter.ts'
 import { defineHeading } from './heading.ts'
 import { defineMeowdownHorizontalRule } from './horizontal-rule.ts'
+import { defineHtmlComment } from './html-comment.ts'
 import { defineInlineMarkPlugin } from './inline-mark-plugin.ts'
 import { defineInlineMarks } from './inline-marks.ts'
 import { defineInlineToggle } from './inline-toggle-commands.ts'
@@ -39,6 +40,7 @@ function defineEditorExtensionImpl() {
     defineTable(),
     defineCodeBlock(),
     defineMeowdownHorizontalRule(),
+    defineHtmlComment(),
 
     // marks
     defineInlineMarks(),

--- a/packages/core/src/extensions/html-comment.test.ts
+++ b/packages/core/src/extensions/html-comment.test.ts
@@ -1,0 +1,84 @@
+import { createEditor } from '@prosekit/core'
+import { DOMParser, DOMSerializer } from '@prosekit/pm/model'
+import { describe, expect, it } from 'vitest'
+
+import { docToMarkdown } from '../converters/pm-to-md.ts'
+import { setupFixture } from '../testing/index.ts'
+
+import { defineEditorExtension } from './extension.ts'
+
+function setupEditor() {
+  const editor = createEditor({ extension: defineEditorExtension() })
+  return { editor, schema: editor.schema, n: editor.nodes }
+}
+
+describe('html comment node', () => {
+  it('serializes to a hidden element and recovers its content from the DOM', () => {
+    const { schema, n } = setupEditor()
+    const doc = n.doc(n.htmlComment({ content: '<!-- marker -->' }))
+
+    const dom = DOMSerializer.fromSchema(schema).serializeFragment(doc.content)
+    const container = document.createElement('div')
+    container.appendChild(dom)
+
+    const element = container.querySelector<HTMLElement>('[data-html-comment]')
+    expect(element).not.toBeNull()
+    expect(element?.style.display).toBe('none')
+
+    const parsed = DOMParser.fromSchema(schema).parse(container)
+    expect(parsed.child(0).type.name).toBe('htmlComment')
+    expect(parsed.child(0).attrs.content).toBe('<!-- marker -->')
+  })
+})
+
+describe('html comment in a mounted editor', () => {
+  it('renders the comment invisibly without spilling into the visible text', () => {
+    using fixture = setupFixture()
+    fixture.set(
+      fixture.n.doc(
+        fixture.n.paragraph('before'),
+        fixture.n.htmlComment({ content: '<!-- reflect-capture-page-text:start -->' }),
+        fixture.n.paragraph('after'),
+      ),
+    )
+
+    const element = fixture.dom.querySelector<HTMLElement>('[data-html-comment]')
+    expect(element).not.toBeNull()
+    expect(getComputedStyle(element as HTMLElement).display).toBe('none')
+    // The raw comment must not read as body text in the editor.
+    expect(fixture.dom.textContent).not.toContain('reflect-capture-page-text')
+    expect(fixture.dom.textContent).toContain('before')
+    expect(fixture.dom.textContent).toContain('after')
+  })
+
+  it('keeps the comment in the document so it round-trips to markdown', () => {
+    using fixture = setupFixture()
+    fixture.set(
+      fixture.n.doc(
+        fixture.n.htmlComment({ content: '<!-- start -->' }),
+        fixture.n.paragraph('body text'),
+        fixture.n.htmlComment({ content: '<!-- end -->' }),
+      ),
+    )
+
+    expect(docToMarkdown(fixture.doc)).toBe('<!-- start -->\n\nbody text\n\n<!-- end -->\n')
+  })
+
+  it('steps the caret past the hidden comment without error', async () => {
+    using fixture = setupFixture()
+    fixture.set(
+      fixture.n.doc(
+        fixture.n.paragraph('first<a>'),
+        fixture.n.htmlComment({ content: '<!-- between -->' }),
+        fixture.n.paragraph('second'),
+      ),
+    )
+    fixture.view.focus()
+    // Arrow-down across the invisible node lands in the next paragraph; the
+    // comment survives, proving navigation neither crashes nor drops it.
+    const { userEvent } = await import('vitest/browser')
+    await userEvent.keyboard('{ArrowDown}{ArrowDown}')
+
+    expect(docToMarkdown(fixture.doc)).toBe('first\n\n<!-- between -->\n\nsecond\n')
+  })
+})

--- a/packages/core/src/extensions/html-comment.ts
+++ b/packages/core/src/extensions/html-comment.ts
@@ -1,0 +1,64 @@
+import { defineNodeSpec, type Extension } from '@prosekit/core'
+
+import type { NodeName } from './node-names.ts'
+
+export interface MeowdownHtmlCommentAttrs {
+  /**
+   * The literal markdown comment, including its delimiters, e.g.
+   * `<!-- reflect-capture-page-text:start -->`. A multi-line comment keeps its
+   * embedded newlines verbatim so the round-trip is lossless.
+   */
+  content: string
+}
+
+type HtmlCommentExtension = Extension<{
+  Nodes: { htmlComment: MeowdownHtmlCommentAttrs }
+}>
+
+/**
+ * A block-level HTML comment (`<!-- ... -->`) as an invisible, atomic node.
+ *
+ * Markdown is the source of truth, so a comment must survive a round-trip — but
+ * a comment is, by definition, not rendered output. Rather than spilling the raw
+ * `<!-- ... -->` into a paragraph (where it reads as body text), the parser maps
+ * a `CommentBlock` onto this node: the text rides on the `content` attribute and
+ * `toDOM` hides it with `display: none`, so it stays in the document and
+ * serializes back verbatim while never showing in the editor. Useful for
+ * sentinel markers that tools embed around a region of a note.
+ *
+ * Only block-level comments (a `<!-- ... -->` that owns its line) become this
+ * node. An inline comment in the middle of a paragraph is left as literal text,
+ * and raw HTML blocks (`<div>…`) stay visible paragraphs — they can carry
+ * content a reader expects to see.
+ *
+ * The node is `atom` (no editable content) and not selectable: it is an opaque,
+ * invisible marker the cursor steps over rather than a block the user edits.
+ */
+export function defineHtmlComment(): HtmlCommentExtension {
+  return defineNodeSpec({
+    name: 'htmlComment' satisfies NodeName,
+    group: 'block',
+    atom: true,
+    selectable: false,
+    attrs: {
+      content: { default: '' },
+    },
+    // Hidden from view, but kept in the DOM so an editor copy/paste or a
+    // serialize → re-parse cycle recovers the raw comment from the data attr.
+    toDOM: (node) => [
+      'div',
+      {
+        'data-html-comment': (node.attrs as MeowdownHtmlCommentAttrs).content,
+        style: 'display: none',
+      },
+    ],
+    parseDOM: [
+      {
+        tag: 'div[data-html-comment]',
+        getAttrs: (dom) => ({
+          content: dom.getAttribute('data-html-comment') ?? '',
+        }),
+      },
+    ],
+  })
+}

--- a/packages/core/src/extensions/node-names.ts
+++ b/packages/core/src/extensions/node-names.ts
@@ -10,6 +10,7 @@ export const NODE_NAMES = [
   'list',
   'codeBlock',
   'horizontalRule',
+  'htmlComment',
   'table',
   'tableRow',
   'tableCell',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ export {
   type TagClickPayload,
 } from './extensions/tag-click.ts'
 export { defineImage, type ImageOptions, defaultResolveImageUrl } from './extensions/image.ts'
+export { defineHtmlComment, type MeowdownHtmlCommentAttrs } from './extensions/html-comment.ts'
 export { matchEmbed, listenForTweetHeight, type EmbedDescriptor } from './extensions/embed/index.ts'
 export {
   defineCodeBlockSyntaxHighlight,


### PR DESCRIPTION
## What

Block-level HTML comments (`<!-- ... -->`) were parsed into a paragraph of literal text, so they showed up as visible body content in the editor — even though a comment is, by definition, not rendered output.

This adds a dedicated, invisible `htmlComment` node. A lezer `CommentBlock` now maps onto it: the raw comment (delimiters included) rides on a `content` attribute, `toDOM` hides it with `display: none`, and it serializes straight back to markdown. The comment stays in the document and round-trips losslessly, but never appears in the editor.

Raw HTML blocks (`<div>…`) and processing instructions (`<?php … ?>`) are unchanged — they still become visible paragraphs, since they can carry content a reader expects to see.

## Why

Comments are a natural place for tools to embed invisible sentinel markers around a region of a note (e.g. wrapping a block of captured page text). Rendering them as body text makes the editor look broken.

## Scope / non-goals

- Only **block-level** comments become the hidden node. An inline `<!-- … -->` mid-paragraph is left as literal text (the block-only parser never produces an inline comment node).
- Block spacing is normalized to blank-line separation on serialize, exactly as it already was for the old paragraph form — round-trip output is byte-identical to before for any given run of blocks.

## Node behavior

`htmlComment` is `atom` and `selectable: false`: an opaque, invisible marker the cursor steps over rather than a block the user edits. `parseDOM` recovers the raw comment from a `data-html-comment` attribute, so editor copy/paste and DOM re-parses stay lossless.

## Testing

- New `html-comment.test.ts`: DOM serialize→parse round-trip, hidden rendering in a mounted editor (`display: none`, never in visible text), caret navigation across the hidden node, markdown round-trip.
- Extended converter + round-trip + schema-coverage tests.
- `pnpm typecheck`, `pnpm lint`, and the full `@meowdown/core` (861) + `@meowdown/react` (119) suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)