### PR TITLE
test: replace magic positions with `<a>` caret tags

### DIFF
--- a/packages/core/src/extensions/file-view.test.ts
+++ b/packages/core/src/extensions/file-view.test.ts
@@ -1,13 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 
-import {
-  setCaret,
-  setupFixture,
-  traceKeyAt,
-  traceKeySelection,
-  type Fixture,
-} from '../testing/index.ts'
+import { setupFixture, traceKeyAt, traceKeySelection, type Fixture } from '../testing/index.ts'
 
 import { defineFileClickHandler, type FileClickHandler } from './file-click.ts'
 import { defineFileView, type FileInfoResolver } from './file-view.ts'
@@ -32,6 +26,7 @@ function setup(
   editor.use(defineFileView({ resolveFileInfo }))
   editor.use(defineMarkMode(mode))
   fixture.set(n.doc(n.paragraph(markdown)))
+  fixture.view.focus()
   return fixture
 }
 
@@ -133,11 +128,9 @@ describe('file pill size', () => {
 
 describe('file pill update', () => {
   it('keeps the same pill element while the name is edited', async () => {
-    using fixture = setup('[report.pdf](assets/report.pdf)', undefined, 'show')
+    using fixture = setup('[report<a>.pdf](assets/report.pdf)', undefined, 'show')
     await expect.element(pill).toHaveTextContent('report.pdf')
     const pillBefore = pill.element()
-    // Offset 7 = after `report`, before `.pdf` inside the label.
-    setCaret(fixture, 7)
     await userEvent.keyboard('X')
     await expect.element(pill).toHaveTextContent('reportX.pdf')
     expect(pill.element()).toBe(pillBefore)
@@ -146,11 +139,10 @@ describe('file pill update', () => {
 
   it('rebuilds the pill when the href is edited', async () => {
     const resolveFileInfo = vi.fn(() => ({ size: 1000 }))
-    using fixture = setup('[report.pdf](assets/report.pdf)', resolveFileInfo, 'show')
+    using fixture = setup('[report.pdf](assets/report<a>.pdf)', resolveFileInfo, 'show')
+    void fixture
     await expect.element(pillSize).toHaveTextContent('1 KB')
     const pillBefore = pill.element()
-    // Offset 26 = inside the href, right after `assets/report`.
-    setCaret(fixture, 26)
     await userEvent.keyboard('X')
     await expect.element(pill).toBeInTheDocument()
     await vi.waitFor(() => {
@@ -160,10 +152,8 @@ describe('file pill update', () => {
   })
 
   it('drops the pill when the href is edited out of the resolver claim', async () => {
-    using fixture = setup('A[report.pdf](assets/report.pdf)', undefined, 'show')
+    using fixture = setup('A[report.pdf](<a>assets/report.pdf)', undefined, 'show')
     await expect.element(pill).toBeInTheDocument()
-    // Offset 14 = right after the `(`, before `assets/…`.
-    setCaret(fixture, 14)
     await userEvent.keyboard('x')
     await vi.waitFor(() => {
       expect(pill.query()).toBeNull()
@@ -172,16 +162,10 @@ describe('file pill update', () => {
   })
 })
 
-// Text:     A   B   C   [  ...29 more chars...  )   D   E   F
-// The file link `[report.pdf](assets/report.pdf)` occupies offsets 3 to 34.
+// The file link `[report.pdf](assets/report.pdf)` is one atom caret stop.
 describe('file pill caret navigation', () => {
-  function setupNavigation(): Fixture {
-    return setup('ABC[report.pdf](assets/report.pdf)DEF')
-  }
-
   it('ArrowRight selects the pill, then steps past into DEF', async () => {
-    using fixture = setupNavigation()
-    setCaret(fixture, 1)
+    using fixture = setup('A<a>BC[report.pdf](assets/report.pdf)DEF')
     expect(await traceKeySelection(fixture, 'ArrowRight', 6)).toMatchInlineSnapshot(`
       [
         "A┃BC[report.pdf](assets/report.pdf)DEF",
@@ -196,8 +180,7 @@ describe('file pill caret navigation', () => {
   })
 
   it('ArrowLeft selects the pill, then collapses to its left edge', async () => {
-    using fixture = setupNavigation()
-    setCaret(fixture, 35)
+    using fixture = setup('ABC[report.pdf](assets/report.pdf)D<a>EF')
     expect(await traceKeySelection(fixture, 'ArrowLeft', 3)).toMatchInlineSnapshot(`
       [
         "ABC[report.pdf](assets/report.pdf)D┃EF",
@@ -209,9 +192,9 @@ describe('file pill caret navigation', () => {
   })
 
   it('Backspace deletes the pill as a unit', async () => {
-    expect(await traceKeyAt(setupNavigation, 34, 'Backspace')).toMatchInlineSnapshot(
-      `"ABC[report.pdf](assets/report.pdf)┃DEF  ->  ABC┃DEF"`,
-    )
+    expect(
+      await traceKeyAt(setup, 'ABC[report.pdf](assets/report.pdf)<a>DEF', 'Backspace'),
+    ).toMatchInlineSnapshot(`"ABC[report.pdf](assets/report.pdf)┃DEF  ->  ABC┃DEF"`)
   })
 })
 

--- a/packages/core/src/extensions/image.test.ts
+++ b/packages/core/src/extensions/image.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 
+import { findText } from '../testing/find-text.ts'
 import {
   getSelectionSnapshot,
-  setCaret,
   setupFixture,
   traceKeyAt,
   traceKeySelection,
@@ -25,13 +25,6 @@ function getSVGImageURL(width: number, height: number): string {
   return `data:image/svg+xml;base64,${btoa(svg)}`
 }
 
-// Text:     A   B   C   !   [   i   m   g   ]   (   u   r   l   )   D   E   F
-// Offset: 0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17
-//
-// The hidden image source `![img](url)` occupies the characters between offsets
-// 3 and 14.
-const TEXT = 'ABC![img](url)DEF'
-
 // An editor showing the image in the given mark mode.
 function setup(mode: MarkMode, text: string): Fixture {
   const fixture = setupFixture()
@@ -43,16 +36,15 @@ function setup(mode: MarkMode, text: string): Fixture {
   return fixture
 }
 
-function setupHidden(): Fixture {
-  return setup('hide', TEXT)
+function setupHidden(text: string): Fixture {
+  return setup('hide', text)
 }
 
 // A hidden image is one caret stop: arrowing onto it selects the whole
 // `![img](url)`, and the next arrow steps past it.
 describe('image caret navigation', () => {
   it('ArrowRight selects the image, then steps past into DEF', async () => {
-    using fixture = setupHidden()
-    setCaret(fixture, 1)
+    using fixture = setupHidden('A<a>BC![img](url)DEF')
     expect(await traceKeySelection(fixture, 'ArrowRight', 6)).toMatchInlineSnapshot(`
       [
         "A┃BC![img](url)DEF",
@@ -67,8 +59,7 @@ describe('image caret navigation', () => {
   })
 
   it('ArrowLeft selects the image, then collapses to its left edge', async () => {
-    using fixture = setupHidden()
-    setCaret(fixture, 15)
+    using fixture = setupHidden('ABC![img](url)D<a>EF')
     expect(await traceKeySelection(fixture, 'ArrowLeft', 3)).toMatchInlineSnapshot(`
       [
         "ABC![img](url)D┃EF",
@@ -85,10 +76,10 @@ describe('image caret navigation', () => {
 describe('image deletion', () => {
   it('Backspace deletes the image as a unit, plain text one char', async () => {
     const result = [
-      await traceKeyAt(setupHidden, 2, 'Backspace'), // between B and C
-      await traceKeyAt(setupHidden, 3, 'Backspace'), // just before the image
-      await traceKeyAt(setupHidden, 14, 'Backspace'), // just after the image
-      await traceKeyAt(setupHidden, 15, 'Backspace'), // between D and E
+      await traceKeyAt(setupHidden, 'AB<a>C![img](url)DEF', 'Backspace'),
+      await traceKeyAt(setupHidden, 'ABC<a>![img](url)DEF', 'Backspace'),
+      await traceKeyAt(setupHidden, 'ABC![img](url)<a>DEF', 'Backspace'),
+      await traceKeyAt(setupHidden, 'ABC![img](url)D<a>EF', 'Backspace'),
     ]
 
     expect(result).toMatchInlineSnapshot(`
@@ -106,10 +97,8 @@ describe('image deletion', () => {
 // it does not. This is what the `md-atom-selected` decoration drives.
 describe('image selection ring', () => {
   it('rings the preview only while the image is selected, from either edge', async () => {
-    using fixture = setupHidden()
-
     // A caret before the image does not ring it.
-    setCaret(fixture, 3)
+    using fixture = setupHidden('ABC<a>![img](url)DEF')
     expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(`"ABC┃![img](url)DEF"`)
     await expect.element(preview).toHaveStyle({ outlineStyle: 'none' })
 
@@ -340,7 +329,10 @@ describe('image mark view update', () => {
 
     const { view } = fixture
     expect(fixture.doc.textContent).toMatchInlineSnapshot(`"ABC![alt1](url)DEF"`)
-    view.dispatch(view.state.tr.replaceWith(6, 10, view.state.schema.text('ALT2')))
+    const altStart = findText(fixture.doc, 'alt1')
+    view.dispatch(
+      view.state.tr.replaceWith(altStart, altStart + 'alt1'.length, view.state.schema.text('ALT2')),
+    )
     expect(fixture.doc.textContent).toMatchInlineSnapshot(`"ABC![ALT2](url)DEF"`)
 
     const image2 = pmRoot.getByAltText('ALT2')

--- a/packages/core/src/extensions/list-collapse.test.ts
+++ b/packages/core/src/extensions/list-collapse.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 
-import { setCaret, setupFixture } from '../testing/index.ts'
+import { setupFixture } from '../testing/index.ts'
 
 const pmRoot = page.locate('.ProseMirror')
 
@@ -13,12 +13,11 @@ describe('toggleListCollapsed', () => {
       n.doc(
         n.list(
           { kind: 'bullet' },
-          n.paragraph('parent'),
+          n.paragraph('<a>parent'),
           n.list({ kind: 'bullet' }, n.paragraph('child')),
         ),
       ),
     )
-    setCaret(fixture, 2)
 
     expect(editor.commands.toggleListCollapsed.canExec()).toBe(true)
     editor.commands.toggleListCollapsed()
@@ -30,8 +29,7 @@ describe('toggleListCollapsed', () => {
   it('cannot fold a leaf bullet', () => {
     using fixture = setupFixture()
     const { editor, n } = fixture
-    fixture.set(n.doc(n.list({ kind: 'bullet' }, n.paragraph('leaf'))))
-    setCaret(fixture, 2)
+    fixture.set(n.doc(n.list({ kind: 'bullet' }, n.paragraph('<a>leaf'))))
     expect(editor.commands.toggleListCollapsed.canExec()).toBe(false)
   })
 
@@ -40,10 +38,9 @@ describe('toggleListCollapsed', () => {
     const { editor, n } = fixture
     fixture.set(
       n.doc(
-        n.list({ kind: 'task' }, n.paragraph('a'), n.list({ kind: 'bullet' }, n.paragraph('b'))),
+        n.list({ kind: 'task' }, n.paragraph('<a>a'), n.list({ kind: 'bullet' }, n.paragraph('b'))),
       ),
     )
-    setCaret(fixture, 2)
     expect(editor.commands.toggleListCollapsed.canExec()).toBe(false)
   })
 })

--- a/packages/core/src/extensions/wikilink-insert-caret.test.ts
+++ b/packages/core/src/extensions/wikilink-insert-caret.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 
-import { getSelectionSnapshot, setCaret, setupFixture, type Fixture } from '../testing/index.ts'
+import { getSelectionSnapshot, setupFixture, type Fixture } from '../testing/index.ts'
 
 import { defineMarkMode, type MarkMode } from './mark-mode.ts'
 
@@ -11,14 +11,14 @@ const label = pmRoot.getByTestId('wikilink')
 const ALL_MODES: MarkMode[] = ['hide', 'focus', 'show']
 
 // An editor in `mode` whose only content is the letter `A`, caret right after it
-// (text offset 1), exactly the state of a user who typed `A` then opened the
+// (the `<a>` tag), exactly the state of a user who typed `A` then opened the
 // wikilink menu.
 function setupAfterA(mode: MarkMode): Fixture {
   const fixture = setupFixture()
   const { editor, n } = fixture
   editor.use(defineMarkMode(mode))
-  fixture.set(n.doc(n.paragraph('A')))
-  setCaret(fixture, 1)
+  fixture.set(n.doc(n.paragraph('A<a>')))
+  fixture.view.focus()
   return fixture
 }
 
@@ -85,9 +85,8 @@ describe.each(ALL_MODES)('typing before an inserted wikilink in %s mode', (mode)
     using fixture = setupFixture()
     const { editor, n } = fixture
     editor.use(defineMarkMode(mode))
-    fixture.set(n.doc(n.paragraph('A[[Note]]C')))
-    // Offset 1 = right after `A`, just before the first `[`.
-    setCaret(fixture, 1)
+    fixture.set(n.doc(n.paragraph('A<a>[[Note]]C')))
+    fixture.view.focus()
     await expect.element(pmRoot).toBeVisible()
 
     await userEvent.keyboard('X')

--- a/packages/core/src/extensions/wikilink.test.ts
+++ b/packages/core/src/extensions/wikilink.test.ts
@@ -3,7 +3,6 @@ import { page, userEvent } from 'vitest/browser'
 
 import {
   getSelectionSnapshot,
-  setCaret,
   setupFixture,
   traceKeyAt,
   traceKeySelection,
@@ -15,21 +14,15 @@ import { defineMarkMode, type MarkMode } from './mark-mode.ts'
 const pmRoot = page.locate('.ProseMirror')
 const label = pmRoot.getByTestId('wikilink')
 
-// Text:    A   B   [   [   N   o   t   e   ]   ]   C   D
-// Offset: 0   1   2   3   4   5   6   7   8   9  10  11  12
-//
-// The wikilink source `[[Note]]` occupies the characters between offsets 2 and
-// 10. It is one atom caret stop in every mark mode.
-const TEXT = 'AB[[Note]]CD'
-
-// A factory for an editor in `mode` showing the wikilink, shared by the suites
-// below.
-function setupMode(mode: MarkMode): () => Fixture {
-  return () => {
+// A factory for an editor in `mode` showing the wikilink `[[Note]]`, one atom
+// caret stop in every mark mode. `text` places the caret with a `<a>` tag.
+function setupMode(mode: MarkMode): (text: string) => Fixture {
+  return (text: string) => {
     const fixture = setupFixture()
     const { editor, n } = fixture
     editor.use(defineMarkMode(mode))
-    fixture.set(n.doc(n.paragraph(TEXT)))
+    fixture.set(n.doc(n.paragraph(text)))
+    fixture.view.focus()
     return fixture
   }
 }
@@ -71,8 +64,7 @@ describe.each(ALL_MODES)('wikilink caret navigation in %s mode', (mode) => {
   const setup = setupMode(mode)
 
   it('ArrowRight selects the wikilink, then steps past into CD', async () => {
-    using fixture = setup()
-    setCaret(fixture, 1)
+    using fixture = setup('A<a>B[[Note]]CD')
     expect(await traceKeySelection(fixture, 'ArrowRight', 5)).toMatchInlineSnapshot(`
       [
         "A┃B[[Note]]CD",
@@ -86,8 +78,7 @@ describe.each(ALL_MODES)('wikilink caret navigation in %s mode', (mode) => {
   })
 
   it('ArrowLeft selects the wikilink, then collapses to its left edge', async () => {
-    using fixture = setup()
-    setCaret(fixture, 11)
+    using fixture = setup('AB[[Note]]C<a>D')
     expect(await traceKeySelection(fixture, 'ArrowLeft', 3)).toMatchInlineSnapshot(`
       [
         "AB[[Note]]C┃D",
@@ -100,10 +91,10 @@ describe.each(ALL_MODES)('wikilink caret navigation in %s mode', (mode) => {
 
   it('Backspace deletes the wikilink as a unit, plain text one char', async () => {
     expect([
-      await traceKeyAt(setup, 1, 'Backspace'), // between A and B
-      await traceKeyAt(setup, 2, 'Backspace'), // just before the wikilink
-      await traceKeyAt(setup, 10, 'Backspace'), // just after the wikilink
-      await traceKeyAt(setup, 11, 'Backspace'), // between C and D
+      await traceKeyAt(setup, 'A<a>B[[Note]]CD', 'Backspace'),
+      await traceKeyAt(setup, 'AB<a>[[Note]]CD', 'Backspace'),
+      await traceKeyAt(setup, 'AB[[Note]]<a>CD', 'Backspace'),
+      await traceKeyAt(setup, 'AB[[Note]]C<a>D', 'Backspace'),
     ]).toMatchInlineSnapshot(`
       [
         "A┃B[[Note]]CD  ->  ┃B[[Note]]CD",
@@ -121,9 +112,8 @@ describe.each(LABEL_MODES)('wikilink selection ring in %s mode', (mode) => {
   const setup = setupMode(mode)
 
   it('rings the label only while the wikilink is selected', async () => {
-    using fixture = setup()
+    using fixture = setup('AB<a>[[Note]]CD')
 
-    setCaret(fixture, 2)
     expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(`"AB┃[[Note]]CD"`)
     await expect.element(label).toHaveStyle({ outlineStyle: 'none' })
 
@@ -137,9 +127,8 @@ describe.each(LABEL_MODES)('wikilink selection ring in %s mode', (mode) => {
   })
 
   it('rings the label when selected from its right edge', async () => {
-    using fixture = setup()
+    using fixture = setup('AB[[Note]]<a>CD')
 
-    setCaret(fixture, 10)
     expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(`"AB[[Note]]┃CD"`)
     await expect.element(label).toHaveStyle({ outlineStyle: 'none' })
 

--- a/packages/core/src/testing/caret.ts
+++ b/packages/core/src/testing/caret.ts
@@ -1,16 +1,8 @@
-import { TextSelection } from '@prosekit/pm/state'
 import { userEvent } from 'vitest/browser'
 
 import { getSelectionSnapshot } from './selection-snapshot.ts'
 
 import type { Fixture } from './index.ts'
-
-/** Place a collapsed caret at text offset `offset`. */
-export function setCaret(fixture: Fixture, offset: number): void {
-  const { view } = fixture
-  view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, offset + 1)))
-  view.focus()
-}
 
 /**
  * Press `key` `times` times, capturing the selection snapshot before the first
@@ -30,16 +22,16 @@ export async function traceKeySelection(
 }
 
 /**
- * On a fresh fixture from `setup`, place the caret at text offset `offset`,
- * press `key` once, and return the `before  ->  after` selection snapshot.
+ * On a fresh fixture from `setup(text)`, with the caret at the `<a>` tag in
+ * `text`, press `key` once, and return the `before  ->  after` selection
+ * snapshot.
  */
 export async function traceKeyAt(
-  setup: () => Fixture,
-  offset: number,
+  setup: (text: string) => Fixture,
+  text: string,
   key: string,
 ): Promise<string> {
-  using fixture = setup()
-  setCaret(fixture, offset)
+  using fixture = setup(text)
   const before = getSelectionSnapshot(fixture.state)
   await userEvent.keyboard(`{${key}}`)
   return `${before}  ->  ${getSelectionSnapshot(fixture.state)}`

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -11,7 +11,7 @@ import { defineEditorExtension, type EditorExtensionOptions } from '../extension
 import { getSelectionSnapshot } from './selection-snapshot.ts'
 
 export { getSelectionSnapshot } from './selection-snapshot.ts'
-export { setCaret, traceKeySelection, traceKeyAt } from './caret.ts'
+export { traceKeySelection, traceKeyAt } from './caret.ts'
 
 export interface SetupFixtureOptions {
   /** Whether to mount the editor onto a real DOM container. Defaults to `true`. */


### PR DESCRIPTION
Replace every numeric `setCaret` / `traceKeyAt` offset in the tests with an inline `<a>` caret tag in the doc builder string, and delete the `setCaret` helper. Also replace the magic `replaceWith(6, 10)` positions in `image.test.ts` with `findText`. All inline snapshots are unchanged, so caret behavior is identical.