### PR TITLE
fix: keep the list marker when Enter splits a list item

### DIFF
--- a/packages/core/src/extensions/list.test.ts
+++ b/packages/core/src/extensions/list.test.ts
@@ -215,6 +215,36 @@ describe('keymap', () => {
     expect(docToMarkdown(fixture.doc)).toBe('* todo\n* next\n')
   })
 
+  it('Enter on an empty circle checkbox task still unwraps it', async () => {
+    using fixture = setupFixture()
+    fixture.set(
+      fixture.n.doc(
+        fixture.n.list({ kind: 'task', marker: '+', checked: false }, fixture.n.paragraph('<a>')),
+      ),
+    )
+    fixture.view.focus()
+
+    await userEvent.keyboard('{Enter}')
+    expect(fixture.doc.firstChild?.type.name).toBe('paragraph')
+  })
+
+  it('Enter at the end of a collapsed bullet adds the next item below its hidden children', async () => {
+    using fixture = setupFixture()
+    fixture.set(
+      fixture.n.doc(
+        fixture.n.list(
+          { kind: 'bullet', marker: '*', collapsed: true },
+          fixture.n.paragraph('parent<a>'),
+          fixture.n.list({ kind: 'bullet' }, fixture.n.paragraph('child')),
+        ),
+      ),
+    )
+    fixture.view.focus()
+
+    await userEvent.keyboard('{Enter}next')
+    expect(docToMarkdown(fixture.doc)).toBe('+ parent\n  - child\n* next\n')
+  })
+
   it('Enter keeps the marker gap on the next item', async () => {
     using fixture = setupFixture()
     fixture.set(

--- a/packages/core/src/extensions/list.test.ts
+++ b/packages/core/src/extensions/list.test.ts
@@ -123,6 +123,111 @@ describe('keymap', () => {
     expect(docToMarkdown(fixture.doc)).toBe('+ [ ] todo\n')
   })
 
+  it('Enter continues a circle checkbox task with another circle checkbox task', async () => {
+    using fixture = setupFixture()
+    fixture.set(
+      fixture.n.doc(
+        fixture.n.list(
+          { kind: 'task', marker: '+', checked: false },
+          fixture.n.paragraph('todo<a>'),
+        ),
+      ),
+    )
+    fixture.view.focus()
+
+    await userEvent.keyboard('{Enter}next')
+    expect(docToMarkdown(fixture.doc)).toBe('+ [ ] todo\n+ [ ] next\n')
+  })
+
+  it('Enter on a checked circle checkbox task continues with an unchecked one', async () => {
+    using fixture = setupFixture()
+    fixture.set(
+      fixture.n.doc(
+        fixture.n.list(
+          { kind: 'task', marker: '+', checked: true },
+          fixture.n.paragraph('done<a>'),
+        ),
+      ),
+    )
+    fixture.view.focus()
+
+    await userEvent.keyboard('{Enter}next')
+    expect(docToMarkdown(fixture.doc)).toBe('+ [x] done\n+ [ ] next\n')
+  })
+
+  it('Enter in the middle of a circle checkbox task keeps the circle on both halves', async () => {
+    using fixture = setupFixture()
+    fixture.set(
+      fixture.n.doc(
+        fixture.n.list(
+          { kind: 'task', marker: '+', checked: false },
+          fixture.n.paragraph('to<a>do'),
+        ),
+      ),
+    )
+    fixture.view.focus()
+
+    await userEvent.keyboard('{Enter}')
+    expect(docToMarkdown(fixture.doc)).toBe('+ [ ] to\n+ [ ] do\n')
+  })
+
+  it('Enter at the start of a circle checkbox task inserts an empty circle task above', async () => {
+    using fixture = setupFixture()
+    fixture.set(
+      fixture.n.doc(
+        fixture.n.list(
+          { kind: 'task', marker: '+', checked: false },
+          fixture.n.paragraph('<a>todo'),
+        ),
+      ),
+    )
+    fixture.view.focus()
+
+    await userEvent.keyboard('{Enter}')
+    expect(fixture.doc.childCount).toBe(2)
+    expect(fixture.doc.firstChild?.attrs).toMatchObject({ kind: 'task', marker: '+' })
+    expect(docToMarkdown(fixture.doc)).toContain('+ [ ] todo\n')
+  })
+
+  it('Enter continues a square checkbox task with a square checkbox task', async () => {
+    using fixture = setupFixture()
+    fixture.set(
+      fixture.n.doc(
+        fixture.n.list({ kind: 'task', checked: false }, fixture.n.paragraph('todo<a>')),
+      ),
+    )
+    fixture.view.focus()
+
+    await userEvent.keyboard('{Enter}next')
+    expect(docToMarkdown(fixture.doc)).toBe('- [ ] todo\n- [ ] next\n')
+  })
+
+  it('Enter continues a `*` bullet with a `*` bullet', async () => {
+    using fixture = setupFixture()
+    fixture.set(
+      fixture.n.doc(
+        fixture.n.list({ kind: 'bullet', marker: '*' }, fixture.n.paragraph('todo<a>')),
+      ),
+    )
+    fixture.view.focus()
+
+    await userEvent.keyboard('{Enter}next')
+    expect(docToMarkdown(fixture.doc)).toBe('* todo\n* next\n')
+  })
+
+  it('Enter keeps the marker gap on the next item', async () => {
+    using fixture = setupFixture()
+    fixture.set(
+      fixture.n.doc(
+        fixture.n.list({ kind: 'bullet', markerGap: 3 }, fixture.n.paragraph('todo<a>')),
+      ),
+    )
+    fixture.view.focus()
+
+    await userEvent.keyboard('{Enter}next')
+    expect(docToMarkdown(fixture.doc)).toBe('-   todo\n-   next\n')
+  })
+
   // The physical digit keys, so the shifted character ('&', '*', '(' on a US
   // layout) exercises prosemirror-keymap's keyCode fallback.
   const pressModShiftDigit = (digit: 7 | 8 | 9) =>

--- a/packages/core/src/extensions/list.ts
+++ b/packages/core/src/extensions/list.ts
@@ -3,6 +3,7 @@ import {
   defineKeymap,
   defineNodeAttr,
   definePlugin,
+  isNodeSelection,
   union,
   type Extension,
   type PlainExtension,
@@ -18,14 +19,18 @@ import {
   wrapInList,
   type ListAttrs,
 } from '@prosekit/extensions/list'
+import { chainCommands } from '@prosekit/pm/commands'
 import type { ProseMirrorNode } from '@prosekit/pm/model'
-import { Plugin } from '@prosekit/pm/state'
+import { Plugin, Selection } from '@prosekit/pm/state'
 import type { Command, EditorState } from '@prosekit/pm/state'
+import { canSplit } from '@prosekit/pm/transform'
 import {
   createListRenderingPlugin,
   createSafariInputMethodWorkaroundPlugin,
   createToggleCollapsedCommand,
   handleListMarkerMouseDown,
+  isListNode,
+  protectCollapsed,
   unwrapListSlice,
   wrappingListInputRule,
   type ListClickHandler,
@@ -295,8 +300,96 @@ function defineCollapseCommands() {
   })
 }
 
+/**
+ * The attrs Enter carries over to the list item it creates: `kind` plus the
+ * attrs declared `splittable` above. The per-item state (`checked`,
+ * `collapsed`, `order`) resets, matching prosemirror-flat-list.
+ */
+function deriveSplittableListAttrs(attrs: MeowdownListAttrs): MeowdownListAttrs {
+  return {
+    kind: attrs.kind,
+    marker: attrs.marker ?? null,
+    taskMarker: attrs.taskMarker ?? null,
+    markerGap: attrs.markerGap ?? 1,
+  }
+}
+
+/**
+ * Split the current list item, keeping the splittable attrs on the new item.
+ *
+ * prosemirror-flat-list's own Enter command derives the new item's attrs from
+ * `kind` alone, so pressing Enter at the end of a circle checkbox task
+ * (`+ [ ]`) would continue with a square one, and a `*` bullet with a `-`
+ * bullet. This mirrors its `splitListCommand`, covering only the paths that
+ * create a new item; the rest (an empty item dedents, a later block of an
+ * item splits in place) return false and fall through to the stock binding.
+ */
+const splitListKeepingMarker: Command = (state, dispatch) => {
+  if (isNodeSelection(state.selection)) {
+    return false
+  }
+  const { $from, $to } = state.selection
+  if (!$from.sameParent($to) || $from.depth < 2) {
+    return false
+  }
+  const listDepth = $from.depth - 1
+  const listNode = $from.node(listDepth)
+  if (!isListNode(listNode)) {
+    return false
+  }
+  const attrs = listNode.attrs as MeowdownListAttrs
+  const newAttrs = deriveSplittableListAttrs(attrs)
+  if (newAttrs.marker === null && newAttrs.taskMarker === null && newAttrs.markerGap === 1) {
+    // Nothing beyond `kind` to keep: the stock command's result is identical.
+    return false
+  }
+  if ($from.index(listDepth) !== 0 || $from.parent.content.size === 0) {
+    // Enter creates no new item here: an empty first block dedents and a
+    // later block splits in place. Nothing to keep either way.
+    return false
+  }
+
+  const tr = state.tr
+  tr.delete(tr.selection.from, tr.selection.to)
+  const $cut = tr.selection.$to
+  const atStart = $cut.parentOffset === 0
+  const atEnd = $cut.parentOffset === $cut.parent.content.size
+
+  if (atStart || (atEnd && attrs.collapsed)) {
+    // The new item is empty: above the caret (`atStart`) or, for a collapsed
+    // item, below its hidden children. The original item stays untouched.
+    const newItem = listNode.type.createAndFill(newAttrs)
+    if (!newItem) {
+      return false
+    }
+    if (dispatch) {
+      const pos = atStart ? tr.selection.$from.before(-1) : tr.selection.$from.after(-1)
+      tr.insert(pos, newItem)
+      if (!atStart) {
+        tr.setSelection(Selection.near(tr.doc.resolve(pos)))
+      }
+      dispatch(tr.scrollIntoView())
+    }
+    return true
+  }
+
+  const nextType = atEnd ? listNode.contentMatchAt(0).defaultType : undefined
+  const typesAfter = [
+    { type: listNode.type, attrs: newAttrs },
+    nextType ? { type: nextType } : null,
+  ]
+  if (!canSplit(tr.doc, tr.selection.from, 2, typesAfter)) {
+    return false
+  }
+  dispatch?.(tr.split(tr.selection.from, 2, typesAfter).scrollIntoView())
+  return true
+}
+
 function defineMeowdownListKeymap(): PlainExtension {
   return defineKeymap({
+    // Runs before prosemirror-flat-list's Enter binding (keymaps registered
+    // later win), which would drop the splittable attrs from the new item.
+    Enter: chainCommands(protectCollapsed, splitListKeepingMarker),
     'Mod-Enter': rotateSquareTask(),
     'Mod-Shift-Enter': rotateCircleTask(),
     'Mod-.': createToggleCollapsedCommand({ isToggleable: isCollapsibleBullet }),


### PR DESCRIPTION
## Problem

Pressing Enter at the end of a rounded (circle-checkbox) task created a square checkbox item instead of another rounded task.

Enter inside a list is handled by prosemirror-flat-list's split command, whose `deriveListAttributes` carries only `kind` over to the new item. A rounded task is a `task` item with `marker: '+'`, so the new item fell back to the default marker and rendered square. The `splittable: true` flags on the marker attrs never applied, because they only affect ProseKit's generic Enter handler, which flat-list's binding preempts inside lists. The same bug also reset `*` bullets to `-` and collapsed a wide marker gap to one space.

## Changes

- Bind `Enter` in the meowdown list keymap (which runs before flat-list's binding) to a new `splitListKeepingMarker` command. It mirrors flat-list's `splitListCommand` but carries the splittable attrs — `marker`, `taskMarker`, `markerGap` — over to the new item, while per-item state (`checked`, `collapsed`) still resets, so Enter after a checked rounded task yields an unchecked rounded task.
- Cases that create no new item (an empty item dedents, Enter in a later block of an item splits in place) return `false` and fall through to the stock binding unchanged, as does any item whose splittable attrs are all defaults.
- The command is chained behind `protectCollapsed`, matching the stock Enter chain's guard for collapsed content.

## Tests

Seven new cases in `list.test.ts`: Enter at the end, middle, and start of a rounded task, checked-state reset, `*` bullet continuation, marker-gap preservation, and a regression guard that square tasks still continue as square. Full suite passes (74 files, 1202 tests), plus `tsc -b`, eslint, oxfmt, and knip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)