### PR TITLE
feat: refactor editor theme

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -75,29 +75,13 @@ const markdown = docToMarkdown(editor.state.doc)
 
 ## Styling
 
-`@meowdown/core/style.css` ships a default editor theme. Colors use `light-dark()`, so they follow the page's `color-scheme` (set `color-scheme: light dark` on `:root` for automatic dark mode). Customize by overriding these variables on `:root` or any ancestor:
+`@meowdown/core/style.css` ships a default editor theme. Colors use `light-dark()`, so they follow the page's `color-scheme` (set `color-scheme: light dark` on `:root` for automatic dark mode). Theme it by overriding the `--meowdown-*` variables on `:root` or any ancestor. The full list, with a one-line description and default for each, lives in the commented `:root` block at the top of [`style.css`](./src/style.css), which is the single source of truth.
 
-- `--meowdown-text`: body text color.
-- `--meowdown-heading`: heading color.
-- `--meowdown-muted`: secondary text (blockquotes).
-- `--meowdown-accent`: links, wikilinks, caret, inline code, tags.
-- `--meowdown-mark`: Markdown syntax characters.
-- `--meowdown-border`: horizontal rules and table borders.
-- `--meowdown-code-bg`: code block background.
-- `--meowdown-table-header-bg`: table header row background.
-- `--meowdown-image-radius`: corner radius of rendered inline images.
-- `--meowdown-placeholder`: placeholder text color (defaults to `--meowdown-muted`).
-- `--meowdown-font-mono`: monospace font stack.
-- `--meowdown-gutter`: horizontal editor padding. Applied to the editable root's `.meowdown-content` class (set by `@meowdown/react`), not `.ProseMirror`, so the block handle's drag preview stays unpadded. Floating UI such as the block handle lives inside it; keep it at least `3.5rem`.
-- `--meowdown-selection`: text `::selection` background.
-- `--meowdown-node-outline`: outline of a selected node; border color of selected tables and cells.
-- `--meowdown-node-selection`: background wash of a selected node or selected cells.
-
-Selection colors are standalone variables, not derived from `--meowdown-accent`, so selection can be restyled independently.
+Two things the variable list cannot show: `--meowdown-gutter` is the horizontal editor padding, applied to the editable root's `.meowdown-content` class (set by `@meowdown/react`), not `.ProseMirror`, so the block handle's drag preview stays unpadded; floating UI such as the block handle lives inside it, so keep it at least `3.5rem`. The selection variables (`--meowdown-selection`, `--meowdown-node-outline`, `--meowdown-node-selection`) are standalone, not derived from `--meowdown-accent`, so selection can be restyled independently.
 
 Tags (`#tag`) render as pills via the `.md-tag` class, tinted from `--meowdown-accent`. Wire click handling with `defineTagClickHandler(({ tag, event }) => ...)` (or `@meowdown/react`'s `onTagClick` prop); `tag` is read from the rendered text without the leading `#`.
 
-Wikilinks (`[[target]]`/`[[target|alias]]`) render in place via a mark view as an immutable label (the alias, or the target when there is no alias), with the raw source hidden in hide and focus modes and shown dimmed in show mode. The label uses the `.md-wikilink-label` class and the raw source the `.md-wikilink-source` class, both dashed-underlined and colored by `--meowdown-accent`. In every mark mode the link is a single immutable caret stop: arrowing onto it selects the whole source (ringed with `--meowdown-node-outline` in hide and focus, the native selection over the visible source in show), and Backspace/Delete remove it as a unit. Wire click navigation with `defineWikilinkClickHandler(({ target, event }) => ...)` (or `@meowdown/react`'s `onWikilinkClick` prop).
+Wikilinks (`[[target]]`/`[[target|alias]]`) render in place via a mark view as an immutable label (the alias, or the target when there is no alias), with the raw source hidden in hide and focus modes and shown dimmed in show mode. The label uses the `.md-wikilink-view-label` class, dashed-underlined and colored by `--meowdown-accent`. In every mark mode the link is a single immutable caret stop: arrowing onto it selects the whole source (ringed with `--meowdown-node-outline` in hide and focus, the native selection over the visible source in show), and Backspace/Delete remove it as a unit. Wire click navigation with `defineWikilinkClickHandler(({ target, event }) => ...)` (or `@meowdown/react`'s `onWikilinkClick` prop).
 
 Markdown links (`[text](url)`) render the label as an `<a href>` with the `.md-link` class, colored by `--meowdown-accent`; the `[`, `]`, and `(url)` syntax dims in show mode and hides in hide and focus modes. Wire click handling with `defineLinkClickHandler(({ href, event }) => ...)` (or `@meowdown/react`'s `onLinkClick` prop).
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -77,6 +77,16 @@ const markdown = docToMarkdown(editor.state.doc)
 
 `@meowdown/core/style.css` ships a default editor theme. Colors use `light-dark()`, so they follow the page's `color-scheme` (set `color-scheme: light dark` on `:root` for automatic dark mode). Theme it by overriding the `--meowdown-*` variables on `:root` or any ancestor. The full list, with a one-line description and default for each, lives in the commented `:root` block at the top of [`style.css`](./src/style.css), which is the single source of truth.
 
+meowdown's CSS is wrapped in a cascade layer, `@layer meowdown` (with sub-layers `meowdown.base` for the bundled ProseMirror / prosekit base styles, `meowdown.theme` for the variables, and `meowdown.editor` for the editor rules). Because an un-layered rule always beats a layered one, **any plain rule you write overrides meowdown with no `!important` and no specificity hacks** (e.g. `.ProseMirror h1 { font-size: 2rem }` wins over meowdown's layered heading rule). Put your overrides outside any `@layer`, or in a layer you declare after `meowdown`.
+
+**With Tailwind CSS v4**, import `@meowdown/core/style.css` _after_ `@import 'tailwindcss'` so the `meowdown` layer sorts after Tailwind's `theme` / `base` / `components` / `utilities`. That keeps meowdown's editor styles from being reset by Tailwind's `base` (Preflight) while your own un-layered rules still win. One caveat: with that order the `meowdown` layer also sorts after `utilities`, so a Tailwind utility _class_ placed directly on an editor element will not beat meowdown. If you need utilities to win (while meowdown still beats Preflight), declare the layer order yourself with `utilities` last, referencing the umbrella `meowdown` layer (not its sub-layers). Doing this at the top of your CSS also pins the order even when meowdown's stylesheet is code-split / lazy-loaded:
+
+```css
+@layer theme, base, components, meowdown, utilities;
+@import 'tailwindcss';
+@import '@meowdown/core/style.css';
+```
+
 Two things the variable list cannot show: `--meowdown-gutter` is the horizontal editor padding, applied to the editable root's `.meowdown-content` class (set by `@meowdown/react`), not `.ProseMirror`, so the block handle's drag preview stays unpadded; floating UI such as the block handle lives inside it, so keep it at least `3.5rem`. The selection variables (`--meowdown-selection`, `--meowdown-node-outline`, `--meowdown-node-selection`) are standalone, not derived from `--meowdown-accent`, so selection can be restyled independently.
 
 Tags (`#tag`) render as pills via the `.md-tag` class, tinted from `--meowdown-accent`. Wire click handling with `defineTagClickHandler(({ tag, event }) => ...)` (or `@meowdown/react`'s `onTagClick` prop); `tag` is read from the rendered text without the leading `#`.

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -72,6 +72,8 @@
     --meowdown-node-selection: light-dark(hsl(25 95% 50% / 0.1), hsl(25 95% 60% / 0.12));
     --meowdown-selection: light-dark(hsl(25 95% 50% / 0.22), hsl(25 95% 60% / 0.3));
 
+    /*REVIEW: let's use oklch for all colors so that it's clear to view the meaning of the color by reading the source code */
+
     /* Collapsible bullets: the filled circle drawn behind a collapsed item's dot
      * (so it reads as a target). Standalone so folding can be themed apart. */
     --meowdown-fold-halo: var(--meowdown-accent);

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -78,8 +78,13 @@
      * `--meowdown-fold-halo` instead). */
     --meowdown-bullet: var(--meowdown-muted);
 
-    /* Collapsible bullets: the filled circle behind a collapsed item's dot (so it
-     * reads as a target). Standalone so folding can be themed apart. */
+    /* Bullet dot radius, and the outer radius of a collapsed/hovered bullet's halo. */
+    --meowdown-bullet-radius: 2.5px;
+    --meowdown-bullet-halo-radius: 5.5px;
+
+    /* Collapsible bullets: the themed dot, plus the halo ring drawn around it when a
+     * foldable bullet is collapsed or hovered. Standalone so folding can be themed
+     * apart. */
     --meowdown-fold-halo: var(--meowdown-accent);
 
     /* Horizontal editor padding. Floating UI tracking the hovered block (the block
@@ -214,8 +219,8 @@
     -webkit-mask: none;
     background: radial-gradient(
       circle at center,
-      var(--meowdown-bullet) 0 0.2rem,
-      transparent 0.2rem
+      var(--meowdown-bullet) 0 var(--meowdown-bullet-radius),
+      transparent var(--meowdown-bullet-radius)
     );
   }
 
@@ -292,9 +297,10 @@
     &[data-list-collapsable] > .list-marker:hover {
       background: radial-gradient(
         circle at center,
-        var(--meowdown-bullet) 0 0.2rem,
-        color-mix(in oklab, var(--meowdown-fold-halo) 20%, transparent) 0.2rem 0.45rem,
-        transparent 0.45rem
+        var(--meowdown-bullet) 0 var(--meowdown-bullet-radius),
+        color-mix(in oklab, var(--meowdown-fold-halo) 20%, transparent)
+          var(--meowdown-bullet-radius) var(--meowdown-bullet-halo-radius),
+        transparent var(--meowdown-bullet-halo-radius)
       );
     }
 
@@ -303,9 +309,10 @@
     &[data-list-collapsable][data-list-collapsed] > .list-marker {
       background: radial-gradient(
         circle at center,
-        var(--meowdown-fold-halo) 0 0.2rem,
-        color-mix(in oklab, var(--meowdown-fold-halo) 35%, transparent) 0.2rem 0.45rem,
-        transparent 0.45rem
+        var(--meowdown-fold-halo) 0 var(--meowdown-bullet-radius),
+        color-mix(in oklab, var(--meowdown-fold-halo) 35%, transparent)
+          var(--meowdown-bullet-radius) var(--meowdown-bullet-halo-radius),
+        transparent var(--meowdown-bullet-halo-radius)
       );
     }
 

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -17,6 +17,7 @@
   --meowdown-mark: var(--meowdown-muted);
   --meowdown-highlight: light-dark(#fef08a, #854d0e);
   --meowdown-border: light-dark(#e4e4e7, #3f3f46);
+  --meowdown-blockquote-border: color-mix(in oklab, var(--meowdown-accent) 35%, transparent);
   --meowdown-code-bg: light-dark(#f4f4f5, #18181b);
   --meowdown-image-loading-bg: light-dark(#f4f4f5, #27272a);
   --meowdown-table-header-bg: light-dark(#fafafa, #27272a);
@@ -128,16 +129,15 @@
   font-size: 0.9em;
   padding: 0.1em 0.35em;
   border-radius: 0.35rem;
-  background: color-mix(in oklab, var(--meowdown-accent) 10%, transparent);
-  color: color-mix(in oklab, var(--meowdown-accent) 80%, var(--meowdown-heading));
+  background: var(--meowdown-code-bg);
+  color: inherit;
 }
 
 .ProseMirror blockquote {
   margin-left: 0;
   padding-left: 1rem;
-  border-left: 3px solid color-mix(in oklab, var(--meowdown-accent) 35%, transparent);
+  border-left: 3px solid var(--meowdown-blockquote-border);
   color: var(--meowdown-muted);
-  font-style: italic;
 }
 
 .ProseMirror ul,
@@ -152,6 +152,10 @@
 }
 .ProseMirror li {
   margin-top: 0.25em;
+}
+
+.ProseMirror .prosemirror-flat-list[data-list-kind='bullet']::marker {
+  color: var(--meowdown-muted);
 }
 
 /* ---------------------------------------------------------------------------
@@ -189,7 +193,7 @@
       box-sizing: border-box;
       width: 0.95rem;
       height: 0.95rem;
-      border: 1.5px solid var(--meowdown-border);
+      border: 1px solid var(--meowdown-muted);
       border-radius: 0.25rem; /* square */
       background: transparent center / 100% 100% no-repeat;
       /* Animation: fade the fill and border when (un)checked. */

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -15,73 +15,75 @@
    * any ancestor to customize.
    * ------------------------------------------------------------------------- */
   :root {
-    /*
-      REVIEW: let's put the comment at a line and put the css at the next line for better readability. Let's have an empty line between two variables. for example:
+    /* body text */
+    --meowdown-text: light-dark(oklch(0.37 0.012 286), oklch(0.871 0.005 286));
 
-      comment1
-      --meowdown-var1: 123;
+    /* headings and table header text */
+    --meowdown-heading: light-dark(oklch(0.21 0.006 286), oklch(0.985 0 0));
 
-      comment2
-      --meowdown-var2: 234;
-      */
+    /* secondary text: blockquotes, syntax marks, bullets */
+    --meowdown-muted: light-dark(oklch(0.442 0.015 286), oklch(0.712 0.013 286));
 
-    --meowdown-text: light-dark(#3f3f46, #d4d4d8); /* body text */
-    --meowdown-heading: light-dark(#18181b, #fafafa); /* headings and table header text */
-    --meowdown-muted: light-dark(
-      #52525b,
-      #a1a1aa
-    ); /* secondary text: blockquotes, syntax marks, bullets */
-    --meowdown-accent: light-dark(
-      #ea580c,
-      #fb923c
-    ); /* links, wikilinks, tags, caret, drop indicator */
-    --meowdown-mark: var(--meowdown-muted); /* Markdown syntax characters */
-    --meowdown-highlight: light-dark(#fef08a, #854d0e); /* `==highlight==` background */
-    --meowdown-border: light-dark(
-      #e4e4e7,
-      #3f3f46
-    ); /* rules, table cell borders, popover borders */
-    --meowdown-blockquote-border: color-mix(
-      in oklab,
-      var(--meowdown-accent) 35%,
-      transparent
-    ); /* blockquote left bar */
-    --meowdown-code-bg: light-dark(#f4f4f5, #18181b); /* inline and block code background */
-    --meowdown-image-loading-bg: light-dark(
-      #f4f4f5,
-      #27272a
-    ); /* placeholder fill while an image loads */
-    --meowdown-image-radius: 0.5rem; /* corner radius of rendered inline images */
-    --meowdown-table-header-bg: light-dark(#fafafa, #27272a); /* table header row background */
-    --meowdown-popover-bg: light-dark(
-      #fff,
-      #18181b
-    ); /* floating menus: autocomplete, link, table, block, code */
-    --meowdown-popover-hover-bg: light-dark(
-      #f4f4f5,
-      #27272a
-    ); /* highlighted/hovered row in those menus */
-    --meowdown-danger: light-dark(#ef4444, #f87171); /* destructive menu items */
-    --meowdown-placeholder: var(--meowdown-muted); /* empty-block placeholder text */
-    --meowdown-font-mono: ui-monospace, SFMono-Regular, Menlo, monospace; /* code font stack */
+    /* links, wikilinks, tags, caret, drop indicator */
+    --meowdown-accent: light-dark(oklch(0.646 0.194 41), oklch(0.758 0.159 56));
 
-    /* Selection colors. Deliberately standalone variables, not derived from
-     * `--meowdown-accent`, so selection can be restyled independently. Warm by
-     * default to sit with the orange accent; a consumer can map them to its own. */
-    --meowdown-node-outline: light-dark(hsl(25 95% 45%), hsl(25 95% 60%));
-    --meowdown-node-selection: light-dark(hsl(25 95% 50% / 0.1), hsl(25 95% 60% / 0.12));
-    --meowdown-selection: light-dark(hsl(25 95% 50% / 0.22), hsl(25 95% 60% / 0.3));
+    /* Markdown syntax characters */
+    --meowdown-mark: var(--meowdown-muted);
 
-    /*REVIEW: let's use oklch for all colors so that it's clear to view the meaning of the color by reading the source code */
+    /* `==highlight==` background */
+    --meowdown-highlight: light-dark(oklch(0.945 0.124 102), oklch(0.476 0.103 62));
 
-    /* Collapsible bullets: the filled circle drawn behind a collapsed item's dot
-     * (so it reads as a target). Standalone so folding can be themed apart. */
+    /* rules, table cell borders, popover borders */
+    --meowdown-border: light-dark(oklch(0.92 0.004 286), oklch(0.37 0.012 286));
+
+    /* blockquote left bar */
+    --meowdown-blockquote-border: color-mix(in oklab, var(--meowdown-accent) 35%, transparent);
+
+    /* inline and block code background */
+    --meowdown-code-bg: light-dark(oklch(0.967 0 0), oklch(0.21 0.006 286));
+
+    /* placeholder fill while an image loads */
+    --meowdown-image-loading-bg: light-dark(oklch(0.967 0 0), oklch(0.274 0.005 286));
+
+    /* corner radius of rendered inline images */
+    --meowdown-image-radius: 0.5rem;
+
+    /* table header row background */
+    --meowdown-table-header-bg: light-dark(oklch(0.985 0 0), oklch(0.274 0.005 286));
+
+    /* floating menus: autocomplete, link, table, block, code */
+    --meowdown-popover-bg: light-dark(oklch(1 0 0), oklch(0.21 0.006 286));
+
+    /* highlighted/hovered row in those menus */
+    --meowdown-popover-hover-bg: light-dark(oklch(0.967 0 0), oklch(0.274 0.005 286));
+
+    /* destructive menu items */
+    --meowdown-danger: light-dark(oklch(0.637 0.208 25), oklch(0.711 0.166 22));
+
+    /* empty-block placeholder text */
+    --meowdown-placeholder: var(--meowdown-muted);
+
+    /* code font stack */
+    --meowdown-font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+
+    /* Selection colors: standalone, not derived from `--meowdown-accent`, so
+     * selection can be restyled independently. Warm by default to sit with the
+     * orange accent; a consumer can remap the hue. */
+    --meowdown-node-outline: light-dark(oklch(0.642 0.178 46), oklch(0.741 0.165 52));
+    --meowdown-node-selection: light-dark(
+      oklch(0.693 0.194 46 / 0.1),
+      oklch(0.741 0.165 52 / 0.12)
+    );
+    --meowdown-selection: light-dark(oklch(0.693 0.194 46 / 0.22), oklch(0.741 0.165 52 / 0.3));
+
+    /* Collapsible bullets: the filled circle behind a collapsed item's dot (so it
+     * reads as a target). Standalone so folding can be themed apart. */
     --meowdown-fold-halo: var(--meowdown-accent);
 
-    /* Horizontal editor padding. Floating UI tracking the hovered block (the
-     * block handle in @meowdown/react) must fit inside it: hover tracking only
-     * sees pointer events on the editor element, so a handle outside the
-     * padding closes before it can be clicked. Keep it >= 3.5rem. */
+    /* Horizontal editor padding. Floating UI tracking the hovered block (the block
+     * handle in @meowdown/react) must fit inside it: hover tracking only sees
+     * pointer events on the editor element, so a handle outside the padding closes
+     * before it can be clicked. Keep it >= 3.5rem. */
     --meowdown-gutter: 3.5rem;
   }
 

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -1,4 +1,4 @@
-@layer meowdown.base, meowdown.theme;
+@layer meowdown.base, meowdown.theme, meowdown.editor;
 
 @import '@prosekit/pm/view/style/prosemirror.css' layer(meowdown.base);
 @import '@prosekit/extensions/list/style.css' layer(meowdown.base);
@@ -84,7 +84,9 @@
      * before it can be clicked. Keep it >= 3.5rem. */
     --meowdown-gutter: 3.5rem;
   }
+}
 
+@layer meowdown.editor {
   /* ---------------------------------------------------------------------------
    * Editor surface
    * ------------------------------------------------------------------------- */

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -6,8 +6,6 @@
 @layer meowdown.theme {
   /* ---------------------------------------------------------------------------
    * Default theme: the themeable `--meowdown-*` variables and their defaults.
-   * This block is the canonical reference for theming; the README links here
-   * instead of duplicating the list.
    *
    * Colors resolve through `light-dark()`, so the editor follows the host
    * page's `color-scheme` (set `color-scheme: light dark` on `:root` to get

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -108,8 +108,10 @@
    * handle's drag preview clones a block into a bare `.ProseMirror` container, which
    * must not pick up the gutter padding. */
   .meowdown-content {
-    /*REVIEW: let's do not use this pattern. Let's write down -top -bottom -left -right to make it clear */
-    padding: 1.25rem var(--meowdown-gutter) 1.75rem;
+    padding-top: 1.25rem;
+    padding-right: var(--meowdown-gutter);
+    padding-bottom: 1.75rem;
+    padding-left: var(--meowdown-gutter);
   }
 
   .ProseMirror > * + * {
@@ -203,10 +205,18 @@
     margin-top: 0.25em;
   }
 
-  /* The bullet dot: flat-list (prosekit) masks `.list-marker` into a dot filled
-   * by its `background-color` (defaulting to `currentColor`). Quiet gray here. */
+  /* The bullet dot is painted as a radial-gradient on the (1lh square)
+   * `.list-marker` box, so the dot and, when collapsed, its halo always share one
+   * center (a separate halo element drifts by a sub-pixel). Override prosekit's
+   * icon mask so the gradient shows; `--meowdown-bullet` colors the resting dot. */
   .ProseMirror .prosemirror-flat-list[data-list-kind='bullet'] > .list-marker {
-    background-color: var(--meowdown-bullet);
+    mask: none;
+    -webkit-mask: none;
+    background: radial-gradient(
+      circle at center,
+      var(--meowdown-bullet) 0 0.2rem,
+      transparent 0.2rem
+    );
   }
 
   /* ---------------------------------------------------------------------------
@@ -277,42 +287,26 @@
       cursor: pointer;
     }
 
-    /* A collapsed bullet recolors its dot to the themed fold color, so it reads
-     * as a saturated target centered in the halo below. */
-    &[data-list-collapsable][data-list-collapsed] > .list-marker {
-      background-color: var(--meowdown-fold-halo);
-    }
-
-    /* The halo: a filled circle behind the dot, aligned to the marker column.
-     * Hidden by default, hinted on hover of a foldable item, fully shown when
-     * collapsed, so a folded bullet reads as a target (a dot inside a disc). */
-    &[data-list-collapsable]::before {
-      content: '';
-      position: absolute;
-      inset-inline-start: 0;
-      top: 0;
-      width: 1lh;
-      height: 1lh;
+    /* Hovering a foldable bullet hints a faint halo around the resting dot, so it
+     * reads as foldable. Same gradient as the dot, so it stays concentric. */
+    &[data-list-collapsable] > .list-marker:hover {
       background: radial-gradient(
         circle at center,
-        var(--meowdown-fold-halo) 0 0.25rem,
-        transparent 0.25rem
+        var(--meowdown-bullet) 0 0.2rem,
+        color-mix(in oklab, var(--meowdown-fold-halo) 20%, transparent) 0.2rem 0.45rem,
+        transparent 0.45rem
       );
-      opacity: 0;
-      transition: opacity 120ms ease;
-      pointer-events: none;
     }
 
-    &[data-list-collapsable]:has(> .list-marker:hover)::before {
-      opacity: 0.2;
-    }
-
-    &[data-list-collapsable][data-list-collapsed]::before {
-      opacity: 0.35;
-    }
-
-    &[data-list-collapsable][data-list-collapsed]:has(> .list-marker:hover)::before {
-      opacity: 0.45;
+    /* A collapsed bullet reads as a target: the dot recolors to the themed fold
+     * color and gains a lighter halo ring, all in one concentric gradient. */
+    &[data-list-collapsable][data-list-collapsed] > .list-marker {
+      background: radial-gradient(
+        circle at center,
+        var(--meowdown-fold-halo) 0 0.2rem,
+        color-mix(in oklab, var(--meowdown-fold-halo) 35%, transparent) 0.2rem 0.45rem,
+        transparent 0.45rem
+      );
     }
 
     /* Hide the descendants of a collapsed bullet, keeping its first block. */

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -102,6 +102,7 @@
    * handle's drag preview clones a block into a bare `.ProseMirror` container, which
    * must not pick up the gutter padding. */
   .meowdown-content {
+    /*REVIEW: let's do not use this pattern. Let's write down -top -bottom -left -right to make it clear */
     padding: 1.25rem var(--meowdown-gutter) 1.75rem;
   }
 

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -2,29 +2,52 @@
 @import '@prosekit/extensions/list/style.css';
 
 /* ---------------------------------------------------------------------------
- * Default theme
+ * Default theme: the themeable `--meowdown-*` variables and their defaults.
+ * This block is the canonical reference for theming; the README links here
+ * instead of duplicating the list.
  *
  * Colors resolve through `light-dark()`, so the editor follows the host
  * page's `color-scheme` (set `color-scheme: light dark` on `:root` to get
- * automatic dark mode). Override the `--meowdown-*` variables on `:root` or
+ * automatic dark mode). Override any `--meowdown-*` variable on `:root` or
  * any ancestor to customize.
  * ------------------------------------------------------------------------- */
 :root {
-  --meowdown-text: light-dark(#3f3f46, #d4d4d8);
-  --meowdown-heading: light-dark(#18181b, #fafafa);
-  --meowdown-muted: light-dark(#52525b, #a1a1aa);
-  --meowdown-accent: light-dark(#ea580c, #fb923c);
-  --meowdown-mark: var(--meowdown-muted);
-  --meowdown-highlight: light-dark(#fef08a, #854d0e);
-  --meowdown-border: light-dark(#e4e4e7, #3f3f46);
-  --meowdown-blockquote-border: color-mix(in oklab, var(--meowdown-accent) 35%, transparent);
-  --meowdown-code-bg: light-dark(#f4f4f5, #18181b);
-  --meowdown-image-loading-bg: light-dark(#f4f4f5, #27272a);
-  --meowdown-table-header-bg: light-dark(#fafafa, #27272a);
-  --meowdown-popover-bg: light-dark(#fff, #18181b);
-  --meowdown-popover-hover-bg: light-dark(#f4f4f5, #27272a);
-  --meowdown-danger: light-dark(#ef4444, #f87171);
-  --meowdown-font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+  --meowdown-text: light-dark(#3f3f46, #d4d4d8); /* body text */
+  --meowdown-heading: light-dark(#18181b, #fafafa); /* headings and table header text */
+  --meowdown-muted: light-dark(
+    #52525b,
+    #a1a1aa
+  ); /* secondary text: blockquotes, syntax marks, bullets */
+  --meowdown-accent: light-dark(
+    #ea580c,
+    #fb923c
+  ); /* links, wikilinks, tags, caret, drop indicator */
+  --meowdown-mark: var(--meowdown-muted); /* Markdown syntax characters */
+  --meowdown-highlight: light-dark(#fef08a, #854d0e); /* `==highlight==` background */
+  --meowdown-border: light-dark(#e4e4e7, #3f3f46); /* rules, table cell borders, popover borders */
+  --meowdown-blockquote-border: color-mix(
+    in oklab,
+    var(--meowdown-accent) 35%,
+    transparent
+  ); /* blockquote left bar */
+  --meowdown-code-bg: light-dark(#f4f4f5, #18181b); /* inline and block code background */
+  --meowdown-image-loading-bg: light-dark(
+    #f4f4f5,
+    #27272a
+  ); /* placeholder fill while an image loads */
+  --meowdown-image-radius: 0.5rem; /* corner radius of rendered inline images */
+  --meowdown-table-header-bg: light-dark(#fafafa, #27272a); /* table header row background */
+  --meowdown-popover-bg: light-dark(
+    #fff,
+    #18181b
+  ); /* floating menus: autocomplete, link, table, block, code */
+  --meowdown-popover-hover-bg: light-dark(
+    #f4f4f5,
+    #27272a
+  ); /* highlighted/hovered row in those menus */
+  --meowdown-danger: light-dark(#ef4444, #f87171); /* destructive menu items */
+  --meowdown-placeholder: var(--meowdown-muted); /* empty-block placeholder text */
+  --meowdown-font-mono: ui-monospace, SFMono-Regular, Menlo, monospace; /* code font stack */
 
   /* Selection colors. Deliberately standalone variables, not derived from
    * `--meowdown-accent`, so selection can be restyled independently. Warm by

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -74,6 +74,10 @@
     );
     --meowdown-selection: light-dark(oklch(0.693 0.194 46 / 0.22), oklch(0.741 0.165 52 / 0.3));
 
+    /* The resting bullet dot color (a collapsed bullet's dot uses the themed
+     * `--meowdown-fold-halo` instead). */
+    --meowdown-bullet: var(--meowdown-muted);
+
     /* Collapsible bullets: the filled circle behind a collapsed item's dot (so it
      * reads as a target). Standalone so folding can be themed apart. */
     --meowdown-fold-halo: var(--meowdown-accent);
@@ -202,7 +206,7 @@
   /* The bullet dot: flat-list (prosekit) masks `.list-marker` into a dot filled
    * by its `background-color` (defaulting to `currentColor`). Quiet gray here. */
   .ProseMirror .prosemirror-flat-list[data-list-kind='bullet'] > .list-marker {
-    background-color: var(--meowdown-muted);
+    background-color: var(--meowdown-bullet);
   }
 
   /* ---------------------------------------------------------------------------

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -13,8 +13,8 @@
   --meowdown-text: light-dark(#3f3f46, #d4d4d8);
   --meowdown-heading: light-dark(#18181b, #fafafa);
   --meowdown-muted: light-dark(#52525b, #a1a1aa);
-  --meowdown-accent: light-dark(#7c3aed, #c084fc);
-  --meowdown-mark: light-dark(#a78bfa, #8b5cf6);
+  --meowdown-accent: light-dark(#ea580c, #fb923c);
+  --meowdown-mark: var(--meowdown-muted);
   --meowdown-highlight: light-dark(#fef08a, #854d0e);
   --meowdown-border: light-dark(#e4e4e7, #3f3f46);
   --meowdown-code-bg: light-dark(#f4f4f5, #18181b);
@@ -25,10 +25,11 @@
   --meowdown-font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
 
   /* Selection colors. Deliberately standalone variables, not derived from
-   * `--meowdown-accent`, so selection can be restyled independently. */
-  --meowdown-node-outline: light-dark(hsl(250 100% 60%), hsl(250 100% 72%));
-  --meowdown-node-selection: light-dark(hsl(250 100% 60% / 0.1), hsl(250 100% 72% / 0.12));
-  --meowdown-selection: light-dark(hsl(250 100% 60% / 0.22), hsl(250 100% 72% / 0.3));
+   * `--meowdown-accent`, so selection can be restyled independently. Warm by
+   * default to sit with the orange accent; a consumer can map them to its own. */
+  --meowdown-node-outline: light-dark(hsl(25 95% 45%), hsl(25 95% 60%));
+  --meowdown-node-selection: light-dark(hsl(25 95% 50% / 0.1), hsl(25 95% 60% / 0.12));
+  --meowdown-selection: light-dark(hsl(25 95% 50% / 0.22), hsl(25 95% 60% / 0.3));
 
   /* Collapsible bullets: the filled circle drawn behind a collapsed item's dot
    * (so it reads as a target). Standalone so folding can be themed apart. */

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -199,8 +199,10 @@
     margin-top: 0.25em;
   }
 
-  .ProseMirror .prosemirror-flat-list[data-list-kind='bullet']::marker {
-    color: var(--meowdown-muted);
+  /* The bullet dot: flat-list (prosekit) masks `.list-marker` into a dot filled
+   * by its `background-color` (defaulting to `currentColor`). Quiet gray here. */
+  .ProseMirror .prosemirror-flat-list[data-list-kind='bullet'] > .list-marker {
+    background-color: var(--meowdown-muted);
   }
 
   /* ---------------------------------------------------------------------------
@@ -269,6 +271,12 @@
     /* A foldable bullet's marker is clickable. */
     &[data-list-collapsable] > .list-marker {
       cursor: pointer;
+    }
+
+    /* A collapsed bullet recolors its dot to the themed fold color, so it reads
+     * as a saturated target centered in the halo below. */
+    &[data-list-collapsable][data-list-collapsed] > .list-marker {
+      background-color: var(--meowdown-fold-halo);
     }
 
     /* The halo: a filled circle behind the dot, aligned to the marker column.

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -21,8 +21,9 @@
   --meowdown-code-bg: light-dark(#f4f4f5, #18181b);
   --meowdown-image-loading-bg: light-dark(#f4f4f5, #27272a);
   --meowdown-table-header-bg: light-dark(#fafafa, #27272a);
-  --meowdown-autocomplete-bg: light-dark(#fff, #18181b);
-  --meowdown-autocomplete-highlight-bg: light-dark(#f4f4f5, #27272a);
+  --meowdown-popover-bg: light-dark(#fff, #18181b);
+  --meowdown-popover-hover-bg: light-dark(#f4f4f5, #27272a);
+  --meowdown-danger: light-dark(#ef4444, #f87171);
   --meowdown-font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
 
   /* Selection colors. Deliberately standalone variables, not derived from

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -295,8 +295,8 @@
       height: 1lh;
       background: radial-gradient(
         circle at center,
-        var(--meowdown-fold-halo) 0 0.45rem,
-        transparent 0.45rem
+        var(--meowdown-fold-halo) 0 0.25rem,
+        transparent 0.25rem
       );
       opacity: 0;
       transition: opacity 120ms ease;

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -75,17 +75,16 @@
     --meowdown-selection: light-dark(oklch(0.693 0.194 46 / 0.22), oklch(0.741 0.165 52 / 0.3));
 
     /* The resting bullet dot color (a collapsed bullet's dot uses the themed
-     * `--meowdown-fold-halo` instead). */
+     * `--meowdown-bullet-collapsed` instead). */
     --meowdown-bullet: var(--meowdown-muted);
 
     /* Bullet dot radius, and the outer radius of a collapsed/hovered bullet's halo. */
     --meowdown-bullet-radius: 2.5px;
     --meowdown-bullet-halo-radius: 5.5px;
 
-    /* Collapsible bullets: the themed dot, plus the halo ring drawn around it when a
-     * foldable bullet is collapsed or hovered. Standalone so folding can be themed
-     * apart. */
-    --meowdown-fold-halo: var(--meowdown-accent);
+    /* The dot color of a collapsed (or hovered) foldable bullet; its halo ring is a
+     * lighter mix of this. Standalone so folding can be themed apart from the accent. */
+    --meowdown-bullet-collapsed: var(--meowdown-accent);
 
     /* Horizontal editor padding. Floating UI tracking the hovered block (the block
      * handle in @meowdown/react) must fit inside it: hover tracking only sees
@@ -298,7 +297,7 @@
       background: radial-gradient(
         circle at center,
         var(--meowdown-bullet) 0 var(--meowdown-bullet-radius),
-        color-mix(in oklab, var(--meowdown-fold-halo) 20%, transparent)
+        color-mix(in oklab, var(--meowdown-bullet-collapsed) 20%, transparent)
           var(--meowdown-bullet-radius) var(--meowdown-bullet-halo-radius),
         transparent var(--meowdown-bullet-halo-radius)
       );
@@ -309,8 +308,8 @@
     &[data-list-collapsable][data-list-collapsed] > .list-marker {
       background: radial-gradient(
         circle at center,
-        var(--meowdown-fold-halo) 0 var(--meowdown-bullet-radius),
-        color-mix(in oklab, var(--meowdown-fold-halo) 35%, transparent)
+        var(--meowdown-bullet-collapsed) 0 var(--meowdown-bullet-radius),
+        color-mix(in oklab, var(--meowdown-bullet-collapsed) 35%, transparent)
           var(--meowdown-bullet-radius) var(--meowdown-bullet-halo-radius),
         transparent var(--meowdown-bullet-halo-radius)
       );

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -1,680 +1,698 @@
-@import '@prosekit/pm/view/style/prosemirror.css';
-@import '@prosekit/extensions/list/style.css';
+@layer meowdown.base, meowdown.theme;
 
-/* ---------------------------------------------------------------------------
- * Default theme: the themeable `--meowdown-*` variables and their defaults.
- * This block is the canonical reference for theming; the README links here
- * instead of duplicating the list.
- *
- * Colors resolve through `light-dark()`, so the editor follows the host
- * page's `color-scheme` (set `color-scheme: light dark` on `:root` to get
- * automatic dark mode). Override any `--meowdown-*` variable on `:root` or
- * any ancestor to customize.
- * ------------------------------------------------------------------------- */
-:root {
-  --meowdown-text: light-dark(#3f3f46, #d4d4d8); /* body text */
-  --meowdown-heading: light-dark(#18181b, #fafafa); /* headings and table header text */
-  --meowdown-muted: light-dark(
-    #52525b,
-    #a1a1aa
-  ); /* secondary text: blockquotes, syntax marks, bullets */
-  --meowdown-accent: light-dark(
-    #ea580c,
-    #fb923c
-  ); /* links, wikilinks, tags, caret, drop indicator */
-  --meowdown-mark: var(--meowdown-muted); /* Markdown syntax characters */
-  --meowdown-highlight: light-dark(#fef08a, #854d0e); /* `==highlight==` background */
-  --meowdown-border: light-dark(#e4e4e7, #3f3f46); /* rules, table cell borders, popover borders */
-  --meowdown-blockquote-border: color-mix(
-    in oklab,
-    var(--meowdown-accent) 35%,
-    transparent
-  ); /* blockquote left bar */
-  --meowdown-code-bg: light-dark(#f4f4f5, #18181b); /* inline and block code background */
-  --meowdown-image-loading-bg: light-dark(
-    #f4f4f5,
-    #27272a
-  ); /* placeholder fill while an image loads */
-  --meowdown-image-radius: 0.5rem; /* corner radius of rendered inline images */
-  --meowdown-table-header-bg: light-dark(#fafafa, #27272a); /* table header row background */
-  --meowdown-popover-bg: light-dark(
-    #fff,
-    #18181b
-  ); /* floating menus: autocomplete, link, table, block, code */
-  --meowdown-popover-hover-bg: light-dark(
-    #f4f4f5,
-    #27272a
-  ); /* highlighted/hovered row in those menus */
-  --meowdown-danger: light-dark(#ef4444, #f87171); /* destructive menu items */
-  --meowdown-placeholder: var(--meowdown-muted); /* empty-block placeholder text */
-  --meowdown-font-mono: ui-monospace, SFMono-Regular, Menlo, monospace; /* code font stack */
+@import '@prosekit/pm/view/style/prosemirror.css' layer(meowdown.base);
+@import '@prosekit/extensions/list/style.css' layer(meowdown.base);
 
-  /* Selection colors. Deliberately standalone variables, not derived from
-   * `--meowdown-accent`, so selection can be restyled independently. Warm by
-   * default to sit with the orange accent; a consumer can map them to its own. */
-  --meowdown-node-outline: light-dark(hsl(25 95% 45%), hsl(25 95% 60%));
-  --meowdown-node-selection: light-dark(hsl(25 95% 50% / 0.1), hsl(25 95% 60% / 0.12));
-  --meowdown-selection: light-dark(hsl(25 95% 50% / 0.22), hsl(25 95% 60% / 0.3));
+@layer meowdown.theme {
+  /* ---------------------------------------------------------------------------
+   * Default theme: the themeable `--meowdown-*` variables and their defaults.
+   * This block is the canonical reference for theming; the README links here
+   * instead of duplicating the list.
+   *
+   * Colors resolve through `light-dark()`, so the editor follows the host
+   * page's `color-scheme` (set `color-scheme: light dark` on `:root` to get
+   * automatic dark mode). Override any `--meowdown-*` variable on `:root` or
+   * any ancestor to customize.
+   * ------------------------------------------------------------------------- */
+  :root {
+    /*
+      REVIEW: let's put the comment at a line and put the css at the next line for better readability. Let's have an empty line between two variables. for example:
 
-  /* Collapsible bullets: the filled circle drawn behind a collapsed item's dot
-   * (so it reads as a target). Standalone so folding can be themed apart. */
-  --meowdown-fold-halo: var(--meowdown-accent);
+      comment1
+      --meowdown-var1: 123;
 
-  /* Horizontal editor padding. Floating UI tracking the hovered block (the
-   * block handle in @meowdown/react) must fit inside it: hover tracking only
-   * sees pointer events on the editor element, so a handle outside the
-   * padding closes before it can be clicked. Keep it >= 3.5rem. */
-  --meowdown-gutter: 3.5rem;
-}
+      comment2
+      --meowdown-var2: 234;
+      */
 
-/* ---------------------------------------------------------------------------
- * Editor surface
- * ------------------------------------------------------------------------- */
-.ProseMirror {
-  box-sizing: border-box;
-  outline: none;
-  font-size: 1.0625rem;
-  line-height: 1.7;
-  color: var(--meowdown-text);
-  caret-color: var(--meowdown-accent);
-  -webkit-font-smoothing: antialiased;
-}
+    --meowdown-text: light-dark(#3f3f46, #d4d4d8); /* body text */
+    --meowdown-heading: light-dark(#18181b, #fafafa); /* headings and table header text */
+    --meowdown-muted: light-dark(
+      #52525b,
+      #a1a1aa
+    ); /* secondary text: blockquotes, syntax marks, bullets */
+    --meowdown-accent: light-dark(
+      #ea580c,
+      #fb923c
+    ); /* links, wikilinks, tags, caret, drop indicator */
+    --meowdown-mark: var(--meowdown-muted); /* Markdown syntax characters */
+    --meowdown-highlight: light-dark(#fef08a, #854d0e); /* `==highlight==` background */
+    --meowdown-border: light-dark(
+      #e4e4e7,
+      #3f3f46
+    ); /* rules, table cell borders, popover borders */
+    --meowdown-blockquote-border: color-mix(
+      in oklab,
+      var(--meowdown-accent) 35%,
+      transparent
+    ); /* blockquote left bar */
+    --meowdown-code-bg: light-dark(#f4f4f5, #18181b); /* inline and block code background */
+    --meowdown-image-loading-bg: light-dark(
+      #f4f4f5,
+      #27272a
+    ); /* placeholder fill while an image loads */
+    --meowdown-image-radius: 0.5rem; /* corner radius of rendered inline images */
+    --meowdown-table-header-bg: light-dark(#fafafa, #27272a); /* table header row background */
+    --meowdown-popover-bg: light-dark(
+      #fff,
+      #18181b
+    ); /* floating menus: autocomplete, link, table, block, code */
+    --meowdown-popover-hover-bg: light-dark(
+      #f4f4f5,
+      #27272a
+    ); /* highlighted/hovered row in those menus */
+    --meowdown-danger: light-dark(#ef4444, #f87171); /* destructive menu items */
+    --meowdown-placeholder: var(--meowdown-muted); /* empty-block placeholder text */
+    --meowdown-font-mono: ui-monospace, SFMono-Regular, Menlo, monospace; /* code font stack */
 
-/* Surface padding stays on a meowdown-owned class, not `.ProseMirror`: the block
- * handle's drag preview clones a block into a bare `.ProseMirror` container, which
- * must not pick up the gutter padding. */
-.meowdown-content {
-  padding: 1.25rem var(--meowdown-gutter) 1.75rem;
-}
+    /* Selection colors. Deliberately standalone variables, not derived from
+     * `--meowdown-accent`, so selection can be restyled independently. Warm by
+     * default to sit with the orange accent; a consumer can map them to its own. */
+    --meowdown-node-outline: light-dark(hsl(25 95% 45%), hsl(25 95% 60%));
+    --meowdown-node-selection: light-dark(hsl(25 95% 50% / 0.1), hsl(25 95% 60% / 0.12));
+    --meowdown-selection: light-dark(hsl(25 95% 50% / 0.22), hsl(25 95% 60% / 0.3));
 
-.ProseMirror > * + * {
-  margin-top: 0.85em;
-}
+    /* Collapsible bullets: the filled circle drawn behind a collapsed item's dot
+     * (so it reads as a target). Standalone so folding can be themed apart. */
+    --meowdown-fold-halo: var(--meowdown-accent);
 
-/* Render soft line breaks (a literal `\n` kept by the paragraph's
- * `whitespace: 'pre'` spec) as line breaks, while still wrapping long lines. */
-.ProseMirror p {
-  white-space: pre-wrap;
-}
-
-.ProseMirror h1,
-.ProseMirror h2,
-.ProseMirror h3,
-.ProseMirror h4,
-.ProseMirror h5,
-.ProseMirror h6 {
-  font-weight: 600;
-  line-height: 1.25;
-  letter-spacing: -0.01em;
-  color: var(--meowdown-heading);
-  /* Render a multi-line setext heading's soft break (kept by the heading's
-   * `whitespace: 'pre'` spec) as a line break, while still wrapping long lines. */
-  white-space: pre-wrap;
-}
-
-.ProseMirror h1 {
-  font-size: 1.75rem;
-}
-.ProseMirror h2 {
-  font-size: 1.4rem;
-}
-.ProseMirror h3 {
-  font-size: 1.2rem;
-}
-.ProseMirror h4 {
-  font-size: 1.1rem;
-}
-.ProseMirror h5 {
-  font-size: 1rem;
-}
-.ProseMirror h6 {
-  font-size: 0.95rem;
-}
-
-.ProseMirror .md-link {
-  color: var(--meowdown-accent);
-  text-decoration: underline;
-  text-decoration-thickness: 1px;
-  text-underline-offset: 2px;
-  cursor: pointer;
-}
-
-.ProseMirror mark {
-  background: var(--meowdown-highlight);
-  color: inherit;
-  border-radius: 2px;
-  padding: 0 1px;
-  box-decoration-break: clone;
-  -webkit-box-decoration-break: clone;
-}
-
-.ProseMirror code {
-  font-family: var(--meowdown-font-mono);
-  font-size: 0.9em;
-  padding: 0.1em 0.35em;
-  border-radius: 0.35rem;
-  background: var(--meowdown-code-bg);
-  color: inherit;
-}
-
-.ProseMirror blockquote {
-  margin-left: 0;
-  padding-left: 1rem;
-  border-left: 3px solid var(--meowdown-blockquote-border);
-  color: var(--meowdown-muted);
-}
-
-.ProseMirror ul,
-.ProseMirror ol {
-  padding-left: 1.5rem;
-}
-.ProseMirror ul {
-  list-style: disc;
-}
-.ProseMirror ol {
-  list-style: decimal;
-}
-.ProseMirror li {
-  margin-top: 0.25em;
-}
-
-.ProseMirror .prosemirror-flat-list[data-list-kind='bullet']::marker {
-  color: var(--meowdown-muted);
-}
-
-/* ---------------------------------------------------------------------------
- * Checkbox task list items
- *
- * `kind: 'task'` is the single checkable list kind; the bullet marker picks the
- * shape. `+` (data-list-marker="+") is a circle checkbox task, any other marker
- * is a square checkbox task. Plain GFM on disk (`+ [ ]` vs `- [ ]`), mirroring
- * reflect-editor.
- * ------------------------------------------------------------------------- */
-.ProseMirror .prosemirror-flat-list[data-list-kind='task'] {
-  /* Animation: fade the opacity when an item is (un)checked. */
-  transition: opacity 200ms ease;
-
-  /* Dim a checked item; reset nested checked items so it does not compound. */
-  &[data-list-checked] {
-    opacity: 0.5;
-
-    & .prosemirror-flat-list[data-list-kind='task'][data-list-checked] {
-      opacity: 1;
-    }
+    /* Horizontal editor padding. Floating UI tracking the hovered block (the
+     * block handle in @meowdown/react) must fit inside it: hover tracking only
+     * sees pointer events on the editor element, so a handle outside the
+     * padding closes before it can be clicked. Keep it >= 3.5rem. */
+    --meowdown-gutter: 3.5rem;
   }
 
-  & > .list-marker {
-    /* Animation: grow the checkbox slightly on hover. */
-    transition: transform 120ms ease;
-
-    &:hover {
-      transform: scale(1.1);
-    }
-
-    & input[type='checkbox'] {
-      appearance: none;
-      -webkit-appearance: none;
-      box-sizing: border-box;
-      width: 0.95rem;
-      height: 0.95rem;
-      border: 1px solid var(--meowdown-muted);
-      border-radius: 0.25rem; /* square */
-      background: transparent center / 100% 100% no-repeat;
-      /* Animation: fade the fill and border when (un)checked. */
-      transition:
-        background-color 150ms ease,
-        border-color 150ms ease;
-
-      &:checked {
-        border-color: transparent;
-        background-color: var(--meowdown-accent);
-        background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
-      }
-    }
-  }
-
-  /* A `+` marker is the circle checkbox task. */
-  &[data-list-marker='+'] > .list-marker input[type='checkbox'] {
-    border-radius: 100rem;
-    width: 1.05rem;
-    height: 1.05rem;
-  }
-}
-
-/* ---------------------------------------------------------------------------
- * Collapsible bullets
- * ------------------------------------------------------------------------- */
-.ProseMirror .prosemirror-flat-list[data-list-kind='bullet'] {
-  /* A foldable bullet's marker is clickable. */
-  &[data-list-collapsable] > .list-marker {
-    cursor: pointer;
-  }
-
-  /* The halo: a filled circle behind the dot, aligned to the marker column.
-   * Hidden by default, hinted on hover of a foldable item, fully shown when
-   * collapsed, so a folded bullet reads as a target (a dot inside a disc). */
-  &[data-list-collapsable]::before {
-    content: '';
-    position: absolute;
-    inset-inline-start: 0;
-    top: 0;
-    width: 1lh;
-    height: 1lh;
-    background: radial-gradient(
-      circle at center,
-      var(--meowdown-fold-halo) 0 0.45rem,
-      transparent 0.45rem
-    );
-    opacity: 0;
-    transition: opacity 120ms ease;
-    pointer-events: none;
-  }
-
-  &[data-list-collapsable]:has(> .list-marker:hover)::before {
-    opacity: 0.2;
-  }
-
-  &[data-list-collapsable][data-list-collapsed]::before {
-    opacity: 0.35;
-  }
-
-  &[data-list-collapsable][data-list-collapsed]:has(> .list-marker:hover)::before {
-    opacity: 0.45;
-  }
-
-  /* Hide the descendants of a collapsed bullet, keeping its first block. */
-  &[data-list-collapsable][data-list-collapsed] > .list-content > *:nth-child(n + 2) {
-    display: none;
-  }
-}
-
-.ProseMirror pre {
-  padding: 0.9rem 1rem;
-  border-radius: 0.6rem;
-  overflow-x: auto;
-  background: var(--meowdown-code-bg);
-  font-family: var(--meowdown-font-mono);
-  font-size: 0.9em;
-  line-height: 1.5;
-}
-.ProseMirror pre code {
-  padding: 0;
-  background: none;
-  color: inherit;
-}
-
-/* Lezer syntax highlighting. `prosemirror-highlight` tags tokens with the
- * `@lezer/highlight` `tok-*` classes; colors follow the page color scheme via
- * `light-dark()` like the rest of the theme. The palette mirrors GitHub's. */
-.ProseMirror pre code .tok-keyword {
-  color: light-dark(#cf222e, #ff7b72);
-}
-.ProseMirror pre code .tok-comment {
-  color: light-dark(#6e7781, #8b949e);
-  font-style: italic;
-}
-.ProseMirror pre code .tok-string,
-.ProseMirror pre code .tok-url {
-  color: light-dark(#0a3069, #a5d6ff);
-}
-.ProseMirror pre code .tok-number,
-.ProseMirror pre code .tok-bool,
-.ProseMirror pre code .tok-atom,
-.ProseMirror pre code .tok-literal {
-  color: light-dark(#0550ae, #79c0ff);
-}
-.ProseMirror pre code .tok-className,
-.ProseMirror pre code .tok-typeName,
-.ProseMirror pre code .tok-namespace {
-  color: light-dark(#953800, #ffa657);
-}
-.ProseMirror pre code .tok-definition {
-  color: light-dark(#8250df, #d2a8ff);
-}
-.ProseMirror pre code .tok-macroName,
-.ProseMirror pre code .tok-meta,
-.ProseMirror pre code .tok-inserted {
-  color: light-dark(#116329, #7ee787);
-}
-.ProseMirror pre code .tok-invalid,
-.ProseMirror pre code .tok-deleted {
-  color: light-dark(#82071e, #ffa198);
-}
-.ProseMirror pre code .tok-heading {
-  font-weight: 600;
-  color: light-dark(#0550ae, #79c0ff);
-}
-.ProseMirror pre code .tok-strong {
-  font-weight: 600;
-}
-.ProseMirror pre code .tok-emphasis {
-  font-style: italic;
-}
-.ProseMirror pre code .tok-link {
-  text-decoration: underline;
-}
-
-.ProseMirror hr {
-  margin: 1.5em 0;
-  border: none;
-  border-top: 1px solid var(--meowdown-border);
-}
-
-/* ---------------------------------------------------------------------------
- * Tables
- * ------------------------------------------------------------------------- */
-.ProseMirror table {
-  width: 100%;
-  overflow: hidden;
-  border-collapse: collapse;
-  table-layout: fixed;
-}
-
-.ProseMirror td,
-.ProseMirror th {
-  box-sizing: border-box;
-  padding: 0.4rem 0.75rem;
-  border: 1px solid var(--meowdown-border);
-  vertical-align: top;
-  text-align: left;
-}
-
-.ProseMirror th {
-  font-weight: 600;
-  color: var(--meowdown-heading);
-  background: var(--meowdown-table-header-bg);
-}
-
-.ProseMirror table.ProseMirror-selectednode td,
-.ProseMirror table.ProseMirror-selectednode th {
-  border-color: var(--meowdown-node-outline);
-}
-
-.ProseMirror .selectedCell {
-  /* `double` wins the collapsed-border conflict against the solid borders of
-   * unselected neighbors, so the whole selection perimeter recolors. */
-  border: 1px double var(--meowdown-node-outline);
-  background: var(--meowdown-node-selection);
-  caret-color: transparent;
-}
-
-/* ---------------------------------------------------------------------------
- * Selection
- * ------------------------------------------------------------------------- */
-.ProseMirror ::selection {
-  background: var(--meowdown-selection);
-}
-
-.ProseMirror .prosekit-virtual-selection {
-  background: var(--meowdown-selection);
-}
-
-/* prosemirror-view adds `ProseMirror-hideselection` whenever the selection is
- * not "visible" (a node selection). */
-.ProseMirror.ProseMirror-hideselection ::selection {
-  --meowdown-selection: transparent;
-  caret-color: transparent;
-}
-
-/* Node selection (e.g. from the block handle): thin outline + faint wash,
- * replacing prosemirror-view's stock blue outline. */
-.ProseMirror .ProseMirror-selectednode {
-  border-radius: 2px;
-  outline: 1px solid var(--meowdown-node-outline);
-  background: var(--meowdown-node-selection);
-}
-
-.ProseMirror pre.ProseMirror-selectednode {
-  border-radius: 0.6rem;
-}
-
-/* While dragging via the block handle, keep only the outline on the
- * source block so it does not sit tinted under the drag preview. */
-.ProseMirror.prosekit-dragging {
-  --meowdown-node-selection: transparent;
-}
-
-/* ---------------------------------------------------------------------------
- * Tags (`#tag`)
- * ------------------------------------------------------------------------- */
-.ProseMirror .md-tag {
-  padding: 2px 6px;
-  border-radius: 6px;
-  background: color-mix(in oklab, var(--meowdown-accent) 10%, transparent);
-  color: color-mix(in oklab, var(--meowdown-accent) 80%, var(--meowdown-heading));
-  cursor: pointer;
-}
-
-/* ---------------------------------------------------------------------------
- * Inline image / embed previews (`![alt](url)`), rendered in place via a mark
- * view at the image's source position.
- * ------------------------------------------------------------------------- */
-
-.ProseMirror .md-embed-youtube {
-  display: block;
-  width: 100%;
-  aspect-ratio: 16 / 9;
-  border: 0;
-  border-radius: var(--meowdown-image-radius, 0.5rem);
-}
-
-.ProseMirror .md-embed-tweet {
-  display: block;
-  width: 100%;
-  max-width: 550px;
-  border: 0;
-}
-
-/* ---------------------------------------------------------------------------
- * Placeholder text for empty blocks (ProseKit's definePlaceholder)
- * ------------------------------------------------------------------------- */
-.ProseMirror .prosekit-placeholder::before {
-  content: attr(data-placeholder);
-  float: left;
-  height: 0;
-  pointer-events: none;
-  color: var(--meowdown-placeholder, var(--meowdown-muted));
-}
-
-/* ---------------------------------------------------------------------------
- * Markdown syntax characters (`md-mark`) and link URIs
- * ------------------------------------------------------------------------- */
-.ProseMirror .md-mark {
-  color: var(--meowdown-mark);
-  opacity: 0.7;
-}
-
-/* The URL of a link/image, and a link title */
-.ProseMirror .md-link-uri,
-.ProseMirror .md-link-title {
-  color: var(--meowdown-accent);
-  text-decoration: underline;
-  text-decoration-thickness: 1px;
-  text-underline-offset: 2px;
-  opacity: 0.7;
-}
-
-/* The mdPack mark wraps a whole inline unit so focus mode can reveal it with one
- * range lookup. It is layout-only: `display: contents` keeps it out of the box
- * tree, so it never affects flow or an inner image mark view, while still being a
- * real element a `.show` decoration can land inside. */
-.ProseMirror .md-pack {
-  display: contents;
-}
-
-.ProseMirror[data-mark-mode='hide'] {
-  .md-mark,
-  .md-link-uri,
-  .md-link-title {
-    display: none;
-  }
-}
-
-.ProseMirror[data-mark-mode='focus'] {
-  .md-mark,
-  .md-link-uri,
-  .md-link-title {
-    overflow: hidden;
-    display: inline-block;
-    vertical-align: bottom;
-
-    letter-spacing: -2em;
-
-    &:has(.show) {
-      letter-spacing: 0;
-    }
-  }
-}
-
-/* atom marks (image, wikilink) */
-.ProseMirror {
-  .md-atom-view {
-    display: inline-block;
-    vertical-align: bottom;
-  }
-
-  .md-atom-view-preview {
-    display: inline-block;
-    vertical-align: bottom;
-    overflow: hidden;
-
-    border-radius: 6px;
-
-    -webkit-user-select: none;
-    user-select: none;
-  }
-
-  .md-atom-view:has(.md-atom-selected) {
-    .md-atom-view-preview {
-      outline: 2px solid var(--meowdown-node-outline);
-      background: var(--meowdown-selection);
-    }
-
-    & ::selection {
-      background-color: transparent;
-    }
-  }
-
-  .md-atom-view-content {
-    overflow: visible;
-    display: inline-flex;
-    align-items: end;
-    letter-spacing: -2em;
-    width: 2px;
+  /* ---------------------------------------------------------------------------
+   * Editor surface
+   * ------------------------------------------------------------------------- */
+  .ProseMirror {
     box-sizing: border-box;
-    background-color: transparent;
-    color: transparent;
-    margin-left: 2px;
-    margin-right: -4px;
-  }
-}
-
-/* image */
-.ProseMirror {
-  .md-image-view {
-    max-width: 100%;
-    margin-left: 2px;
-    margin-right: 2px;
+    outline: none;
+    font-size: 1.0625rem;
+    line-height: 1.7;
+    color: var(--meowdown-text);
+    caret-color: var(--meowdown-accent);
+    -webkit-font-smoothing: antialiased;
   }
 
-  .md-image-view-preview {
-    /* inline-block, not inline-flex: the resizable root sizes itself with
-     * `aspect-ratio` + `height: auto`, which only resolves in normal flow. As a
-     * flex item the root loses that derivation and collapses to its
-     * `min-height`. The root's `vertical-align: bottom` removes the baseline
-     * descender gap that would otherwise show as empty space inside the
-     * selection outline. */
-    display: inline-block;
-    max-width: 100%;
-    border-radius: 6px;
-    outline-offset: 2px;
+  /* Surface padding stays on a meowdown-owned class, not `.ProseMirror`: the block
+   * handle's drag preview clones a block into a bare `.ProseMirror` container, which
+   * must not pick up the gutter padding. */
+  .meowdown-content {
+    padding: 1.25rem var(--meowdown-gutter) 1.75rem;
   }
 
-  .md-image-resizable {
-    position: relative;
-    display: inline-block;
-    /* Sit on the line-box bottom so the inline-block preview wrapper wraps the
-     * image with no baseline descender gap below it. */
-    vertical-align: bottom;
-    /* New stacking context so the handle's `mix-blend-mode` mixes only with the
-     * image, not the page behind it. */
-    isolation: isolate;
-    max-width: 100%;
-    /* Avoid a 1px collapse before the image loads / a width is known, and keep
-     * the corner handle clear of the image center. */
-    min-width: 2.5rem;
-    min-height: 2.5rem;
+  .ProseMirror > * + * {
+    margin-top: 0.85em;
   }
 
-  /* While the image is still loading (e.g. a freshly dropped image), fill the
-   * box with a placeholder so it reads as an image, not an empty gap. Cleared
-   * once the image paints (`data-loading` is removed on load/error). */
-  .md-image-resizable[data-loading] {
-    background: var(--meowdown-image-loading-bg);
-    border-radius: var(--meowdown-image-radius, 0.5rem);
+  /* Render soft line breaks (a literal `\n` kept by the paragraph's
+   * `whitespace: 'pre'` spec) as line breaks, while still wrapping long lines. */
+  .ProseMirror p {
+    white-space: pre-wrap;
   }
 
-  .md-image-resizable img {
-    display: block;
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-    border-radius: var(--meowdown-image-radius, 0.5rem);
+  .ProseMirror h1,
+  .ProseMirror h2,
+  .ProseMirror h3,
+  .ProseMirror h4,
+  .ProseMirror h5,
+  .ProseMirror h6 {
+    font-weight: 600;
+    line-height: 1.25;
+    letter-spacing: -0.01em;
+    color: var(--meowdown-heading);
+    /* Render a multi-line setext heading's soft break (kept by the heading's
+     * `whitespace: 'pre'` spec) as a line break, while still wrapping long lines. */
+    white-space: pre-wrap;
   }
 
-  .md-image-resize-handle {
-    position: absolute;
-    right: 4px;
-    bottom: 4px;
-    box-sizing: border-box;
-    width: 14px;
-    height: 14px;
-    border-right: 3px solid #fff;
-    border-bottom: 3px solid #fff;
-    border-bottom-right-radius: 5px;
-    /* Blend against the image so the corner bracket reads on both light and dark
-     * photos. Pairs with `isolation: isolate` on `.md-image-resizable`. */
-    mix-blend-mode: exclusion;
-    cursor: nwse-resize;
-    /* Hidden handle never intercepts a click meant for the image. */
-    pointer-events: none;
-    touch-action: none;
-    /* A light one-shot pop: scale up to full size when revealed on hover. */
-    opacity: 0;
-    transform: scale(0.8);
-    transform-origin: bottom right;
-    transition:
-      opacity 0.12s ease,
-      transform 0.12s ease;
+  .ProseMirror h1 {
+    font-size: 1.75rem;
+  }
+  .ProseMirror h2 {
+    font-size: 1.4rem;
+  }
+  .ProseMirror h3 {
+    font-size: 1.2rem;
+  }
+  .ProseMirror h4 {
+    font-size: 1.1rem;
+  }
+  .ProseMirror h5 {
+    font-size: 1rem;
+  }
+  .ProseMirror h6 {
+    font-size: 0.95rem;
   }
 
-  .md-image-resizable:hover .md-image-resize-handle,
-  .md-image-resizable[data-resizing] .md-image-resize-handle {
-    opacity: 1;
-    transform: scale(1);
-    pointer-events: auto;
-  }
-}
-
-/* wikilink */
-.ProseMirror {
-  .md-wikilink-view-label {
-    overflow: hidden;
-    padding: 2px 5px;
-    border-radius: 6px;
-
-    background: color-mix(in oklab, var(--meowdown-accent) 10%, transparent);
-    color: color-mix(in oklab, var(--meowdown-accent) 80%, var(--meowdown-heading));
-
-    text-decoration-line: underline;
-    text-decoration-style: dashed;
+  .ProseMirror .md-link {
+    color: var(--meowdown-accent);
+    text-decoration: underline;
     text-decoration-thickness: 1px;
     text-underline-offset: 2px;
     cursor: pointer;
   }
 
-  .md-wikilink-view:has(.md-atom-selected) .md-wikilink-view-label {
-    background-color: transparent;
-    outline-color: transparent;
+  .ProseMirror mark {
+    background: var(--meowdown-highlight);
+    color: inherit;
+    border-radius: 2px;
+    padding: 0 1px;
+    box-decoration-break: clone;
+    -webkit-box-decoration-break: clone;
+  }
+
+  .ProseMirror code {
+    font-family: var(--meowdown-font-mono);
+    font-size: 0.9em;
+    padding: 0.1em 0.35em;
+    border-radius: 0.35rem;
+    background: var(--meowdown-code-bg);
+    color: inherit;
+  }
+
+  .ProseMirror blockquote {
+    margin-left: 0;
+    padding-left: 1rem;
+    border-left: 3px solid var(--meowdown-blockquote-border);
+    color: var(--meowdown-muted);
+  }
+
+  .ProseMirror ul,
+  .ProseMirror ol {
+    padding-left: 1.5rem;
+  }
+  .ProseMirror ul {
+    list-style: disc;
+  }
+  .ProseMirror ol {
+    list-style: decimal;
+  }
+  .ProseMirror li {
+    margin-top: 0.25em;
+  }
+
+  .ProseMirror .prosemirror-flat-list[data-list-kind='bullet']::marker {
+    color: var(--meowdown-muted);
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Checkbox task list items
+   *
+   * `kind: 'task'` is the single checkable list kind; the bullet marker picks the
+   * shape. `+` (data-list-marker="+") is a circle checkbox task, any other marker
+   * is a square checkbox task. Plain GFM on disk (`+ [ ]` vs `- [ ]`), mirroring
+   * reflect-editor.
+   * ------------------------------------------------------------------------- */
+  .ProseMirror .prosemirror-flat-list[data-list-kind='task'] {
+    /* Animation: fade the opacity when an item is (un)checked. */
+    transition: opacity 200ms ease;
+
+    /* Dim a checked item; reset nested checked items so it does not compound. */
+    &[data-list-checked] {
+      opacity: 0.5;
+
+      & .prosemirror-flat-list[data-list-kind='task'][data-list-checked] {
+        opacity: 1;
+      }
+    }
+
+    & > .list-marker {
+      /* Animation: grow the checkbox slightly on hover. */
+      transition: transform 120ms ease;
+
+      &:hover {
+        transform: scale(1.1);
+      }
+
+      & input[type='checkbox'] {
+        appearance: none;
+        -webkit-appearance: none;
+        box-sizing: border-box;
+        width: 0.95rem;
+        height: 0.95rem;
+        border: 1px solid var(--meowdown-muted);
+        border-radius: 0.25rem; /* square */
+        background: transparent center / 100% 100% no-repeat;
+        /* Animation: fade the fill and border when (un)checked. */
+        transition:
+          background-color 150ms ease,
+          border-color 150ms ease;
+
+        &:checked {
+          border-color: transparent;
+          background-color: var(--meowdown-accent);
+          background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
+        }
+      }
+    }
+
+    /* A `+` marker is the circle checkbox task. */
+    &[data-list-marker='+'] > .list-marker input[type='checkbox'] {
+      border-radius: 100rem;
+      width: 1.05rem;
+      height: 1.05rem;
+    }
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Collapsible bullets
+   * ------------------------------------------------------------------------- */
+  .ProseMirror .prosemirror-flat-list[data-list-kind='bullet'] {
+    /* A foldable bullet's marker is clickable. */
+    &[data-list-collapsable] > .list-marker {
+      cursor: pointer;
+    }
+
+    /* The halo: a filled circle behind the dot, aligned to the marker column.
+     * Hidden by default, hinted on hover of a foldable item, fully shown when
+     * collapsed, so a folded bullet reads as a target (a dot inside a disc). */
+    &[data-list-collapsable]::before {
+      content: '';
+      position: absolute;
+      inset-inline-start: 0;
+      top: 0;
+      width: 1lh;
+      height: 1lh;
+      background: radial-gradient(
+        circle at center,
+        var(--meowdown-fold-halo) 0 0.45rem,
+        transparent 0.45rem
+      );
+      opacity: 0;
+      transition: opacity 120ms ease;
+      pointer-events: none;
+    }
+
+    &[data-list-collapsable]:has(> .list-marker:hover)::before {
+      opacity: 0.2;
+    }
+
+    &[data-list-collapsable][data-list-collapsed]::before {
+      opacity: 0.35;
+    }
+
+    &[data-list-collapsable][data-list-collapsed]:has(> .list-marker:hover)::before {
+      opacity: 0.45;
+    }
+
+    /* Hide the descendants of a collapsed bullet, keeping its first block. */
+    &[data-list-collapsable][data-list-collapsed] > .list-content > *:nth-child(n + 2) {
+      display: none;
+    }
+  }
+
+  .ProseMirror pre {
+    padding: 0.9rem 1rem;
+    border-radius: 0.6rem;
+    overflow-x: auto;
+    background: var(--meowdown-code-bg);
+    font-family: var(--meowdown-font-mono);
+    font-size: 0.9em;
+    line-height: 1.5;
+  }
+  .ProseMirror pre code {
+    padding: 0;
+    background: none;
+    color: inherit;
+  }
+
+  /* Lezer syntax highlighting. `prosemirror-highlight` tags tokens with the
+   * `@lezer/highlight` `tok-*` classes; colors follow the page color scheme via
+   * `light-dark()` like the rest of the theme. The palette mirrors GitHub's. */
+  .ProseMirror pre code .tok-keyword {
+    color: light-dark(#cf222e, #ff7b72);
+  }
+  .ProseMirror pre code .tok-comment {
+    color: light-dark(#6e7781, #8b949e);
+    font-style: italic;
+  }
+  .ProseMirror pre code .tok-string,
+  .ProseMirror pre code .tok-url {
+    color: light-dark(#0a3069, #a5d6ff);
+  }
+  .ProseMirror pre code .tok-number,
+  .ProseMirror pre code .tok-bool,
+  .ProseMirror pre code .tok-atom,
+  .ProseMirror pre code .tok-literal {
+    color: light-dark(#0550ae, #79c0ff);
+  }
+  .ProseMirror pre code .tok-className,
+  .ProseMirror pre code .tok-typeName,
+  .ProseMirror pre code .tok-namespace {
+    color: light-dark(#953800, #ffa657);
+  }
+  .ProseMirror pre code .tok-definition {
+    color: light-dark(#8250df, #d2a8ff);
+  }
+  .ProseMirror pre code .tok-macroName,
+  .ProseMirror pre code .tok-meta,
+  .ProseMirror pre code .tok-inserted {
+    color: light-dark(#116329, #7ee787);
+  }
+  .ProseMirror pre code .tok-invalid,
+  .ProseMirror pre code .tok-deleted {
+    color: light-dark(#82071e, #ffa198);
+  }
+  .ProseMirror pre code .tok-heading {
+    font-weight: 600;
+    color: light-dark(#0550ae, #79c0ff);
+  }
+  .ProseMirror pre code .tok-strong {
+    font-weight: 600;
+  }
+  .ProseMirror pre code .tok-emphasis {
+    font-style: italic;
+  }
+  .ProseMirror pre code .tok-link {
+    text-decoration: underline;
+  }
+
+  .ProseMirror hr {
+    margin: 1.5em 0;
+    border: none;
+    border-top: 1px solid var(--meowdown-border);
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Tables
+   * ------------------------------------------------------------------------- */
+  .ProseMirror table {
+    width: 100%;
+    overflow: hidden;
+    border-collapse: collapse;
+    table-layout: fixed;
+  }
+
+  .ProseMirror td,
+  .ProseMirror th {
+    box-sizing: border-box;
+    padding: 0.4rem 0.75rem;
+    border: 1px solid var(--meowdown-border);
+    vertical-align: top;
+    text-align: left;
+  }
+
+  .ProseMirror th {
+    font-weight: 600;
+    color: var(--meowdown-heading);
+    background: var(--meowdown-table-header-bg);
+  }
+
+  .ProseMirror table.ProseMirror-selectednode td,
+  .ProseMirror table.ProseMirror-selectednode th {
+    border-color: var(--meowdown-node-outline);
+  }
+
+  .ProseMirror .selectedCell {
+    /* `double` wins the collapsed-border conflict against the solid borders of
+     * unselected neighbors, so the whole selection perimeter recolors. */
+    border: 1px double var(--meowdown-node-outline);
+    background: var(--meowdown-node-selection);
+    caret-color: transparent;
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Selection
+   * ------------------------------------------------------------------------- */
+  .ProseMirror ::selection {
+    background: var(--meowdown-selection);
+  }
+
+  .ProseMirror .prosekit-virtual-selection {
+    background: var(--meowdown-selection);
+  }
+
+  /* prosemirror-view adds `ProseMirror-hideselection` whenever the selection is
+   * not "visible" (a node selection). */
+  .ProseMirror.ProseMirror-hideselection ::selection {
+    background: transparent;
+    caret-color: transparent;
+  }
+
+  /* Node selection (e.g. from the block handle): thin outline + faint wash,
+   * replacing prosemirror-view's stock blue outline. */
+  .ProseMirror .ProseMirror-selectednode {
+    border-radius: 2px;
+    outline: 1px solid var(--meowdown-node-outline);
+    background: var(--meowdown-node-selection);
+  }
+
+  .ProseMirror pre.ProseMirror-selectednode {
+    border-radius: 0.6rem;
+  }
+
+  /* While dragging via the block handle, keep only the outline on the
+   * source block so it does not sit tinted under the drag preview. */
+  .ProseMirror.prosekit-dragging .ProseMirror-selectednode,
+  .ProseMirror.prosekit-dragging .selectedCell {
+    background: transparent;
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Tags (`#tag`)
+   * ------------------------------------------------------------------------- */
+  .ProseMirror .md-tag {
+    padding: 2px 6px;
+    border-radius: 6px;
+    background: color-mix(in oklab, var(--meowdown-accent) 10%, transparent);
+    color: color-mix(in oklab, var(--meowdown-accent) 80%, var(--meowdown-heading));
+    cursor: pointer;
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Inline image / embed previews (`![alt](url)`), rendered in place via a mark
+   * view at the image's source position.
+   * ------------------------------------------------------------------------- */
+
+  .ProseMirror .md-embed-youtube {
+    display: block;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    border: 0;
+    border-radius: var(--meowdown-image-radius, 0.5rem);
+  }
+
+  .ProseMirror .md-embed-tweet {
+    display: block;
+    width: 100%;
+    max-width: 550px;
+    border: 0;
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Placeholder text for empty blocks (ProseKit's definePlaceholder)
+   * ------------------------------------------------------------------------- */
+  .ProseMirror .prosekit-placeholder::before {
+    content: attr(data-placeholder);
+    float: left;
+    height: 0;
+    pointer-events: none;
+    color: var(--meowdown-placeholder, var(--meowdown-muted));
+  }
+
+  /* ---------------------------------------------------------------------------
+   * Markdown syntax characters (`md-mark`) and link URIs
+   * ------------------------------------------------------------------------- */
+  .ProseMirror .md-mark {
+    color: var(--meowdown-mark);
+    opacity: 0.7;
+  }
+
+  /* The URL of a link/image, and a link title */
+  .ProseMirror .md-link-uri,
+  .ProseMirror .md-link-title {
+    color: var(--meowdown-accent);
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+    opacity: 0.7;
+  }
+
+  /* The mdPack mark wraps a whole inline unit so focus mode can reveal it with one
+   * range lookup. It is layout-only: `display: contents` keeps it out of the box
+   * tree, so it never affects flow or an inner image mark view, while still being a
+   * real element a `.show` decoration can land inside. */
+  .ProseMirror .md-pack {
+    display: contents;
+  }
+
+  .ProseMirror[data-mark-mode='hide'] {
+    .md-mark,
+    .md-link-uri,
+    .md-link-title {
+      display: none;
+    }
+  }
+
+  .ProseMirror[data-mark-mode='focus'] {
+    .md-mark,
+    .md-link-uri,
+    .md-link-title {
+      overflow: hidden;
+      display: inline-block;
+      vertical-align: bottom;
+
+      letter-spacing: -2em;
+
+      &:has(.show) {
+        letter-spacing: 0;
+      }
+    }
+  }
+
+  /* atom marks (image, wikilink) */
+  .ProseMirror {
+    .md-atom-view {
+      display: inline-block;
+      vertical-align: bottom;
+    }
+
+    .md-atom-view-preview {
+      display: inline-block;
+      vertical-align: bottom;
+      overflow: hidden;
+
+      border-radius: 6px;
+
+      -webkit-user-select: none;
+      user-select: none;
+    }
+
+    .md-atom-view:has(.md-atom-selected) {
+      .md-atom-view-preview {
+        outline: 2px solid var(--meowdown-node-outline);
+        background: var(--meowdown-selection);
+      }
+
+      & ::selection {
+        background-color: transparent;
+      }
+    }
+
+    .md-atom-view-content {
+      overflow: visible;
+      display: inline-flex;
+      align-items: end;
+      letter-spacing: -2em;
+      width: 2px;
+      box-sizing: border-box;
+      background-color: transparent;
+      color: transparent;
+      margin-left: 2px;
+      margin-right: -4px;
+    }
+  }
+
+  /* image */
+  .ProseMirror {
+    .md-image-view {
+      max-width: 100%;
+      margin-left: 2px;
+      margin-right: 2px;
+    }
+
+    .md-image-view-preview {
+      /* inline-block, not inline-flex: the resizable root sizes itself with
+       * `aspect-ratio` + `height: auto`, which only resolves in normal flow. As a
+       * flex item the root loses that derivation and collapses to its
+       * `min-height`. The root's `vertical-align: bottom` removes the baseline
+       * descender gap that would otherwise show as empty space inside the
+       * selection outline. */
+      display: inline-block;
+      max-width: 100%;
+      border-radius: 6px;
+      outline-offset: 2px;
+    }
+
+    .md-image-resizable {
+      position: relative;
+      display: inline-block;
+      /* Sit on the line-box bottom so the inline-block preview wrapper wraps the
+       * image with no baseline descender gap below it. */
+      vertical-align: bottom;
+      /* New stacking context so the handle's `mix-blend-mode` mixes only with the
+       * image, not the page behind it. */
+      isolation: isolate;
+      max-width: 100%;
+      /* Avoid a 1px collapse before the image loads / a width is known, and keep
+       * the corner handle clear of the image center. */
+      min-width: 2.5rem;
+      min-height: 2.5rem;
+    }
+
+    /* While the image is still loading (e.g. a freshly dropped image), fill the
+     * box with a placeholder so it reads as an image, not an empty gap. Cleared
+     * once the image paints (`data-loading` is removed on load/error). */
+    .md-image-resizable[data-loading] {
+      background: var(--meowdown-image-loading-bg);
+      border-radius: var(--meowdown-image-radius, 0.5rem);
+    }
+
+    .md-image-resizable img {
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      border-radius: var(--meowdown-image-radius, 0.5rem);
+    }
+
+    .md-image-resize-handle {
+      position: absolute;
+      right: 4px;
+      bottom: 4px;
+      box-sizing: border-box;
+      width: 14px;
+      height: 14px;
+      border-right: 3px solid #fff;
+      border-bottom: 3px solid #fff;
+      border-bottom-right-radius: 5px;
+      /* Blend against the image so the corner bracket reads on both light and dark
+       * photos. Pairs with `isolation: isolate` on `.md-image-resizable`. */
+      mix-blend-mode: exclusion;
+      cursor: nwse-resize;
+      /* Hidden handle never intercepts a click meant for the image. */
+      pointer-events: none;
+      touch-action: none;
+      /* A light one-shot pop: scale up to full size when revealed on hover. */
+      opacity: 0;
+      transform: scale(0.8);
+      transform-origin: bottom right;
+      transition:
+        opacity 0.12s ease,
+        transform 0.12s ease;
+    }
+
+    .md-image-resizable:hover .md-image-resize-handle,
+    .md-image-resizable[data-resizing] .md-image-resize-handle {
+      opacity: 1;
+      transform: scale(1);
+      pointer-events: auto;
+    }
+  }
+
+  /* wikilink */
+  .ProseMirror {
+    .md-wikilink-view-label {
+      overflow: hidden;
+      padding: 2px 5px;
+      border-radius: 6px;
+
+      background: color-mix(in oklab, var(--meowdown-accent) 10%, transparent);
+      color: color-mix(in oklab, var(--meowdown-accent) 80%, var(--meowdown-heading));
+
+      text-decoration-line: underline;
+      text-decoration-style: dashed;
+      text-decoration-thickness: 1px;
+      text-underline-offset: 2px;
+      cursor: pointer;
+    }
+
+    .md-wikilink-view:has(.md-atom-selected) .md-wikilink-view-label {
+      background-color: transparent;
+      outline-color: transparent;
+    }
   }
 }

--- a/packages/react/src/components/autocomplete-menu.module.css
+++ b/packages/react/src/components/autocomplete-menu.module.css
@@ -22,8 +22,7 @@
   user-select: none;
   border: 1px solid var(--meowdown-border);
   border-radius: 0.75rem;
-  background: #fff;
-  background: var(--meowdown-autocomplete-bg, light-dark(#fff, #18181b));
+  background: var(--meowdown-popover-bg);
   box-shadow:
     0 10px 15px -3px rgb(0 0 0 / 0.1),
     0 4px 6px -4px rgb(0 0 0 / 0.1);
@@ -52,8 +51,7 @@
   }
 
   &[data-highlighted] {
-    background: #f4f4f5;
-    background: var(--meowdown-autocomplete-highlight-bg, light-dark(#f4f4f5, #27272a));
+    background: var(--meowdown-popover-hover-bg);
   }
 
   kbd {

--- a/packages/react/src/components/block-handle.module.css
+++ b/packages/react/src/components/block-handle.module.css
@@ -47,7 +47,7 @@
   cursor: grab;
 
   &:hover {
-    background: light-dark(#f4f4f5, #27272a);
+    background: var(--meowdown-popover-hover-bg);
   }
 
   svg {

--- a/packages/react/src/components/code-block-view.module.css
+++ b/packages/react/src/components/code-block-view.module.css
@@ -32,7 +32,7 @@
   padding: 0 0.4rem;
   border: 1px solid var(--meowdown-border);
   border-radius: 0.35rem;
-  background: light-dark(#ffffff, #27272a);
+  background: var(--meowdown-popover-bg);
   color: var(--meowdown-muted);
   font-family: ui-sans-serif, system-ui, sans-serif;
   font-size: 0.75rem;
@@ -68,7 +68,7 @@
   padding: 0;
   border: 1px solid var(--meowdown-border);
   border-radius: 0.35rem;
-  background: light-dark(#ffffff, #27272a);
+  background: var(--meowdown-popover-bg);
   color: var(--meowdown-muted);
   cursor: pointer;
 
@@ -100,7 +100,7 @@
   width: 14rem;
   border: 1px solid var(--meowdown-border);
   border-radius: 0.5rem;
-  background: light-dark(#ffffff, #27272a);
+  background: var(--meowdown-popover-bg);
   box-shadow:
     0 4px 6px -1px rgb(0 0 0 / 0.1),
     0 2px 4px -2px rgb(0 0 0 / 0.1);

--- a/packages/react/src/components/link-menu.module.css
+++ b/packages/react/src/components/link-menu.module.css
@@ -13,7 +13,7 @@
   font-size: 0.875rem;
   border: 1px solid var(--meowdown-border);
   border-radius: 0.75rem;
-  background: var(--meowdown-link-popover-bg, light-dark(#fff, #18181b));
+  background: var(--meowdown-popover-bg);
   box-shadow:
     0 10px 15px -3px rgb(0 0 0 / 0.1),
     0 4px 6px -4px rgb(0 0 0 / 0.1);
@@ -47,7 +47,7 @@
   cursor: pointer;
 
   &:hover {
-    background: var(--meowdown-link-popover-hover-bg, light-dark(#f4f4f5, #27272a));
+    background: var(--meowdown-popover-hover-bg);
   }
 
   & svg {

--- a/packages/react/src/components/table-handle.module.css
+++ b/packages/react/src/components/table-handle.module.css
@@ -53,7 +53,7 @@
   padding: 0;
   border: 1px solid var(--meowdown-border);
   border-radius: 0.25rem;
-  background: light-dark(#fff, #18181b);
+  background: var(--meowdown-popover-bg);
   color: color-mix(in oklab, var(--meowdown-muted) 50%, transparent);
   cursor: grab;
   outline: none;
@@ -61,7 +61,7 @@
   transition: background-color 100ms;
 
   &:hover {
-    background: light-dark(#f4f4f5, #27272a);
+    background: var(--meowdown-popover-hover-bg);
   }
 
   svg {
@@ -85,7 +85,7 @@
   outline: none;
   border: 1px solid var(--meowdown-border);
   border-radius: 0.75rem;
-  background: light-dark(#fff, #18181b);
+  background: var(--meowdown-popover-bg);
   box-shadow:
     0 10px 15px -3px rgb(0 0 0 / 0.1),
     0 4px 6px -4px rgb(0 0 0 / 0.1);
@@ -127,11 +127,11 @@
   scroll-margin: 0.25rem;
 
   &[data-highlighted] {
-    background: light-dark(#f4f4f5, #27272a);
+    background: var(--meowdown-popover-hover-bg);
   }
 
   &[data-danger] {
-    color: light-dark(#ef4444, #f87171);
+    color: var(--meowdown-danger);
   }
 
   &[data-disabled='true'] {


### PR DESCRIPTION
Refactor the editor theme so a consumer can restyle it with only the `--meowdown-*` color variables: the stylesheet now lives in `@layer meowdown` (consumer rules win without specificity hacks), the floating menus read a unified `--meowdown-popover-*` family, and the inline-code, bullet, checkbox, and blockquote defaults are quieter. It also flips the default accent to a playful orange (warm selection, gray syntax marks), expresses the palette in `oklch`, and fixes the stale wikilink class names in the README.