### PR TITLE
ci: show version in release PR title

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,20 @@ jobs:
         with:
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
+      # release-please titles the grouped release PR "chore: release master": the
+      # merge plugin fills ${version} only from a root-path package, which this repo
+      # does not have (https://github.com/googleapis/release-please/issues/2386), and
+      # the linked-versions plugin hardcodes its own title
+      # (https://github.com/googleapis/release-please/issues/2305). This step
+      # retitles the PR with the version from the manifest on the PR branch.
+      #
       # The title must keep the exact shape "chore: release X.Y.Z": release-please
-      # re-parses it when the PR merges, and any other shape breaks tagging.
+      # re-parses the title when the PR merges, and a shape it cannot parse skips
+      # tagging and publish (https://github.com/googleapis/release-please/issues/2712).
+      # Component versions still come from the PR body, not the title
+      # (https://github.com/googleapis/release-please/issues/2101), so the rewrite is
+      # safe. Delete this step once the grouped title becomes configurable upstream
+      # (https://github.com/googleapis/release-please/pull/2617).
       - name: Add version to release PR title
         if: ${{ steps.release-please.outputs.prs_created == 'true' }}
         continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,25 @@ jobs:
         id: release-please
         with:
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
+
+      # The title must keep the exact shape "chore: release X.Y.Z": release-please
+      # re-parses it when the PR merges, and any other shape breaks tagging.
+      - name: Add version to release PR title
+        if: ${{ steps.release-please.outputs.prs_created == 'true' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          PRS: ${{ steps.release-please.outputs.prs }}
+        run: |
+          number=$(jq -r '.[0].number' <<< "$PRS")
+          branch=$(jq -r '.[0].headBranchName' <<< "$PRS")
+          version=$(gh api "repos/${{ github.repository }}/contents/.release-please-manifest.json?ref=$branch" \
+            -H 'Accept: application/vnd.github.raw+json' | jq -r '.["packages/core"]')
+          if [ -z "$version" ] || [ "$version" = "null" ]; then
+            echo "could not resolve version from manifest on $branch" >&2
+            exit 1
+          fi
+          gh pr edit "$number" --repo "${{ github.repository }}" --title "chore: release $version"
     outputs:
       releases_created: ${{ steps.release-please.outputs.releases_created }}
 


### PR DESCRIPTION
release-please titles the grouped release PR "chore: release master" because the merge plugin only fills ${version} from a root-path package, which this repo does not have. Add a best-effort step after release-please that reads the new version from the manifest on the PR head branch and retitles the PR to "chore: release X.Y.Z". That exact single-token shape still matches release-please's title parser on merge, so tagging and publish are unaffected.