### PR TITLE
feat: insertMarkdown never deletes a selection; SlashMenuItem keywords

### DIFF
--- a/packages/core/src/extensions/commands.test.ts
+++ b/packages/core/src/extensions/commands.test.ts
@@ -14,14 +14,16 @@ describe('insertMarkdown', () => {
     expect(docToMarkdown(fixture.doc)).toBe('Hello brave **new** world\n')
   })
 
-  it('replaces the current selection with the inserted fragment', () => {
+  it('collapses an active selection instead of deleting it', () => {
     using fixture = setupFixture()
     const { editor, n } = fixture
     fixture.set(n.doc(n.paragraph('<a>Hello<b> world')))
 
-    editor.commands.insertMarkdown('Goodbye')
+    // A host-initiated insert is not a paste: the selected text must
+    // survive, with the fragment landing at the caret.
+    editor.commands.insertMarkdown('Goodbye ')
 
-    expect(docToMarkdown(fixture.doc)).toBe('Goodbye world\n')
+    expect(docToMarkdown(fixture.doc)).toBe('Goodbye Hello world\n')
   })
 
   it('inserts a multi-block fragment as blocks with the cursor at its end', () => {

--- a/packages/core/src/extensions/commands.ts
+++ b/packages/core/src/extensions/commands.ts
@@ -40,7 +40,13 @@ function insertMarkdown(markdown: string): Command {
     const slice = isSingleParagraph
       ? new Slice(content, 1, 1)
       : new Slice(content, 0, Slice.maxOpen(content).openEnd)
-    if (dispatch) dispatch(state.tr.replaceSelection(slice).scrollIntoView())
+    if (dispatch) {
+      // Collapse any selection first: this is a host-initiated insert (a
+      // template, not a paste), and it must never delete user content.
+      const tr = state.tr
+      tr.setSelection(TextSelection.near(tr.selection.$from))
+      dispatch(tr.replaceSelection(slice).scrollIntoView())
+    }
     return true
   }
 }

--- a/packages/react/src/components/slash-menu.test.tsx
+++ b/packages/react/src/components/slash-menu.test.tsx
@@ -143,6 +143,23 @@ describe('SlashMenu', () => {
     await expect.element(menu.getByText('Heading 1')).not.toBeVisible()
   })
 
+  it('matches host-item keywords, never displaying them', async () => {
+    const onSlashMenuSearch = (): SlashMenuItem[] => [
+      { label: 'Meeting note', keywords: ['template'], onSelect: () => {} },
+      { label: 'Daily log', keywords: ['template'], onSelect: () => {} },
+      { label: 'Untagged', onSelect: () => {} },
+    ]
+    await render(<ProseKitEditor onSlashMenuSearch={onSlashMenuSearch} />)
+    await pmRoot.click()
+    // Typing the shared keyword lists every keyworded row (the v1 template
+    // affordance) without it appearing in any label.
+    await userEvent.keyboard('/template')
+
+    await expect.element(menu.getByText('Meeting note')).toBeVisible()
+    await expect.element(menu.getByText('Daily log')).toBeVisible()
+    await expect.element(menu.getByText('Untagged')).not.toBeVisible()
+  })
+
   it('closes the menu and calls onSelect on a host item click', async () => {
     const onSelect = vi.fn()
     const onSlashMenuSearch = (): SlashMenuItem[] => [{ label: 'Meeting note', onSelect }]

--- a/packages/react/src/components/slash-menu.tsx
+++ b/packages/react/src/components/slash-menu.tsx
@@ -20,14 +20,20 @@ const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
 
 interface SlashMenuItemProps {
   label: string
+  /** Extra match terms folded into the filter value, never displayed. */
+  keywords?: string[]
   detail?: string
   kbd?: string
   onSelect: VoidFunction
 }
 
-function SlashMenuItem({ label, detail, kbd, onSelect }: SlashMenuItemProps) {
+function SlashMenuItem({ label, keywords, detail, kbd, onSelect }: SlashMenuItemProps) {
   return (
-    <AutocompleteItem value={label} className={styles.Item} onSelect={onSelect}>
+    <AutocompleteItem
+      value={[label, ...(keywords ?? [])].join(' ')}
+      className={styles.Item}
+      onSelect={onSelect}
+    >
       <span className={detail ? styles.Label : undefined}>{label}</span>
       {detail ? <span className={styles.Detail}>{detail}</span> : null}
       {kbd && <kbd>{kbd}</kbd>}
@@ -159,6 +165,7 @@ export function SlashMenu({ timeFormat = '12', onSlashMenuSearch }: SlashMenuPro
             <SlashMenuItem
               key={item.id ?? item.label}
               label={item.label}
+              keywords={item.keywords}
               detail={item.detail}
               onSelect={item.onSelect}
             />

--- a/packages/react/src/components/types.ts
+++ b/packages/react/src/components/types.ts
@@ -22,7 +22,9 @@ export interface EditorHandle {
 
   /**
    * Parses `markdown` and inserts it at the current selection as a single
-   * undoable edit, replacing any selected content. A lone paragraph is
+   * undoable edit. An active selection collapses first and is never
+   * deleted — this is a host-initiated insert (a template), not a paste. A
+   * lone paragraph is
    * inserted inline at the cursor; anything else is inserted as blocks. The
    * cursor lands at the end of the inserted content. An empty or
    * whitespace-only string is a no-op. Unlike `setMarkdown`, it fires
@@ -66,6 +68,12 @@ export interface SlashMenuItem {
   id?: string
   /** Display text, matched against the typed query like the built-in items. */
   label: string
+  /**
+   * Extra match terms beyond the label (never displayed) — e.g. every
+   * template row matching the word "template" so typing `/template` lists
+   * them all.
+   */
+  keywords?: string[]
   /** Secondary text shown beside the label. */
   detail?: string
   /** Runs after the menu closes and the typed `/query` text is removed. */


### PR DESCRIPTION
Follow-up to #197 and #198 (thanks for landing those!), porting two behaviors from the original Reflect template extension this API is built for:

**`insertMarkdown` collapses an active selection instead of replacing it.** The v1 template command did exactly this (`TextSelection.near($from)` before `replaceSelection`, commented "Empty the selection, so we won't delete anything"). A host-initiated insert is not a paste: when the user picks a template from a palette while text happens to be selected, silently deleting that text is data loss. The cursor/paste-open slice behavior is unchanged.

**`SlashMenuItem.keywords`** — optional extra match terms folded into the row's filter value but never displayed. v1 gave every template row the match label `template<name>`, so typing `/template` listed all templates regardless of their names; this restores that affordance generically.

## Verification

- `pnpm run typecheck` — pass
- `@meowdown/core` + `@meowdown/react`: 1118 passed, 17 pre-existing expected-fail; the old "replaces the current selection" test now pins the collapse behavior, and a new slash-menu test pins keyword matching (visible rows, keyword not displayed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)