### PR TITLE
feat: make `insertMarkdown` preserve selected content

### DIFF
--- a/packages/core/src/extensions/commands.test.ts
+++ b/packages/core/src/extensions/commands.test.ts
@@ -14,14 +14,14 @@ describe('insertMarkdown', () => {
     expect(docToMarkdown(fixture.doc)).toBe('Hello brave **new** world\n')
   })
 
-  it('replaces the current selection with the inserted fragment', () => {
+  it('collapses an active selection instead of deleting it', () => {
     using fixture = setupFixture()
     const { editor, n } = fixture
     fixture.set(n.doc(n.paragraph('<a>Hello<b> world')))
 
-    editor.commands.insertMarkdown('Goodbye')
+    editor.commands.insertMarkdown('Goodbye ')
 
-    expect(docToMarkdown(fixture.doc)).toBe('Goodbye world\n')
+    expect(docToMarkdown(fixture.doc)).toBe('Goodbye Hello world\n')
   })
 
   it('inserts a multi-block fragment as blocks with the cursor at its end', () => {

--- a/packages/core/src/extensions/commands.ts
+++ b/packages/core/src/extensions/commands.ts
@@ -1,4 +1,4 @@
-import { defineCommands } from '@prosekit/core'
+import { defineCommands, isTextSelection } from '@prosekit/core'
 import { Slice, type ResolvedPos } from '@prosekit/pm/model'
 import { TextSelection, type Command } from '@prosekit/pm/state'
 
@@ -40,7 +40,14 @@ function insertMarkdown(markdown: string): Command {
     const slice = isSingleParagraph
       ? new Slice(content, 1, 1)
       : new Slice(content, 0, Slice.maxOpen(content).openEnd)
-    if (dispatch) dispatch(state.tr.replaceSelection(slice).scrollIntoView())
+    if (dispatch) {
+      const tr = state.tr
+      const selection = tr.selection
+      if (!isTextSelection(selection) || !selection.empty) {
+        tr.setSelection(TextSelection.near(selection.$from))
+      }
+      dispatch(tr.replaceSelection(slice).scrollIntoView())
+    }
     return true
   }
 }

--- a/packages/react/src/components/types.ts
+++ b/packages/react/src/components/types.ts
@@ -28,7 +28,8 @@ export interface EditorHandle {
 
   /**
    * Parses `markdown` and inserts it at the current selection as a single
-   * undoable edit, replacing any selected content. A lone paragraph is
+   * undoable edit. An active selection collapses first and is never
+   * deleted - this is a host-initiated insert, not a paste. A lone paragraph is
    * inserted inline at the cursor; anything else is inserted as blocks. The
    * cursor lands at the end of the inserted content. An empty or
    * whitespace-only string is a no-op. Unlike `setMarkdown`, it fires


### PR DESCRIPTION
Split from #206. insertMarkdown now collapses an active selection before inserting so host-triggered template inserts do not delete selected text. The focused core test and pnpm run typecheck pass.