### PR TITLE
fix: preserve wikilink query casing

### DIFF
--- a/packages/react/src/components/editor.tsx
+++ b/packages/react/src/components/editor.tsx
@@ -55,10 +55,10 @@ export interface EditorProps {
 
   /**
    * Searches notes for the wikilink menu, which opens as soon as `[[` or `@`
-   * is typed. Receives the query (lowercased, punctuation stripped, may be
-   * empty) and returns the note names to show, synchronously or as a promise.
-   * Pass a stable function (e.g. from `useCallback`). Omit to disable the
-   * wikilink menu.
+   * is typed. Receives the query (trimmed, with casing and punctuation
+   * preserved, may be empty) and returns the note names to show, synchronously
+   * or as a promise. Pass a stable function (e.g. from `useCallback`). Omit to
+   * disable the wikilink menu.
    */
   onWikilinkSearch?: WikilinkSearchHandler
 

--- a/packages/react/src/components/types.ts
+++ b/packages/react/src/components/types.ts
@@ -84,7 +84,8 @@ export interface WikilinkItem {
 
 /**
  * Searches notes for the wikilink menu. Receives the query typed after
- * `[[` or `@` (lowercased, punctuation stripped, may be empty or contain
- * spaces) and returns the rows to show, either synchronously or as a promise.
+ * `[[` or `@` (trimmed, with casing and punctuation preserved; may be empty
+ * or contain spaces) and returns the rows to show, either synchronously or as
+ * a promise.
  */
 export type WikilinkSearchHandler = (query: string) => WikilinkItem[] | Promise<WikilinkItem[]>

--- a/packages/react/src/components/wikilink-menu.test.tsx
+++ b/packages/react/src/components/wikilink-menu.test.tsx
@@ -20,7 +20,8 @@ const WIKILINKS: WikilinkItem[] = [
 ]
 
 function searchNotes(query: string): WikilinkItem[] {
-  return WIKILINKS.filter((item) => item.target.toLowerCase().includes(query))
+  const normalizedQuery = query.toLowerCase()
+  return WIKILINKS.filter((item) => item.target.toLowerCase().includes(normalizedQuery))
 }
 
 // In `userEvent.keyboard`, a literal `[` is escaped by doubling it.
@@ -48,6 +49,28 @@ describe('WikilinkMenu', () => {
     await userEvent.keyboard(`${TWO_BRACKETS}re`)
     await expect.element(menu.getByText('Reading list')).toBeVisible()
     await expect.element(menu.getByText('Cat naps')).not.toBeInTheDocument()
+  })
+
+  it('passes the typed wikilink query with casing preserved', async () => {
+    const onWikilinkSearch = vi.fn((): WikilinkItem[] => [{ target: 'Project Note' }])
+    await render(<ProseKitEditor onWikilinkSearch={onWikilinkSearch} />)
+    await pmRoot.click()
+    await userEvent.keyboard(`${TWO_BRACKETS}Project Note`)
+
+    await vi.waitFor(() => {
+      expect(onWikilinkSearch).toHaveBeenLastCalledWith('Project Note')
+    })
+  })
+
+  it('passes the typed wikilink query with punctuation preserved', async () => {
+    const onWikilinkSearch = vi.fn((): WikilinkItem[] => [{ target: 'C++ Notes' }])
+    await render(<ProseKitEditor onWikilinkSearch={onWikilinkSearch} />)
+    await pmRoot.click()
+    await userEvent.keyboard(`${TWO_BRACKETS}C++ Notes`)
+
+    await vi.waitFor(() => {
+      expect(onWikilinkSearch).toHaveBeenLastCalledWith('C++ Notes')
+    })
   })
 
   it('does not open on a single "["', async () => {

--- a/packages/react/src/components/wikilink-menu.tsx
+++ b/packages/react/src/components/wikilink-menu.tsx
@@ -1,5 +1,5 @@
-import type { EditorExtension } from '@meowdown/core'
-import { canUseRegexLookbehind } from '@prosekit/core'
+import type { EditorExtension, TypedEditor } from '@meowdown/core'
+import { canUseRegexLookbehind, OBJECT_REPLACEMENT_CHARACTER } from '@prosekit/core'
 import { useEditor } from '@prosekit/react'
 import {
   AutocompleteEmpty,
@@ -26,6 +26,41 @@ import type { WikilinkItem, WikilinkSearchHandler } from './types.ts'
 const regex = canUseRegexLookbehind()
   ? /(?:\[\[[^[\]]*|(?<!\S)@(?:[^[\]\s][^[\]]*)?)$/u
   : /(?:\[\[[^[\]]*|@(?:[^[\]\s][^[\]]*)?)$/u
+
+const MAX_AUTOCOMPLETE_MATCH = 200
+
+function queryFromMatchedText(text: string): string {
+  if (text.startsWith('[[')) return text.slice(2).trim()
+  if (text.startsWith('@')) return text.slice(1).trim()
+  return text.trim()
+}
+
+// AutocompleteRoot exposes only its normalized query, but defineAutocomplete
+// documents the raw matched text on this decoration.
+function getActiveMatchedText(editor: TypedEditor): string | undefined {
+  const activeMatch = editor.view.dom.querySelector('.prosekit-autocomplete-match')
+  return activeMatch?.getAttribute('data-autocomplete-match-text') ?? undefined
+}
+
+function getMatchedTextBeforeCursor(editor: TypedEditor): string | undefined {
+  const { $from } = editor.state.selection
+  const from = Math.max(0, $from.parentOffset - MAX_AUTOCOMPLETE_MATCH)
+  const textBeforeCursor = $from.parent.textBetween(
+    from,
+    $from.parentOffset,
+    null,
+    OBJECT_REPLACEMENT_CHARACTER,
+  )
+  return regex.exec(textBeforeCursor)?.[0]
+}
+
+function queryFromAutocomplete(editor: TypedEditor, autocompleteQuery: string): string {
+  const activeMatchedText = getActiveMatchedText(editor)
+  if (activeMatchedText != null) return queryFromMatchedText(activeMatchedText)
+  if (autocompleteQuery === '') return ''
+  const matchedText = getMatchedTextBeforeCursor(editor)
+  return matchedText != null ? queryFromMatchedText(matchedText) : autocompleteQuery
+}
 
 interface WikilinkMenuProps {
   onWikilinkSearch: WikilinkSearchHandler
@@ -72,7 +107,9 @@ export function WikilinkMenu({ onWikilinkSearch }: WikilinkMenuProps) {
       regex={regex}
       filter={returnsTrue}
       onOpenChange={(event) => setOpen(event.detail)}
-      onQueryChange={(event) => setQuery(event.detail)}
+      onQueryChange={(event) => {
+        setQuery(queryFromAutocomplete(editor, event.detail))
+      }}
     >
       <AutocompletePositioner className={styles.Positioner}>
         <AutocompletePopup className={styles.Popup} data-testid="wikilink-menu">

--- a/website/src/app.tsx
+++ b/website/src/app.tsx
@@ -109,7 +109,8 @@ const NOTES = [
 async function searchNotes(query: string): Promise<WikilinkItem[]> {
   // Simulate network latency so the wikilink menu's loading state shows up.
   await new Promise((resolve) => setTimeout(resolve, 200))
-  return NOTES.filter((note) => note.toLowerCase().includes(query)).map((note) => ({
+  const normalizedQuery = query.toLowerCase()
+  return NOTES.filter((note) => note.toLowerCase().includes(normalizedQuery)).map((note) => ({
     target: note,
   }))
 }


### PR DESCRIPTION
## Problem

Wikilink autocomplete queries were using ProseKit's default query normalization, which lowercases text and strips punctuation. That is useful for search filtering, but it leaks into note creation flows that use the typed query as the new note target. Typing `[[Project Note` could therefore become a lowercase target instead of preserving the user's intended title casing.

## Before -> After

| Path | Before | After |
| --- | --- | --- |
| `onWikilinkSearch` query | Lowercased and punctuation-stripped | Trimmed, with casing and punctuation preserved |
| Demo note filtering | Assumed already-lowercase input | Normalizes only for comparison |
| Existing note selection | Inserted the selected note target | Unchanged |

## Changes

1. `WikilinkMenu` now derives the query from the active autocomplete match text and strips only the `[[` or `@` trigger.
2. The public `onWikilinkSearch` docs now describe the preserved query semantics.
3. The demo and React test search helpers normalize queries locally for case-insensitive matching.
4. Added regression tests for typed uppercase and punctuation-bearing wikilink queries.

## Verification

- `pnpm vitest packages/react/src/components/wikilink-menu.test.tsx` passed: 25 tests.
- `pnpm typecheck` passed.
- `pnpm lint` passed.
- `pnpm test -- --run` passed: 62 test files, 1063 passing tests, 17 expected failures.

## Risk / Rollout

Low risk. Hosts that want case-insensitive search should normalize inside their `onWikilinkSearch` callback, as the demo now does. Existing selection insertion behavior is unchanged because chosen `WikilinkItem.target` values are still inserted verbatim.
