### PR TITLE
feat: add `insertMarkdown` command

### DIFF
--- a/packages/core/src/extensions/commands.test.ts
+++ b/packages/core/src/extensions/commands.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { docToMarkdown } from '../converters/pm-to-md.ts'
+import { setupFixture } from '../testing/index.ts'
+
+describe('insertMarkdown', () => {
+  it('inserts a lone-paragraph fragment inline at the cursor', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(n.doc(n.paragraph('Hello <a>world')))
+
+    expect(editor.commands.insertMarkdown('brave **new** ')).toBe(true)
+
+    expect(docToMarkdown(fixture.doc)).toBe('Hello brave **new** world\n')
+  })
+
+  it('replaces the current selection with the inserted fragment', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>Hello<b> world')))
+
+    editor.commands.insertMarkdown('Goodbye')
+
+    expect(docToMarkdown(fixture.doc)).toBe('Goodbye world\n')
+  })
+
+  it('inserts a multi-block fragment as blocks with the cursor at its end', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(n.doc(n.paragraph('Hello<a>'), n.paragraph('World')))
+
+    editor.commands.insertMarkdown('# Title\n\n- item')
+    editor.commands.insertText({ text: '!' })
+
+    expect(docToMarkdown(fixture.doc)).toBe('Hello\n\n# Title\n\n- item!\n\nWorld\n')
+  })
+
+  it('undoes an inserted fragment as a single history entry', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(n.doc(n.paragraph('Hello<a>')))
+
+    editor.commands.insertMarkdown('# Title\n\n- item')
+    editor.commands.undo()
+
+    expect(docToMarkdown(fixture.doc)).toBe('Hello\n')
+  })
+
+  it('ignores an empty or whitespace-only fragment', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(n.doc(n.paragraph('Hello<a>')))
+
+    expect(editor.commands.insertMarkdown('')).toBe(false)
+    expect(editor.commands.insertMarkdown('  \n\t ')).toBe(false)
+
+    expect(docToMarkdown(fixture.doc)).toBe('Hello\n')
+  })
+})

--- a/packages/core/src/extensions/commands.ts
+++ b/packages/core/src/extensions/commands.ts
@@ -4,6 +4,7 @@ import { TextSelection, type Command } from '@prosekit/pm/state'
 
 import { markdownToDoc } from '../converters/md-to-pm.ts'
 
+import type { NodeName } from './node-names.ts'
 import { getNodeBuildersForSchema } from './schema.ts'
 
 function selectText(anchor: number, head?: number): Command {
@@ -33,9 +34,10 @@ function insertMarkdown(markdown: string): Command {
     if (!markdown.trim()) return false
     const nodes = getNodeBuildersForSchema(state.schema)
     const content = markdownToDoc(markdown, { nodes }).content
-    const isLoneParagraph =
-      content.childCount === 1 && content.firstChild?.type.name === 'paragraph'
-    const slice = isLoneParagraph
+    if (content.childCount === 0) return false
+    const isSingleParagraph =
+      content.childCount === 1 && content.child(0).type.name === ('paragraph' satisfies NodeName)
+    const slice = isSingleParagraph
       ? new Slice(content, 1, 1)
       : new Slice(content, 0, Slice.maxOpen(content).openEnd)
     if (dispatch) dispatch(state.tr.replaceSelection(slice).scrollIntoView())

--- a/packages/core/src/extensions/commands.ts
+++ b/packages/core/src/extensions/commands.ts
@@ -1,6 +1,10 @@
 import { defineCommands } from '@prosekit/core'
-import type { ResolvedPos } from '@prosekit/pm/model'
+import { Slice, type ResolvedPos } from '@prosekit/pm/model'
 import { TextSelection, type Command } from '@prosekit/pm/state'
+
+import { markdownToDoc } from '../converters/md-to-pm.ts'
+
+import { getNodeBuildersForSchema } from './schema.ts'
 
 function selectText(anchor: number, head?: number): Command {
   return (state, dispatch) => {
@@ -24,8 +28,24 @@ function selectTextBetween($anchor: ResolvedPos, $head: ResolvedPos, bias?: numb
   }
 }
 
+function insertMarkdown(markdown: string): Command {
+  return (state, dispatch) => {
+    if (!markdown.trim()) return false
+    const nodes = getNodeBuildersForSchema(state.schema)
+    const content = markdownToDoc(markdown, { nodes }).content
+    const isLoneParagraph =
+      content.childCount === 1 && content.firstChild?.type.name === 'paragraph'
+    const slice = isLoneParagraph
+      ? new Slice(content, 1, 1)
+      : new Slice(content, 0, Slice.maxOpen(content).openEnd)
+    if (dispatch) dispatch(state.tr.replaceSelection(slice).scrollIntoView())
+    return true
+  }
+}
+
 export function defineEditorCommands() {
   return defineCommands({
+    insertMarkdown,
     selectText,
     selectTextBetween,
   })

--- a/packages/react/src/components/editor.tsx
+++ b/packages/react/src/components/editor.tsx
@@ -225,6 +225,9 @@ export function MeowdownEditor({
     function setMarkdown(markdown: string): void {
       childRef.current?.setMarkdown(markdown)
     }
+    function insertMarkdown(markdown: string): void {
+      childRef.current?.insertMarkdown(markdown)
+    }
     function getState(): EditorStateSnapshot {
       return childRef.current?.getState() ?? ['', { type: 'text', anchor: 0, head: 0 }]
     }
@@ -246,6 +249,7 @@ export function MeowdownEditor({
     return {
       getMarkdown,
       setMarkdown,
+      insertMarkdown,
       getState,
       setState,
       getSelection,

--- a/packages/react/src/components/prosekit-editor.test.tsx
+++ b/packages/react/src/components/prosekit-editor.test.tsx
@@ -76,4 +76,22 @@ describe('ProseKitEditor', () => {
     await userEvent.keyboard('{ControlOrMeta>}z{/ControlOrMeta}')
     await expect.element(screen.getByText('Hello')).toBeInTheDocument()
   })
+
+  it('fires onDocChange for insertMarkdown, unlike setMarkdown', async () => {
+    const onDocChange = vi.fn()
+    const ref = createRef<EditorHandle>()
+    const screen = await render(
+      <ProseKitEditor ref={ref} initialMarkdown="Hello" onDocChange={onDocChange} />,
+    )
+    await expect.element(screen.getByText('Hello')).toBeInTheDocument()
+
+    ref.current?.setMarkdown('World')
+    ref.current?.setSelection('end')
+    ref.current?.insertMarkdown('!')
+
+    await vi.waitFor(() => {
+      expect(onDocChange).toHaveBeenCalledTimes(1)
+    })
+    expect(ref.current?.getMarkdown()).toBe('World!\n')
+  })
 })

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -211,6 +211,9 @@ export function ProseKitEditor({
     function setMarkdown(markdown: string): void {
       setState(markdown)
     }
+    function insertMarkdown(markdown: string): void {
+      editor.commands.insertMarkdown(markdown)
+    }
     function setSelection(selection: SelectionHint): void {
       setState(undefined, selection)
     }
@@ -223,6 +226,7 @@ export function ProseKitEditor({
     return {
       getMarkdown,
       setMarkdown,
+      insertMarkdown,
       getState,
       setState,
       getSelection,

--- a/packages/react/src/components/types.ts
+++ b/packages/react/src/components/types.ts
@@ -20,6 +20,16 @@ export interface EditorHandle {
   /** Replaces the whole document as a single undoable edit. */
   setMarkdown: (markdown: string) => void
 
+  /**
+   * Parses `markdown` and inserts it at the current selection as a single
+   * undoable edit, replacing any selected content. A lone paragraph is
+   * inserted inline at the cursor; anything else is inserted as blocks. The
+   * cursor lands at the end of the inserted content. An empty or
+   * whitespace-only string is a no-op. Unlike `setMarkdown`, it fires
+   * `onDocChange`: the host cannot know the resulting document.
+   */
+  insertMarkdown: (markdown: string) => void
+
   /** Returns the current Markdown and selection. */
   getState: () => EditorStateSnapshot
 

--- a/website/src/components/codemirror-editor.tsx
+++ b/website/src/components/codemirror-editor.tsx
@@ -97,6 +97,9 @@ export function CodeMirrorEditor({
     function setMarkdown(markdown: string): void {
       setState(markdown)
     }
+    function insertMarkdown(_markdown: string): void {
+      throw new Error('CodeMirrorEditor.insertMarkdown is not implemented')
+    }
     function setSelection(selection: SelectionHint): void {
       setState(undefined, selection)
     }
@@ -109,6 +112,7 @@ export function CodeMirrorEditor({
     return {
       getMarkdown,
       setMarkdown,
+      insertMarkdown,
       getState,
       setState,
       getSelection,


### PR DESCRIPTION
Adds `EditorHandle.insertMarkdown(markdown)` for inserting parsed Markdown at the current selection in rich mode and source mode. This splits the insertion API out from #192 so it can be reviewed independently.
