### PR TITLE
ci: add timeout-minutes to workflow jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -27,6 +28,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -40,6 +42,7 @@ jobs:
   test:
     runs-on: ${{ matrix.runner }}
     name: test-${{ matrix.os }}-${{ matrix.browser }}
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false
@@ -88,6 +91,7 @@ jobs:
 
   publish-snapshot:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     needs: [build]
 

--- a/.github/workflows/fix.yml
+++ b/.github/workflows/fix.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   fix:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ permissions: {}
 jobs:
   version:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       pull-requests: write
@@ -22,6 +23,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [version]
     permissions:
       contents: read


### PR DESCRIPTION
Add a 15-minute `timeout-minutes` to every job in `ci.yml`, `fix.yml`, and `release.yml`. Jobs normally finish in 1-2 minutes, but without a limit a hung test runs until GitHub's 6-hour default kills it (one recent CI run sat for over 3 hours before being cancelled manually).