### PR TITLE
feat: add onExitBoundary callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@ocavue/tsconfig": "^0.7.1",
     "@types/node": "^24.0.0",
     "@vitest/coverage-v8": "^4.1.9",
+    "clsx": "^2.1.1",
     "eslint": "^10.5.0",
     "knip": "^6.17.1",
     "monorepo-typescript-references": "^1.1.2",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -111,6 +111,8 @@ Pasting rich-text HTML from a browser (a bullet list, **bold**, a link, ...) con
 
 Pressing Enter at the end of the document's first heading (the title line) can start a fresh empty bullet on the next line instead of a plain paragraph. `defineBulletAfterHeading()` binds this. It is not part of `defineEditorExtension`; add it explicitly.
 
+Pressing ArrowUp on the first visual line or ArrowDown on the last, when the caret can move no further, can notify the host so it can move focus elsewhere (a previous/next note or page). `defineExitBoundaryHandler(({ direction, event }) => ...)` (or `@meowdown/react`'s `onExitBoundary` prop) fires with `direction` (`'up'` or `'down'`) and the original `KeyboardEvent`; return `false` to let the editor handle the key normally. It also fires for a selected node at the edge, and ignores arrows carrying a modifier. It is not part of `defineEditorExtension`; add it explicitly.
+
 ## API
 
 See the full API reference [here](https://npmx.dev/package-docs/@meowdown%2Fcore/).

--- a/packages/core/src/extensions/exit-boundary.test.ts
+++ b/packages/core/src/extensions/exit-boundary.test.ts
@@ -1,0 +1,143 @@
+import { NodeSelection } from '@prosekit/pm/state'
+import { describe, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+
+import { setupFixture, type Fixture } from '../testing/index.ts'
+
+import { defineExitBoundaryHandler, type ExitBoundaryHandler } from './exit-boundary.ts'
+
+function setup(onExitBoundary: ExitBoundaryHandler): Fixture {
+  const fixture = setupFixture()
+  fixture.editor.use(defineExitBoundaryHandler(onExitBoundary))
+  return fixture
+}
+
+// A block node that can be wrapped in a NodeSelection.
+function makeTable(n: Fixture['n']) {
+  return n.table(
+    n.tableRow(n.tableHeaderCell(n.paragraph('a')), n.tableHeaderCell(n.paragraph('b'))),
+    n.tableRow(n.tableCell(n.paragraph('1')), n.tableCell(n.paragraph('2'))),
+  )
+}
+
+describe('defineExitBoundaryHandler', () => {
+  it('fires "up" when ArrowUp is pressed at the document top', async () => {
+    const onExitBoundary = vi.fn<ExitBoundaryHandler>()
+    using fixture = setup(onExitBoundary)
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>hello'), n.paragraph('world')))
+    fixture.view.focus()
+    await userEvent.keyboard('{ArrowUp}')
+    expect(onExitBoundary).toHaveBeenCalledTimes(1)
+    expect(onExitBoundary.mock.calls[0][0]).toMatchObject({ direction: 'up' })
+    expect(onExitBoundary.mock.calls[0][0].event).toBeInstanceOf(KeyboardEvent)
+  })
+
+  it('fires "down" when ArrowDown is pressed at the document bottom', async () => {
+    const onExitBoundary = vi.fn<ExitBoundaryHandler>()
+    using fixture = setup(onExitBoundary)
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('hello'), n.paragraph('world<a>')))
+    fixture.view.focus()
+    await userEvent.keyboard('{ArrowDown}')
+    expect(onExitBoundary).toHaveBeenCalledTimes(1)
+    expect(onExitBoundary.mock.calls[0][0]).toMatchObject({ direction: 'down' })
+  })
+
+  it('does not fire ArrowUp when a block sits above the cursor', async () => {
+    const onExitBoundary = vi.fn<ExitBoundaryHandler>()
+    using fixture = setup(onExitBoundary)
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('hello'), n.paragraph('<a>world')))
+    fixture.view.focus()
+    await userEvent.keyboard('{ArrowUp}')
+    expect(onExitBoundary).not.toHaveBeenCalled()
+  })
+
+  it('does not fire ArrowDown when a block sits below the cursor', async () => {
+    const onExitBoundary = vi.fn<ExitBoundaryHandler>()
+    using fixture = setup(onExitBoundary)
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>hello'), n.paragraph('world')))
+    fixture.view.focus()
+    await userEvent.keyboard('{ArrowDown}')
+    expect(onExitBoundary).not.toHaveBeenCalled()
+  })
+
+  it('uses the visual line, not the caret position: ArrowUp fires from the first wrapped line', async () => {
+    const onExitBoundary = vi.fn<ExitBoundaryHandler>()
+    using fixture = setup(onExitBoundary)
+    const { n } = fixture
+    const filler = 'lorem ipsum '.repeat(300)
+    // Caret a few chars in: still the first visual line, but its pos is not 1.
+    fixture.set(n.doc(n.paragraph(`lo<a>rem ${filler}`)))
+    fixture.view.focus()
+    await userEvent.keyboard('{ArrowUp}')
+    expect(onExitBoundary).toHaveBeenCalledWith(expect.objectContaining({ direction: 'up' }))
+  })
+
+  it('does not fire ArrowUp from a lower visual line of the first paragraph', async () => {
+    const onExitBoundary = vi.fn<ExitBoundaryHandler>()
+    using fixture = setup(onExitBoundary)
+    const { n } = fixture
+    const filler = 'lorem ipsum '.repeat(300)
+    // Caret at the very end: the last visual line of the wrapped paragraph.
+    fixture.set(n.doc(n.paragraph(`${filler}end<a>`)))
+    fixture.view.focus()
+    await userEvent.keyboard('{ArrowUp}')
+    expect(onExitBoundary).not.toHaveBeenCalled()
+  })
+
+  it('fires "up" for a NodeSelection at the document top', async () => {
+    const onExitBoundary = vi.fn<ExitBoundaryHandler>()
+    using fixture = setup(onExitBoundary)
+    const { n, view } = fixture
+    fixture.set(n.doc(makeTable(n), n.paragraph('after')))
+    view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, 0)))
+    view.focus()
+    await userEvent.keyboard('{ArrowUp}')
+    expect(onExitBoundary).toHaveBeenCalledWith(expect.objectContaining({ direction: 'up' }))
+  })
+
+  it('does not fire "down" for a NodeSelection with content below', async () => {
+    const onExitBoundary = vi.fn<ExitBoundaryHandler>()
+    using fixture = setup(onExitBoundary)
+    const { n, view } = fixture
+    fixture.set(n.doc(makeTable(n), n.paragraph('after')))
+    view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, 0)))
+    view.focus()
+    await userEvent.keyboard('{ArrowDown}')
+    expect(onExitBoundary).not.toHaveBeenCalled()
+  })
+
+  it('does not fire for a non-empty text selection', async () => {
+    const onExitBoundary = vi.fn<ExitBoundaryHandler>()
+    using fixture = setup(onExitBoundary)
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>hello<b>'), n.paragraph('world')))
+    fixture.view.focus()
+    await userEvent.keyboard('{ArrowUp}')
+    expect(onExitBoundary).not.toHaveBeenCalled()
+  })
+
+  it('does not fire when a modifier (Shift) is held', async () => {
+    const onExitBoundary = vi.fn<ExitBoundaryHandler>()
+    using fixture = setup(onExitBoundary)
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>hello')))
+    fixture.view.focus()
+    await userEvent.keyboard('{Shift>}{ArrowUp}{/Shift}')
+    expect(onExitBoundary).not.toHaveBeenCalled()
+  })
+
+  it('fires both directions in an empty document', async () => {
+    const onExitBoundary = vi.fn<ExitBoundaryHandler>()
+    using fixture = setup(onExitBoundary)
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>')))
+    fixture.view.focus()
+    await userEvent.keyboard('{ArrowUp}')
+    await userEvent.keyboard('{ArrowDown}')
+    expect(onExitBoundary.mock.calls.map((call) => call[0].direction)).toEqual(['up', 'down'])
+  })
+})

--- a/packages/core/src/extensions/exit-boundary.test.ts
+++ b/packages/core/src/extensions/exit-boundary.test.ts
@@ -88,15 +88,39 @@ describe('defineExitBoundaryHandler', () => {
     expect(onExitBoundary).not.toHaveBeenCalled()
   })
 
-  it('fires "up" for a NodeSelection at the document top', async () => {
+  it('fires "up" only once a node-selected top block has become a gap cursor', async () => {
     const onExitBoundary = vi.fn<ExitBoundaryHandler>()
     using fixture = setup(onExitBoundary)
     const { n, view } = fixture
     fixture.set(n.doc(makeTable(n), n.paragraph('after')))
     view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, 0)))
     view.focus()
+    // First press: gapcursor moves the selection to a gap above the table. The
+    // caret is still inside the document, so the boundary handler must not fire.
     await userEvent.keyboard('{ArrowUp}')
+    expect(onExitBoundary).not.toHaveBeenCalled()
+    // Second press: the gap cursor is at the very top with nothing above it, so
+    // the caret is finally stuck at the boundary.
+    await userEvent.keyboard('{ArrowUp}')
+    expect(onExitBoundary).toHaveBeenCalledTimes(1)
     expect(onExitBoundary).toHaveBeenCalledWith(expect.objectContaining({ direction: 'up' }))
+  })
+
+  it('fires "down" only once a node-selected bottom block has become a gap cursor', async () => {
+    const onExitBoundary = vi.fn<ExitBoundaryHandler>()
+    using fixture = setup(onExitBoundary)
+    const { n, view } = fixture
+    fixture.set(n.doc(n.paragraph('before'), makeTable(n)))
+    const tablePos = view.state.doc.child(0).nodeSize
+    view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, tablePos)))
+    view.focus()
+    // First press: gapcursor moves the selection to a gap below the table.
+    await userEvent.keyboard('{ArrowDown}')
+    expect(onExitBoundary).not.toHaveBeenCalled()
+    // Second press: the gap cursor is at the very bottom with nothing below it.
+    await userEvent.keyboard('{ArrowDown}')
+    expect(onExitBoundary).toHaveBeenCalledTimes(1)
+    expect(onExitBoundary).toHaveBeenCalledWith(expect.objectContaining({ direction: 'down' }))
   })
 
   it('does not fire "down" for a NodeSelection with content below', async () => {

--- a/packages/core/src/extensions/exit-boundary.ts
+++ b/packages/core/src/extensions/exit-boundary.ts
@@ -1,6 +1,6 @@
 import {
   definePlugin,
-  isNodeSelection,
+  isAllSelection,
   isTextSelection,
   Priority,
   withPriority,
@@ -22,7 +22,8 @@ export type ExitBoundaryHandler = (options: ExitBoundaryOptions) => boolean | vo
 // https://code.haverbeke.berlin/prosemirror/prosemirror-view/src/tag/1.41.8/src/capturekeys.ts#L7-L12
 //
 // Whether moving in `direction` lands the selection on another block (a sibling
-// textblock, a node selection, ...). False only when nothing is reachable.
+// textblock, a node selection, a gap cursor position, ...). False only when
+// nothing is reachable.
 function canMoveBlockwise(state: EditorState, direction: 1 | -1): boolean {
   const { $anchor, $head } = state.selection
   const $side = direction > 0 ? $anchor.max($head) : $anchor.min($head)
@@ -34,22 +35,32 @@ function canMoveBlockwise(state: EditorState, direction: 1 | -1): boolean {
   return !!($start && Selection.findFrom($start, direction))
 }
 
+// Mirrors prosemirror-view's `selectVertically`
+// https://code.haverbeke.berlin/prosemirror/prosemirror-view/src/tag/1.41.8/src/capturekeys.ts#L247
+//
+// Whether pressing an arrow in `direction` can still move the selection within
+// the document. When it cannot, the caret is at the document boundary.
 function canMoveVertically(view: EditorView, direction: 1 | -1): boolean {
   const { state } = view
   const { selection } = state
 
-  if (isTextSelection(selection)) {
-    if (!selection.empty) return true
-    if (!view.endOfTextblock(direction < 0 ? 'up' : 'down')) return true
-    return canMoveBlockwise(state, direction)
+  // A non-empty text selection collapses toward `direction`, and a select-all
+  // collapses to a document end. Either way the caret moves, so never a
+  // boundary. (A gap cursor and a node selection fall through to the checks
+  // below.)
+  if (isTextSelection(selection) && !selection.empty) return true
+  if (isAllSelection(selection)) return true
+
+  // When the selection sits in inline content (a text cursor, or a selected
+  // inline node), the caret can still reach another visual line of the same
+  // textblock. `selectVertically` only consults `endOfTextblock` here, where
+  // the parent holds inline content; a block node selection and a gap cursor
+  // have no visual line, so they skip straight to the blockwise check.
+  if (selection.$from.parent.inlineContent && !view.endOfTextblock(direction < 0 ? 'up' : 'down')) {
+    return true
   }
 
-  if (isNodeSelection(selection)) {
-    if (!view.endOfTextblock(direction < 0 ? 'up' : 'down')) return true
-    return canMoveBlockwise(state, direction)
-  }
-
-  return true
+  return canMoveBlockwise(state, direction)
 }
 
 function createExitBoundaryPlugin(onExitBoundary: ExitBoundaryHandler) {

--- a/packages/core/src/extensions/exit-boundary.ts
+++ b/packages/core/src/extensions/exit-boundary.ts
@@ -1,0 +1,77 @@
+import {
+  definePlugin,
+  isNodeSelection,
+  isTextSelection,
+  Priority,
+  withPriority,
+  type PlainExtension,
+} from '@prosekit/core'
+import { Plugin, PluginKey, Selection, type EditorState } from '@prosekit/pm/state'
+import type { EditorView } from '@prosekit/pm/view'
+
+const exitBoundaryKey = new PluginKey('meowdown-exit-boundary')
+
+export interface ExitBoundaryOptions {
+  direction: 'up' | 'down'
+  event: KeyboardEvent
+}
+
+export type ExitBoundaryHandler = (options: ExitBoundaryOptions) => void
+
+// Ported from prosemirror-view's `moveSelectionBlock`
+// https://code.haverbeke.berlin/prosemirror/prosemirror-view/src/tag/1.41.8/src/capturekeys.ts#L7-L12
+//
+// Whether moving in `direction` lands the selection on another block (a sibling
+// textblock, a node selection, ...). False only when nothing is reachable.
+function canMoveBlockwise(state: EditorState, direction: 1 | -1): boolean {
+  const { $anchor, $head } = state.selection
+  const $side = direction > 0 ? $anchor.max($head) : $anchor.min($head)
+  const $start = !$side.parent.inlineContent
+    ? $side
+    : $side.depth
+      ? state.doc.resolve(direction > 0 ? $side.after() : $side.before())
+      : undefined
+  return !!($start && Selection.findFrom($start, direction))
+}
+
+function canMoveVertically(view: EditorView, direction: 1 | -1): boolean {
+  const { state } = view
+  const { selection } = state
+
+  if (isTextSelection(selection)) {
+    if (!selection.empty) return true
+    if (!view.endOfTextblock(direction < 0 ? 'up' : 'down')) return true
+    return canMoveBlockwise(state, direction)
+  }
+
+  if (isNodeSelection(selection)) {
+    if (!view.endOfTextblock(direction < 0 ? 'up' : 'down')) return true
+    return canMoveBlockwise(state, direction)
+  }
+
+  return true
+}
+
+function createExitBoundaryPlugin(onExitBoundary: ExitBoundaryHandler) {
+  return new Plugin({
+    key: exitBoundaryKey,
+    props: {
+      handleKeyDown: (view, event) => {
+        if (event.shiftKey || event.altKey || event.ctrlKey || event.metaKey) {
+          return false
+        }
+
+        const dir = event.key === 'ArrowUp' ? -1 : event.key === 'ArrowDown' ? 1 : undefined
+        if (!dir) return false
+
+        if (canMoveVertically(view, dir)) return false
+        onExitBoundary({ direction: dir < 0 ? 'up' : 'down', event })
+        return true
+      },
+    },
+  })
+}
+
+export function defineExitBoundaryHandler(onExitBoundary: ExitBoundaryHandler): PlainExtension {
+  return withPriority(definePlugin(createExitBoundaryPlugin(onExitBoundary)), Priority.low)
+}

--- a/packages/core/src/extensions/exit-boundary.ts
+++ b/packages/core/src/extensions/exit-boundary.ts
@@ -16,7 +16,7 @@ export interface ExitBoundaryOptions {
   event: KeyboardEvent
 }
 
-export type ExitBoundaryHandler = (options: ExitBoundaryOptions) => void
+export type ExitBoundaryHandler = (options: ExitBoundaryOptions) => boolean | void
 
 // Ported from prosemirror-view's `moveSelectionBlock`
 // https://code.haverbeke.berlin/prosemirror/prosemirror-view/src/tag/1.41.8/src/capturekeys.ts#L7-L12
@@ -65,7 +65,8 @@ function createExitBoundaryPlugin(onExitBoundary: ExitBoundaryHandler) {
         if (!dir) return false
 
         if (canMoveVertically(view, dir)) return false
-        onExitBoundary({ direction: dir < 0 ? 'up' : 'down', event })
+        const result = onExitBoundary({ direction: dir < 0 ? 'up' : 'down', event })
+        if (result === false) return false
         return true
       },
     },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,11 @@ export { codeBlockLanguages } from './extensions/code-block-languages.ts'
 export { defineEmbedPaste } from './extensions/embed-paste.ts'
 export { listenForTweetHeight, matchEmbed, type EmbedDescriptor } from './extensions/embed/index.ts'
 export {
+  defineExitBoundaryHandler,
+  type ExitBoundaryHandler,
+  type ExitBoundaryOptions,
+} from './extensions/exit-boundary.ts'
+export {
   defineEditorExtension,
   type EditorExtension,
   type TypedEditor,

--- a/packages/react/src/components/editor-extensions.tsx
+++ b/packages/react/src/components/editor-extensions.tsx
@@ -1,6 +1,7 @@
 import {
   defineBulletAfterHeading,
   defineEmbedPaste,
+  defineExitBoundaryHandler,
   defineHTMLPaste,
   defineImage,
   defineImageClickHandler,
@@ -12,6 +13,7 @@ import {
   defineTagClickHandler,
   defineWikilinkClickHandler,
   defineWikilinkTrigger,
+  type ExitBoundaryHandler,
   type ImageClickHandler,
   type ImageOptions,
   type LinkClickHandler,
@@ -30,6 +32,7 @@ export interface EditorExtensionsProps {
   onWikilinkClick?: WikilinkClickHandler
   onLinkClick?: LinkClickHandler
   onTagClick?: TagClickHandler
+  onExitBoundary?: ExitBoundaryHandler
   resolveImageUrl?: ImageOptions['resolveImageUrl']
   onImagePaste?: ImageOptions['onImagePaste']
   onImageSaveError?: ImageOptions['onImageSaveError']
@@ -50,6 +53,7 @@ export function EditorExtensions({
   onWikilinkClick,
   onLinkClick,
   onTagClick,
+  onExitBoundary,
   resolveImageUrl,
   onImagePaste,
   onImageSaveError,
@@ -94,6 +98,12 @@ export function EditorExtensions({
     useMemo(() => {
       return onTagClick ? defineTagClickHandler(onTagClick) : null
     }, [onTagClick]),
+  )
+
+  useExtension(
+    useMemo(() => {
+      return onExitBoundary ? defineExitBoundaryHandler(onExitBoundary) : null
+    }, [onExitBoundary]),
   )
 
   useExtension(

--- a/packages/react/src/components/editor.test.tsx
+++ b/packages/react/src/components/editor.test.tsx
@@ -454,6 +454,28 @@ describe('MeowdownEditor', () => {
     })
   })
 
+  it('calls onExitBoundary with "up" when ArrowUp is pressed at the top', async () => {
+    const onExitBoundary = vi.fn()
+    const screen = await render(
+      <MeowdownEditor initialMarkdown="only line" onExitBoundary={onExitBoundary} />,
+    )
+    await screen.getByText('only line').click()
+    await userEvent.keyboard('{ArrowUp}')
+    await vi.waitFor(() => {
+      expect(onExitBoundary).toHaveBeenCalledWith(expect.objectContaining({ direction: 'up' }))
+    })
+  })
+
+  it('does not call onExitBoundary from a middle paragraph', async () => {
+    const onExitBoundary = vi.fn()
+    const screen = await render(
+      <MeowdownEditor initialMarkdown={'one\n\ntwo\n\nthree'} onExitBoundary={onExitBoundary} />,
+    )
+    await screen.getByText('two').click()
+    await userEvent.keyboard('{ArrowUp}')
+    expect(onExitBoundary).not.toHaveBeenCalled()
+  })
+
   it('does not render children in source mode', async () => {
     await render(
       <MeowdownEditor mode="source" initialMarkdown="Hi">

--- a/packages/react/src/components/editor.tsx
+++ b/packages/react/src/components/editor.tsx
@@ -1,4 +1,5 @@
 import type {
+  ExitBoundaryHandler,
   ImageClickHandler,
   ImageOptions,
   LinkClickHandler,
@@ -82,6 +83,17 @@ export interface EditorProps {
    * mode.
    */
   onTagClick?: TagClickHandler
+
+  /**
+   * Called when the caret can move no further in the pressed arrow direction
+   * and leaves the document boundary: ArrowUp on the first visual line,
+   * ArrowDown on the last, or an arrow press on a selected node at the edge.
+   * Use it to move focus to a previous/next note or page. Receives the
+   * `direction` and the original `KeyboardEvent`. Return `false` to let the
+   * editor handle the key normally; any other return value consumes it. Pass a
+   * stable function (e.g. from `useCallback`). Ignored in source mode.
+   */
+  onExitBoundary?: ExitBoundaryHandler
 
   /**
    * Maps an image `src` to a displayable URL, or `undefined` to skip that image.
@@ -168,6 +180,7 @@ export function MeowdownEditor({
   onWikilinkClick,
   onLinkClick,
   onTagClick,
+  onExitBoundary,
   resolveImageUrl,
   onImagePaste,
   onImageSaveError,
@@ -251,6 +264,7 @@ export function MeowdownEditor({
           onWikilinkClick={onWikilinkClick}
           onLinkClick={onLinkClick}
           onTagClick={onTagClick}
+          onExitBoundary={onExitBoundary}
           resolveImageUrl={resolveImageUrl}
           onImagePaste={onImagePaste}
           onImageSaveError={onImageSaveError}

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -2,6 +2,7 @@ import {
   defineEditorExtension,
   type TypedEditor,
   type EditorExtension,
+  type ExitBoundaryHandler,
   type ImageClickHandler,
   type ImageOptions,
   type LinkClickHandler,
@@ -80,6 +81,9 @@ export interface ProseKitEditorProps {
   /** Called on click of a rendered tag. See `EditorProps.onTagClick`. */
   onTagClick?: TagClickHandler
 
+  /** Called when an arrow press leaves the document boundary. See `EditorProps.onExitBoundary`. */
+  onExitBoundary?: ExitBoundaryHandler
+
   /** Resolves an image `src` to a URL. See `EditorProps.resolveImageUrl`. */
   resolveImageUrl?: ImageOptions['resolveImageUrl']
 
@@ -132,6 +136,7 @@ export function ProseKitEditor({
   onWikilinkClick,
   onLinkClick,
   onTagClick,
+  onExitBoundary,
   resolveImageUrl,
   onImagePaste,
   onImageSaveError,
@@ -236,6 +241,7 @@ export function ProseKitEditor({
         onWikilinkClick={onWikilinkClick}
         onLinkClick={onLinkClick}
         onTagClick={onTagClick}
+        onExitBoundary={onExitBoundary}
         resolveImageUrl={resolveImageUrl}
         onImagePaste={onImagePaste}
         onImageSaveError={onImageSaveError}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.9
         version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       eslint:
         specifier: ^10.5.0
         version: 10.5.0(jiti@2.7.0)
@@ -239,6 +242,9 @@ importers:
 
   website:
     dependencies:
+      '@meowdown/core':
+        specifier: workspace:*
+        version: link:../packages/core
       '@meowdown/react':
         specifier: workspace:*
         version: link:../packages/react
@@ -258,6 +264,9 @@ importers:
       '@ocavue/tsconfig':
         specifier: ^0.7.1
         version: 0.7.1
+      '@ocavue/utils':
+        specifier: ^1.7.0
+        version: 1.7.0
       '@tailwindcss/vite':
         specifier: ^4.3.1
         version: 4.3.1(vite@8.1.0)

--- a/website/package.json
+++ b/website/package.json
@@ -8,6 +8,7 @@
     "build": "vite build"
   },
   "dependencies": {
+    "@meowdown/core": "workspace:*",
     "@meowdown/react": "workspace:*",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
@@ -16,6 +17,7 @@
     "@egoist/tailwindcss-icons": "^1.9.2",
     "@iconify-json/simple-icons": "^1.2.86",
     "@ocavue/tsconfig": "^0.7.1",
+    "@ocavue/utils": "^1.7.0",
     "@tailwindcss/vite": "^4.3.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/website/src/app.tsx
+++ b/website/src/app.tsx
@@ -1,5 +1,8 @@
+import type { ExitBoundaryHandler } from '@meowdown/core'
 import { MeowdownEditor, type TagItem, type WikilinkItem } from '@meowdown/react'
-import { type CSSProperties, useLayoutEffect, useState } from 'react'
+import { getId } from '@ocavue/utils'
+import { clsx } from 'clsx/lite'
+import { type CSSProperties, useCallback, useLayoutEffect, useState } from 'react'
 
 import { uploadFile } from './upload-file.ts'
 import { MODES, useEditorMode } from './use-editor-mode.ts'
@@ -186,6 +189,14 @@ function Brand() {
 export function App() {
   const { mode, setMode, activeMode } = useEditorMode()
 
+  // When the caret leaves the document boundary (onExitBoundary), briefly flash
+  // a top or bottom border inside the editor box. A bumped id remounts the
+  // overlay so its one-shot fade restarts on every press.
+  const [edgeFlash, setEdgeFlash] = useState<{ id: number; direction: 'up' | 'down' }>()
+  const handleExitBoundary: ExitBoundaryHandler = useCallback(({ direction }) => {
+    setEdgeFlash({ id: getId(), direction })
+  }, [])
+
   return (
     <main className="relative min-h-dvh overflow-hidden text-stone-600 dark:bg-stone-950">
       <div className="relative mx-auto flex h-dvh max-w-5xl flex-col px-4 py-5 sm:px-6 sm:py-7">
@@ -231,18 +242,35 @@ export function App() {
             />
           </div>
 
-          <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
-            <MeowdownEditor
-              mode={mode}
-              spellCheck={false}
-              initialMarkdown={INITIAL_CONTENT}
-              onTagSearch={searchTags}
-              onWikilinkSearch={searchNotes}
-              onImagePaste={uploadFile}
-              onImageClick={handleImageClick}
-              onLinkClick={handleLinkClick}
-              onTagClick={handleTagClick}
-            />
+          <div className="relative flex min-h-0 flex-1 flex-col">
+            <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+              <MeowdownEditor
+                mode={mode}
+                spellCheck={false}
+                initialMarkdown={INITIAL_CONTENT}
+                onTagSearch={searchTags}
+                onWikilinkSearch={searchNotes}
+                onImagePaste={uploadFile}
+                onImageClick={handleImageClick}
+                onLinkClick={handleLinkClick}
+                onTagClick={handleTagClick}
+                onExitBoundary={handleExitBoundary}
+              />
+            </div>
+
+            {edgeFlash && (
+              <div
+                key={edgeFlash.id}
+                onAnimationEnd={() => setEdgeFlash(undefined)}
+                aria-hidden
+                className={clsx(
+                  'edge-border',
+                  'border-0 pointer-events-none absolute inset-0 z-10',
+                  'border-(--meowdown-accent)',
+                  edgeFlash.direction === 'up' ? 'border-t-2' : 'border-b-2',
+                )}
+              />
+            )}
           </div>
 
           <div className="flex items-center gap-2 border-t border-stone-200/80 bg-stone-50/60 px-4 py-3 text-sm sm:px-5 dark:border-stone-800 dark:bg-stone-950/30">

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -30,6 +30,24 @@ html {
   animation: meowdown-fade-in 0.25s ease;
 }
 
+/* a top/bottom border briefly fades in inside the
+ * editor box when the caret leaves the document boundary */
+@keyframes edge-border {
+  0% {
+    opacity: 0;
+  }
+  20% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.edge-border {
+  animation: edge-border 0.5s ease forwards;
+}
+
 /* ---------------------------------------------------------------------------
  * Segmented control
  *

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -8,6 +8,9 @@
   },
   "references": [
     {
+      "path": "../packages/core/tsconfig.json"
+    },
+    {
       "path": "../packages/react/tsconfig.json"
     }
   ]


### PR DESCRIPTION
Adds an `onExitBoundary` prop (and core `defineExitBoundaryHandler`) that fires when an ArrowUp/ArrowDown press leaves the document boundary, so the host can move focus to a previous/next note or page. The website demo flashes the editor card's inset ring when this happens.