### PR TITLE
fix(react): soften drag selector icon

### DIFF
--- a/packages/react/src/components/block-handle.module.css
+++ b/packages/react/src/components/block-handle.module.css
@@ -54,5 +54,6 @@
     display: block;
     width: 1.25rem;
     height: 1.25rem;
+    opacity: 0.65;
   }
 }


### PR DESCRIPTION
## Summary
- reduce the block drag handle SVG opacity so the selector icon feels less harsh
- keep the existing hit area and hover treatment unchanged

## Testing
- pnpm exec oxfmt --check packages/react/src/components/block-handle.module.css
- git diff --check