### PR TITLE
feat: support slash menu keywords

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -54,6 +54,8 @@ export function App() {
 
 See the full API reference [here](https://npmx.dev/package-docs/@meowdown%2Freact/).
 
+Slash menu host items can include `keywords` to match hidden terms without changing the displayed label.
+
 ## Styling
 
 Import both stylesheets: `@meowdown/core/style.css` (the editor theme and variables) and `@meowdown/react/style.css` (the component layout). The core theme is documented in [`@meowdown/core`](https://www.npmjs.com/package/@meowdown/core).

--- a/packages/react/src/components/slash-menu.test.tsx
+++ b/packages/react/src/components/slash-menu.test.tsx
@@ -143,6 +143,22 @@ describe('SlashMenu', () => {
     await expect.element(menu.getByText('Heading 1')).not.toBeVisible()
   })
 
+  it('matches host-item keywords, never displaying them', async () => {
+    const onSlashMenuSearch = (): SlashMenuItem[] => [
+      { label: 'Meeting note', keywords: ['template'], onSelect: () => {} },
+      { label: 'Daily log', keywords: ['template'], onSelect: () => {} },
+      { label: 'Untagged', onSelect: () => {} },
+    ]
+    await render(<ProseKitEditor onSlashMenuSearch={onSlashMenuSearch} />)
+    await pmRoot.click()
+    await userEvent.keyboard('/template')
+
+    await expect.element(menu.getByText('Meeting note')).toBeVisible()
+    await expect.element(menu.getByText('Daily log')).toBeVisible()
+    await expect.element(menu.getByText('Untagged')).not.toBeVisible()
+    expect(menu.element().textContent).not.toContain('template')
+  })
+
   it('closes the menu and calls onSelect on a host item click', async () => {
     const onSelect = vi.fn()
     const onSlashMenuSearch = (): SlashMenuItem[] => [{ label: 'Meeting note', onSelect }]

--- a/packages/react/src/components/slash-menu.tsx
+++ b/packages/react/src/components/slash-menu.tsx
@@ -20,14 +20,19 @@ const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
 
 interface SlashMenuItemProps {
   label: string
+  keywords?: string[]
   detail?: string
   kbd?: string
   onSelect: VoidFunction
 }
 
-function SlashMenuItem({ label, detail, kbd, onSelect }: SlashMenuItemProps) {
+function SlashMenuItem({ label, keywords, detail, kbd, onSelect }: SlashMenuItemProps) {
   return (
-    <AutocompleteItem value={label} className={styles.Item} onSelect={onSelect}>
+    <AutocompleteItem
+      value={[label, ...(keywords ?? [])].join(' ')}
+      className={styles.Item}
+      onSelect={onSelect}
+    >
       <span className={detail ? styles.Label : undefined}>{label}</span>
       {detail ? <span className={styles.Detail}>{detail}</span> : null}
       {kbd && <kbd>{kbd}</kbd>}
@@ -159,6 +164,7 @@ export function SlashMenu({ timeFormat = '12', onSlashMenuSearch }: SlashMenuPro
             <SlashMenuItem
               key={item.id ?? item.label}
               label={item.label}
+              keywords={item.keywords}
               detail={item.detail}
               onSelect={item.onSelect}
             />

--- a/packages/react/src/components/types.ts
+++ b/packages/react/src/components/types.ts
@@ -105,6 +105,8 @@ export interface SlashMenuItem {
   id?: string
   /** Display text, matched against the typed query like the built-in items. */
   label: string
+  /** Extra match terms beyond the label; never displayed. */
+  keywords?: string[]
   /** Secondary text shown beside the label. */
   detail?: string
   /** Runs after the menu closes and the typed `/query` text is removed. */


### PR DESCRIPTION
Split from #206. SlashMenuItem.keywords adds hidden match terms for host slash-menu rows and documents the new React API. The focused slash-menu test and pnpm run typecheck pass.