### PR TITLE
fix: anchor the link popover to the visible label

### DIFF
--- a/packages/core/src/utils/virtual-element.ts
+++ b/packages/core/src/utils/virtual-element.ts
@@ -21,8 +21,8 @@ export function getVirtualElementFromRange(view: EditorView, range: PositionRang
       // (the default `side`), an edge that sits against hidden markdown syntax
       // at a block boundary has no visible neighbor and yields a bogus
       // zero rect, anchoring the popover at the viewport corner.
-      const start = view.coordsAtPos(range.from, 1)
-      const end = view.coordsAtPos(range.to, -1)
+      const start = tryCoordsAtPos(view, range.from, 1)
+      const end = tryCoordsAtPos(view, range.to, -1)
       const left = Math.min(start.left, end.left)
       const right = Math.max(start.right, end.right)
       const top = Math.min(start.top, end.top)
@@ -37,4 +37,20 @@ export function getVirtualElementFromRange(view: EditorView, range: PositionRang
     getBoundingClientRect,
     getClientRects: () => [getBoundingClientRect()],
   }
+}
+
+interface Rect {
+  left: number
+  top: number
+  right: number
+  bottom: number
+}
+
+function isZeroRect(rect: Rect): boolean {
+  return rect.left === 0 && rect.top === 0 && rect.right === 0 && rect.bottom === 0
+}
+
+function tryCoordsAtPos(view: EditorView, pos: number, bias: -1 | 1): Rect {
+  const rect: Rect = view.coordsAtPos(pos, bias)
+  return isZeroRect(rect) ? view.coordsAtPos(pos, -bias) : rect
 }

--- a/packages/core/src/utils/virtual-element.ts
+++ b/packages/core/src/utils/virtual-element.ts
@@ -17,8 +17,12 @@ export function getVirtualElementFromRange(view: EditorView, range: PositionRang
   const getBoundingClientRect = (): DOMRect => {
     if (view.isDestroyed) return lastRect
     try {
-      const start = view.coordsAtPos(range.from)
-      const end = view.coordsAtPos(range.to)
+      // Bias both measurements into the range's own content. Measured outward
+      // (the default `side`), an edge that sits against hidden markdown syntax
+      // at a block boundary has no visible neighbor and yields a bogus
+      // zero rect, anchoring the popover at the viewport corner.
+      const start = view.coordsAtPos(range.from, 1)
+      const end = view.coordsAtPos(range.to, -1)
       const left = Math.min(start.left, end.left)
       const right = Math.max(start.right, end.right)
       const top = Math.min(start.top, end.top)

--- a/packages/react/src/components/link-menu.test.tsx
+++ b/packages/react/src/components/link-menu.test.tsx
@@ -30,6 +30,29 @@ describe('LinkMenu', () => {
     })
   })
 
+  it('anchors the preview to the link when hidden syntax ends the block', async () => {
+    // The whole block is one link: the hidden `](url)` syntax reaches the block
+    // boundary, so a unit-edge measurement has no visible neighbor to snap to
+    // and used to collapse to a zero rect at the viewport origin.
+    const label = 'export-Meters-1780294218812-20260601.xlsx'
+    const screen = await render(
+      <MeowdownEditor initialMarkdown={`[${label}](assets/export.xlsx)`} />,
+    )
+    const link = screen.getByText(label)
+    await link.hover()
+    await expect.element(popover.getByTestId('link-popover-read')).toBeVisible()
+
+    const linkRect = link.element().getBoundingClientRect()
+    const popRect = popover.element().getBoundingClientRect()
+    // Just below the link...
+    expect(popRect.top).toBeGreaterThan(linkRect.bottom)
+    expect(popRect.top).toBeLessThan(linkRect.bottom + 40)
+    // ...and centered on it, not dragged toward the viewport corner.
+    const linkCenter = (linkRect.left + linkRect.right) / 2
+    const popCenter = (popRect.left + popRect.right) / 2
+    expect(Math.abs(popCenter - linkCenter)).toBeLessThan(20)
+  })
+
   it('creates a link from a selection with Mod-k', async () => {
     const ref = createRef<EditorHandle>()
     const screen = await render(<MeowdownEditor handleRef={ref} initialMarkdown="Docs" />)

--- a/packages/react/src/components/link-menu.tsx
+++ b/packages/react/src/components/link-menu.tsx
@@ -231,12 +231,18 @@ export function LinkMenu({ onLinkClick, onLinkCopy }: LinkMenuProps) {
   let rangeFrom: number | undefined
   let rangeTo: number | undefined
 
+  // Anchor on the visible `[ ]` label rather than the whole unit: the unit's
+  // outer edges sit inside the hidden `[`/`](url)` syntax, whose collapsed
+  // glyphs measure at bogus coordinates. Autolinks (no `label`) are fully
+  // visible, so their unit is safe.
   if (edit) {
-    rangeFrom = edit.from
-    rangeTo = edit.to
+    const anchorRange = edit.link?.label ?? edit
+    rangeFrom = anchorRange.from
+    rangeTo = anchorRange.to
   } else if (hover) {
-    rangeFrom = hover.unit.from
-    rangeTo = hover.unit.to
+    const anchorRange = hover.label ?? hover.unit
+    rangeFrom = anchorRange.from
+    rangeTo = anchorRange.to
   }
 
   const anchor: VirtualElement | undefined = useMemo(() => {


### PR DESCRIPTION
## Problem

Reported on Discord (with screenshot): the link hover popover sometimes renders far from the link — pinned near the top-left of the window.

The hover and edit popovers anchor on a virtual element that measures the whole `[text](url)` unit with `coordsAtPos` at both ends. The unit's trailing edge sits inside the hidden `](url)` syntax (`display: none` in hide mode; collapsed via `letter-spacing: -2em` in focus mode). Mid-paragraph, `coordsAtPos` snaps to the next visible character and everything works — which is why the bug is intermittent. But when the link ends its block (e.g. a file link alone on a line, as in the report), there is no visible neighbor and `coordsAtPos(unit.to)` returns an all-zero rect. The anchor rect then unions with the viewport origin `(0, 0)`, dragging the popover to the corner. Reproduced in the website playground: the measured anchor came back as `{x: 0, y: 0, width: 81, height: 308}`.

## Changes

- **`link-menu.tsx`** — anchor both the hover preview and the Mod-k edit form on the link's visible `[ ]` label instead of the full unit, falling back to the unit for autolinks (which are fully visible).
- **`virtual-element.ts`** — bias `getVirtualElementFromRange`'s two measurements *into* the range (`coordsAtPos(from, 1)` / `coordsAtPos(to, -1)`), so callers measure the range's own content rather than whatever follows it. This also hardens the selection-menu and pending-replacement anchors, which share this helper.
- **`link-menu.test.tsx`** — regression test: a block consisting solely of a link, asserting the popover lands just below the link and horizontally centered on it. Fails on the unfixed code.

## Verification

- Verified live in the website playground: the popover now lands centered 8px below the link in all three mark modes (focus, hide, show), for both the hover preview and the Mod-k edit form; mid-paragraph links unaffected.
- Full `@meowdown/core` + `@meowdown/react` suites pass (1192 tests), plus typecheck and lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)