### PR TITLE
feat(react): add /now slash command

### DIFF
--- a/packages/react/src/components/editor.tsx
+++ b/packages/react/src/components/editor.tsx
@@ -13,6 +13,8 @@ import type { SelectionJSON } from '@prosekit/core'
 import { clsx } from 'clsx/lite'
 import { useImperativeHandle, useRef, type ReactNode, type Ref } from 'react'
 
+import type { TimeFormat } from '../utils/date-format.ts'
+
 import { CodeMirrorEditor } from './codemirror-editor.tsx'
 import { ProseKitEditor } from './prosekit-editor.tsx'
 import type {
@@ -166,6 +168,12 @@ export interface EditorProps {
    */
   spellCheck?: boolean
 
+  /**
+   * Clock format the `/now` slash command inserts: '12' for "3:45pm" or '24'
+   * for "15:45". Defaults to '12'. Ignored in source mode.
+   */
+  timeFormat?: TimeFormat
+
   /** Class on the editable root (the contenteditable). Rich modes only. */
   editorClassName?: string
 
@@ -201,6 +209,7 @@ export function MeowdownEditor({
   placeholder,
   readOnly,
   spellCheck,
+  timeFormat,
   editorClassName,
   wrapperClassName,
   handleRef,
@@ -286,6 +295,7 @@ export function MeowdownEditor({
           placeholder={placeholder}
           readOnly={readOnly}
           spellCheck={spellCheck}
+          timeFormat={timeFormat}
           editorClassName={editorClassName}
         >
           {children}

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -23,6 +23,7 @@ import { clsx } from 'clsx/lite'
 import { useImperativeHandle, useMemo, useRef, useState, type ReactNode, type Ref } from 'react'
 
 import { defineCodeBlockView } from '../extensions/code-block-view.ts'
+import type { TimeFormat } from '../utils/date-format.ts'
 
 import { BlockHandle } from './block-handle.tsx'
 import { DropIndicator } from './drop-indicator.tsx'
@@ -122,6 +123,9 @@ export interface ProseKitEditorProps {
   /** Enables or disables spell checking in the editor. */
   spellCheck?: boolean
 
+  /** Clock format the `/now` slash command inserts. See `EditorProps.timeFormat`. */
+  timeFormat?: TimeFormat
+
   /** Class on the editable root. See `EditorProps.editorClassName`. */
   editorClassName?: string
 
@@ -154,6 +158,7 @@ export function ProseKitEditor({
   placeholder,
   readOnly,
   spellCheck,
+  timeFormat,
   editorClassName,
   ref,
   children,
@@ -261,7 +266,7 @@ export function ProseKitEditor({
       {blockHandle && !readOnly && <BlockHandle />}
       {!readOnly && <TableHandle />}
       {blockHandle && !readOnly && <DropIndicator />}
-      <SlashMenu />
+      <SlashMenu timeFormat={timeFormat} />
       {!readOnly && <LinkMenu onLinkClick={onLinkClick} onLinkCopy={onLinkCopy} />}
       {onTagSearch && <TagMenu onTagSearch={onTagSearch} />}
       {onWikilinkSearch && <WikilinkMenu onWikilinkSearch={onWikilinkSearch} />}

--- a/packages/react/src/components/slash-menu.test.tsx
+++ b/packages/react/src/components/slash-menu.test.tsx
@@ -23,6 +23,7 @@ const LABELS = [
   'Checkbox list',
   'Code block',
   'Table',
+  'Now',
 ]
 
 describe('SlashMenu', () => {
@@ -75,5 +76,25 @@ describe('SlashMenu', () => {
     await menu.getByText('Checkbox list', { exact: true }).click()
 
     expect(ref.current?.getMarkdown()).toContain('- [ ] Buy milk')
+  })
+
+  it('inserts the current time in 12-hour format by default', async () => {
+    const ref = createRef<EditorHandle>()
+    await render(<ProseKitEditor ref={ref} />)
+    await pmRoot.click()
+    await userEvent.keyboard('/now')
+    await menu.getByText('Now', { exact: true }).click()
+
+    expect(ref.current?.getMarkdown()).toMatch(/^\d{1,2}:\d{2}(am|pm)\n$/)
+  })
+
+  it('inserts the current time in 24-hour format when timeFormat is "24"', async () => {
+    const ref = createRef<EditorHandle>()
+    await render(<ProseKitEditor ref={ref} timeFormat="24" />)
+    await pmRoot.click()
+    await userEvent.keyboard('/now')
+    await menu.getByText('Now', { exact: true }).click()
+
+    expect(ref.current?.getMarkdown()).toMatch(/^\d{2}:\d{2}\n$/)
   })
 })

--- a/packages/react/src/components/slash-menu.tsx
+++ b/packages/react/src/components/slash-menu.tsx
@@ -9,6 +9,8 @@ import {
   AutocompleteRoot,
 } from '@prosekit/react/autocomplete'
 
+import { formatNowTime, type TimeFormat } from '../utils/date-format.ts'
+
 import styles from './autocomplete-menu.module.css'
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
@@ -29,7 +31,12 @@ function SlashMenuItem({ label, kbd, onSelect }: SlashMenuItemProps) {
   )
 }
 
-export function SlashMenu() {
+interface SlashMenuProps {
+  /** The clock format the "Now" item inserts. Defaults to '12'. */
+  timeFormat?: TimeFormat
+}
+
+export function SlashMenu({ timeFormat = '12' }: SlashMenuProps) {
   const editor = useEditor<EditorExtension>()
 
   return (
@@ -92,6 +99,10 @@ export function SlashMenu() {
           <SlashMenuItem
             label="Table"
             onSelect={() => editor.commands.insertTable({ row: 3, col: 3, header: true })}
+          />
+          <SlashMenuItem
+            label="Now"
+            onSelect={() => editor.commands.insertText({ text: formatNowTime(timeFormat) })}
           />
           <AutocompleteEmpty className={styles.Item}>No results</AutocompleteEmpty>
         </AutocompletePopup>

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,5 +1,6 @@
 export { MeowdownEditor, type EditorMode, type EditorProps } from './components/editor.tsx'
 export { MarkdownView, type MarkdownViewProps } from './components/markdown-view.tsx'
+export type { TimeFormat } from './utils/date-format.ts'
 export type {
   EditorHandle,
   EditorStateSnapshot,

--- a/packages/react/src/utils/date-format.test.ts
+++ b/packages/react/src/utils/date-format.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatNowTime, formatTime } from './date-format.ts'
+
+// Build the date from local-time components so getHours/getMinutes read back
+// the same values in any timezone.
+function localTime(hours: number, minutes: number): Date {
+  return new Date(2026, 0, 1, hours, minutes)
+}
+
+// Each case is [hours, minutes, expected].
+type Case = [hours: number, minutes: number, expected: string]
+
+describe('formatTime', () => {
+  it('formats time in 12-hour format', () => {
+    // 12-hour clock drops the leading hour zero and appends am/pm.
+    const cases: Case[] = [
+      [0, 0, '12:00am'],
+      [0, 5, '12:05am'],
+      [9, 8, '9:08am'],
+      [11, 59, '11:59am'],
+      [12, 0, '12:00pm'],
+      [12, 30, '12:30pm'],
+      [13, 45, '1:45pm'],
+      [15, 45, '3:45pm'],
+      [23, 9, '11:09pm'],
+    ]
+    for (const [hours, minutes, expected] of cases) {
+      expect(formatTime(localTime(hours, minutes), '12')).toBe(expected)
+    }
+  })
+
+  it('formats time in 24-hour format', () => {
+    // 24-hour clock keeps the leading hour zero and has no suffix.
+    const cases: Case[] = [
+      [0, 0, '00:00'],
+      [0, 5, '00:05'],
+      [9, 8, '09:08'],
+      [13, 45, '13:45'],
+      [15, 45, '15:45'],
+      [23, 9, '23:09'],
+    ]
+    for (const [hours, minutes, expected] of cases) {
+      expect(formatTime(localTime(hours, minutes), '24')).toBe(expected)
+    }
+  })
+})
+
+describe('formatNowTime', () => {
+  it('formats the current time in 12-hour format', () => {
+    expect(formatNowTime('12')).toMatch(/^\d{1,2}:\d{2}(am|pm)$/)
+  })
+
+  it('formats the current time in 24-hour format', () => {
+    expect(formatNowTime('24')).toMatch(/^\d{2}:\d{2}$/)
+  })
+})

--- a/packages/react/src/utils/date-format.ts
+++ b/packages/react/src/utils/date-format.ts
@@ -1,4 +1,3 @@
-/** The clock format the `/now` slash command inserts. */
 export type TimeFormat = '12' | '24'
 
 /** Formats the current wall-clock time for the `/now` slash command. */
@@ -6,7 +5,8 @@ export function formatNowTime(timeFormat: TimeFormat): string {
   return formatTime(new Date(), timeFormat)
 }
 
-function formatTime(date: Date, timeFormat: TimeFormat): string {
+/** Formats a given time as `3:45pm` ('12') or `15:45` ('24'). */
+export function formatTime(date: Date, timeFormat: TimeFormat): string {
   return timeFormat === '12' ? formatTime12(date) : formatTime24(date)
 }
 

--- a/packages/react/src/utils/date-format.ts
+++ b/packages/react/src/utils/date-format.ts
@@ -1,0 +1,26 @@
+/** The clock format the `/now` slash command inserts. */
+export type TimeFormat = '12' | '24'
+
+/** Formats the current wall-clock time for the `/now` slash command. */
+export function formatNowTime(timeFormat: TimeFormat): string {
+  return formatTime(new Date(), timeFormat)
+}
+
+function formatTime(date: Date, timeFormat: TimeFormat): string {
+  return timeFormat === '12' ? formatTime12(date) : formatTime24(date)
+}
+
+// 12-hour clock drops the leading zero on the hour: "3:45pm", "12:08am".
+function formatTime12(date: Date): string {
+  const hours = date.getHours() % 12 || 12
+  const minutes = date.getMinutes().toString().padStart(2, '0')
+  const meridiem = date.getHours() >= 12 ? 'pm' : 'am'
+  return `${hours}:${minutes}${meridiem}`
+}
+
+// 24-hour clock keeps the leading zero on the hour: "15:45", "09:08".
+function formatTime24(date: Date): string {
+  const hours = date.getHours().toString().padStart(2, '0')
+  const minutes = date.getMinutes().toString().padStart(2, '0')
+  return `${hours}:${minutes}`
+}


### PR DESCRIPTION
Adds a `Now` item to the slash menu that inserts the current time at the caret, ported from reflect-editor. A new `timeFormat` prop (`'12'` default, like `3:45pm`, or `'24'` like `15:45`) on `MeowdownEditor` controls the format.