### PR TITLE
test: destructure `n` from the fixture

### DIFF
--- a/packages/core/src/extensions/follow-link.test.ts
+++ b/packages/core/src/extensions/follow-link.test.ts
@@ -26,7 +26,8 @@ describe('defineFollowLinkHandler', () => {
   it('follows the wikilink under the caret and passes the KeyboardEvent', async () => {
     const onWikilinkClick = vi.fn<WikilinkClickHandler>()
     using fixture = setup({ onWikilinkClick })
-    fixture.set(fixture.n.doc(fixture.n.paragraph('see [[No<a>te]] here')))
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('see [[No<a>te]] here')))
     fixture.view.focus()
     await pressModEnter()
     expect(onWikilinkClick).toHaveBeenCalledWith(expect.objectContaining({ target: 'Note' }))
@@ -38,7 +39,8 @@ describe('defineFollowLinkHandler', () => {
   it('follows the tag under the caret', async () => {
     const onTagClick = vi.fn<TagClickHandler>()
     using fixture = setup({ onTagClick })
-    fixture.set(fixture.n.doc(fixture.n.paragraph('about #ca<a>ts today')))
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('about #ca<a>ts today')))
     fixture.view.focus()
     await pressModEnter()
     expect(onTagClick).toHaveBeenCalledWith(expect.objectContaining({ tag: 'cats' }))
@@ -47,7 +49,8 @@ describe('defineFollowLinkHandler', () => {
   it('follows the Markdown link under the caret', async () => {
     const onLinkClick = vi.fn<LinkClickHandler>()
     using fixture = setup({ onLinkClick })
-    fixture.set(fixture.n.doc(fixture.n.paragraph('see [do<a>cs](https://example.com) here')))
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('see [do<a>cs](https://example.com) here')))
     fixture.view.focus()
     await pressModEnter()
     expect(onLinkClick).toHaveBeenCalledWith(
@@ -62,7 +65,8 @@ describe('defineFollowLinkHandler', () => {
       extensionOptions: { resolveFileLink: ({ href }) => href.startsWith('assets/') },
     })
     fixture.editor.use(defineFollowLinkHandler({ onFileClick, onLinkClick }))
-    fixture.set(fixture.n.doc(fixture.n.paragraph('see [repo<a>rt.pdf](assets/report.pdf) here')))
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('see [repo<a>rt.pdf](assets/report.pdf) here')))
     fixture.view.focus()
     await pressModEnter()
     expect(onFileClick).toHaveBeenCalledWith(
@@ -101,7 +105,8 @@ describe('defineFollowLinkHandler', () => {
   it('Mod-Shift-Enter still rotates a circle task even on a link', async () => {
     const onWikilinkClick = vi.fn<WikilinkClickHandler>()
     using fixture = setup({ onWikilinkClick })
-    fixture.set(fixture.n.doc(fixture.n.paragraph('see [[No<a>te]] here')))
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('see [[No<a>te]] here')))
     fixture.view.focus()
     await pressModShiftEnter()
     expect(onWikilinkClick).not.toHaveBeenCalled()
@@ -111,7 +116,8 @@ describe('defineFollowLinkHandler', () => {
   it('falls through to the task rotation when no handler matches the unit', async () => {
     const onTagClick = vi.fn<TagClickHandler>()
     using fixture = setup({ onTagClick })
-    fixture.set(fixture.n.doc(fixture.n.paragraph('see [[No<a>te]] here')))
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('see [[No<a>te]] here')))
     fixture.view.focus()
     await pressModEnter()
     expect(onTagClick).not.toHaveBeenCalled()

--- a/packages/core/src/extensions/heading.test.ts
+++ b/packages/core/src/extensions/heading.test.ts
@@ -11,7 +11,8 @@ describe('keymap', () => {
   for (const level of LEVELS) {
     it(`Mod-${level} sets heading ${level}`, async () => {
       using fixture = setupFixture()
-      fixture.set(fixture.n.doc(fixture.n.paragraph('title<a>')))
+      const { n } = fixture
+      fixture.set(n.doc(n.paragraph('title<a>')))
       fixture.view.focus()
       await userEvent.keyboard(`{ControlOrMeta>}${level}{/ControlOrMeta}`)
       expect(docToMarkdown(fixture.doc)).toBe(`${'#'.repeat(level)} title\n`)
@@ -20,7 +21,8 @@ describe('keymap', () => {
 
   it('toggles a heading back off with a second Mod-1', async () => {
     using fixture = setupFixture()
-    fixture.set(fixture.n.doc(fixture.n.heading({ level: 1 }, 'title<a>')))
+    const { n } = fixture
+    fixture.set(n.doc(n.heading({ level: 1 }, 'title<a>')))
     fixture.view.focus()
     await userEvent.keyboard(`{ControlOrMeta>}1{/ControlOrMeta}`)
     expect(docToMarkdown(fixture.doc)).toBe('title\n')
@@ -28,7 +30,8 @@ describe('keymap', () => {
 
   it('does not bind Mod-Alt-1 (dropped in favor of Mod-1)', async () => {
     using fixture = setupFixture()
-    fixture.set(fixture.n.doc(fixture.n.paragraph('title<a>')))
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('title<a>')))
     fixture.view.focus()
     await userEvent.keyboard(`{ControlOrMeta>}{Alt>}1{/Alt}{/ControlOrMeta}`)
     expect(docToMarkdown(fixture.doc)).toBe('title\n')
@@ -36,7 +39,8 @@ describe('keymap', () => {
 
   it('turns a heading back into a paragraph on Backspace at its start', async () => {
     using fixture = setupFixture()
-    fixture.set(fixture.n.doc(fixture.n.heading({ level: 1 }, '<a>title')))
+    const { n } = fixture
+    fixture.set(n.doc(n.heading({ level: 1 }, '<a>title')))
     fixture.view.focus()
     await userEvent.keyboard('{Backspace}')
     expect(docToMarkdown(fixture.doc)).toBe('title\n')

--- a/packages/core/src/extensions/html-comment.test.ts
+++ b/packages/core/src/extensions/html-comment.test.ts
@@ -34,11 +34,12 @@ describe('html comment node', () => {
 describe('html comment in a mounted editor', () => {
   it('renders the comment invisibly without spilling into the visible text', () => {
     using fixture = setupFixture()
+    const { n } = fixture
     fixture.set(
-      fixture.n.doc(
-        fixture.n.paragraph('before'),
-        fixture.n.htmlComment({ content: '<!-- reflect-capture-page-text:start -->' }),
-        fixture.n.paragraph('after'),
+      n.doc(
+        n.paragraph('before'),
+        n.htmlComment({ content: '<!-- reflect-capture-page-text:start -->' }),
+        n.paragraph('after'),
       ),
     )
 
@@ -53,11 +54,12 @@ describe('html comment in a mounted editor', () => {
 
   it('keeps the comment in the document so it round-trips to markdown', () => {
     using fixture = setupFixture()
+    const { n } = fixture
     fixture.set(
-      fixture.n.doc(
-        fixture.n.htmlComment({ content: '<!-- start -->' }),
-        fixture.n.paragraph('body text'),
-        fixture.n.htmlComment({ content: '<!-- end -->' }),
+      n.doc(
+        n.htmlComment({ content: '<!-- start -->' }),
+        n.paragraph('body text'),
+        n.htmlComment({ content: '<!-- end -->' }),
       ),
     )
 
@@ -66,11 +68,12 @@ describe('html comment in a mounted editor', () => {
 
   it('steps the caret past the hidden comment without error', async () => {
     using fixture = setupFixture()
+    const { n } = fixture
     fixture.set(
-      fixture.n.doc(
-        fixture.n.paragraph('first<a>'),
-        fixture.n.htmlComment({ content: '<!-- between -->' }),
-        fixture.n.paragraph('second'),
+      n.doc(
+        n.paragraph('first<a>'),
+        n.htmlComment({ content: '<!-- between -->' }),
+        n.paragraph('second'),
       ),
     )
     fixture.view.focus()

--- a/packages/core/src/extensions/inline-toggle-commands.test.ts
+++ b/packages/core/src/extensions/inline-toggle-commands.test.ts
@@ -178,7 +178,8 @@ describe('keymap', () => {
     ['e', '`bold`'],
   ])('Mod-%s wraps the selection', async (key, expected) => {
     using fixture = setupFixture()
-    fixture.set(fixture.n.doc(fixture.n.paragraph('<a>bold<b>')))
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>bold<b>')))
     fixture.view.focus()
     await userEvent.keyboard(`{ControlOrMeta>}${key}{/ControlOrMeta}`)
     expect(docToMarkdown(fixture.doc)).toBe(`${expected}\n`)
@@ -186,7 +187,8 @@ describe('keymap', () => {
 
   it('Mod-Shift-x wraps the selection in ~~', async () => {
     using fixture = setupFixture()
-    fixture.set(fixture.n.doc(fixture.n.paragraph('<a>bold<b>')))
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>bold<b>')))
     fixture.view.focus()
     await userEvent.keyboard(`{ControlOrMeta>}{Shift>}x{/Shift}{/ControlOrMeta}`)
     expect(docToMarkdown(fixture.doc)).toBe('~~bold~~\n')
@@ -194,7 +196,8 @@ describe('keymap', () => {
 
   it('Mod-Shift-h wraps the selection in ==', async () => {
     using fixture = setupFixture()
-    fixture.set(fixture.n.doc(fixture.n.paragraph('<a>bold<b>')))
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>bold<b>')))
     fixture.view.focus()
     await userEvent.keyboard(`{ControlOrMeta>}{Shift>}h{/Shift}{/ControlOrMeta}`)
     expect(docToMarkdown(fixture.doc)).toBe('==bold==\n')
@@ -202,7 +205,8 @@ describe('keymap', () => {
 
   it('Mod-Shift-h unwraps an existing highlight', async () => {
     using fixture = setupFixture()
-    fixture.set(fixture.n.doc(fixture.n.paragraph('==<a>bold<b>==')))
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('==<a>bold<b>==')))
     fixture.view.focus()
     await userEvent.keyboard(`{ControlOrMeta>}{Shift>}h{/Shift}{/ControlOrMeta}`)
     expect(docToMarkdown(fixture.doc)).toBe('bold\n')

--- a/packages/core/src/extensions/list.test.ts
+++ b/packages/core/src/extensions/list.test.ts
@@ -7,7 +7,8 @@ import { setupFixture } from '../testing/index.ts'
 describe('input rule', () => {
   it('wraps a block into a circle checkbox task on `+ `', async () => {
     using fixture = setupFixture()
-    fixture.set(fixture.n.doc(fixture.n.paragraph('<a>todo')))
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>todo')))
     fixture.view.focus()
     await userEvent.keyboard('+ ')
     expect(docToMarkdown(fixture.doc)).toBe('+ [ ] todo\n')
@@ -15,7 +16,8 @@ describe('input rule', () => {
 
   it('wraps a block into a plain bullet on `- ` (not a checkbox task)', async () => {
     using fixture = setupFixture()
-    fixture.set(fixture.n.doc(fixture.n.paragraph('<a>todo')))
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>todo')))
     fixture.view.focus()
     await userEvent.keyboard('- ')
     expect(docToMarkdown(fixture.doc)).toBe('- todo\n')
@@ -25,39 +27,32 @@ describe('input rule', () => {
 describe('commands', () => {
   it('wrapInCircleTask makes a circle checkbox task', () => {
     using fixture = setupFixture()
-    fixture.set(fixture.n.doc(fixture.n.paragraph('todo<a>')))
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('todo<a>')))
     fixture.editor.commands.wrapInCircleTask()
     expect(docToMarkdown(fixture.doc)).toBe('+ [ ] todo\n')
   })
 
   it('wrapInSquareTask makes a square checkbox task', () => {
     using fixture = setupFixture()
-    fixture.set(fixture.n.doc(fixture.n.paragraph('todo<a>')))
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('todo<a>')))
     fixture.editor.commands.wrapInSquareTask()
     expect(docToMarkdown(fixture.doc)).toBe('- [ ] todo\n')
   })
 
   it('converts a square checkbox task to a circle checkbox task, keeping checked', () => {
     using fixture = setupFixture()
-    fixture.set(
-      fixture.n.doc(
-        fixture.n.list({ kind: 'task', checked: true }, fixture.n.paragraph('done<a>')),
-      ),
-    )
+    const { n } = fixture
+    fixture.set(n.doc(n.list({ kind: 'task', checked: true }, n.paragraph('done<a>'))))
     fixture.editor.commands.wrapInCircleTask()
     expect(docToMarkdown(fixture.doc)).toBe('+ [x] done\n')
   })
 
   it('converts a circle checkbox task back to a square checkbox task, keeping checked', () => {
     using fixture = setupFixture()
-    fixture.set(
-      fixture.n.doc(
-        fixture.n.list(
-          { kind: 'task', marker: '+', checked: true },
-          fixture.n.paragraph('done<a>'),
-        ),
-      ),
-    )
+    const { n } = fixture
+    fixture.set(n.doc(n.list({ kind: 'task', marker: '+', checked: true }, n.paragraph('done<a>'))))
     fixture.editor.commands.wrapInSquareTask()
     expect(docToMarkdown(fixture.doc)).toBe('- [x] done\n')
   })
@@ -70,7 +65,8 @@ describe('keymap', () => {
 
   it('Mod-Enter cycles a square checkbox task: unchecked -> checked -> bullet', async () => {
     using fixture = setupFixture()
-    fixture.set(fixture.n.doc(fixture.n.paragraph('todo<a>')))
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('todo<a>')))
     fixture.view.focus()
 
     await pressModEnter()
@@ -83,7 +79,8 @@ describe('keymap', () => {
 
   it('Mod-Shift-Enter cycles a circle checkbox task: unchecked -> checked -> bullet', async () => {
     using fixture = setupFixture()
-    fixture.set(fixture.n.doc(fixture.n.paragraph('todo<a>')))
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('todo<a>')))
     fixture.view.focus()
 
     await pressModShiftEnter()
@@ -96,13 +93,9 @@ describe('keymap', () => {
 
   it('Mod-Enter converts a circle checkbox task into a square checkbox task', async () => {
     using fixture = setupFixture()
+    const { n } = fixture
     fixture.set(
-      fixture.n.doc(
-        fixture.n.list(
-          { kind: 'task', marker: '+', checked: false },
-          fixture.n.paragraph('todo<a>'),
-        ),
-      ),
+      n.doc(n.list({ kind: 'task', marker: '+', checked: false }, n.paragraph('todo<a>'))),
     )
     fixture.view.focus()
 
@@ -112,11 +105,8 @@ describe('keymap', () => {
 
   it('Mod-Shift-Enter converts a square checkbox task into a circle checkbox task', async () => {
     using fixture = setupFixture()
-    fixture.set(
-      fixture.n.doc(
-        fixture.n.list({ kind: 'task', checked: false }, fixture.n.paragraph('todo<a>')),
-      ),
-    )
+    const { n } = fixture
+    fixture.set(n.doc(n.list({ kind: 'task', checked: false }, n.paragraph('todo<a>'))))
     fixture.view.focus()
 
     await pressModShiftEnter()
@@ -130,7 +120,8 @@ describe('keymap', () => {
 
   it('Mod-Shift-8 wraps a paragraph into a bullet and unwraps it again', async () => {
     using fixture = setupFixture()
-    fixture.set(fixture.n.doc(fixture.n.paragraph('todo<a>')))
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('todo<a>')))
     fixture.view.focus()
 
     await pressModShiftDigit(8)
@@ -141,7 +132,8 @@ describe('keymap', () => {
 
   it('Mod-Shift-7 wraps a paragraph into an ordered list and unwraps it again', async () => {
     using fixture = setupFixture()
-    fixture.set(fixture.n.doc(fixture.n.paragraph('todo<a>')))
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('todo<a>')))
     fixture.view.focus()
 
     await pressModShiftDigit(7)
@@ -152,7 +144,8 @@ describe('keymap', () => {
 
   it('Mod-Shift-9 wraps a paragraph into a square checkbox task and unwraps it again', async () => {
     using fixture = setupFixture()
-    fixture.set(fixture.n.doc(fixture.n.paragraph('todo<a>')))
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('todo<a>')))
     fixture.view.focus()
 
     await pressModShiftDigit(9)
@@ -163,7 +156,8 @@ describe('keymap', () => {
 
   it('Mod-Shift-7 converts a bullet into an ordered list in place', async () => {
     using fixture = setupFixture()
-    fixture.set(fixture.n.doc(fixture.n.list({ kind: 'bullet' }, fixture.n.paragraph('todo<a>'))))
+    const { n } = fixture
+    fixture.set(n.doc(n.list({ kind: 'bullet' }, n.paragraph('todo<a>'))))
     fixture.view.focus()
 
     await pressModShiftDigit(7)


### PR DESCRIPTION
Refactor the remaining tests that call `fixture.n.doc` and `fixture.n.list` etc directly to the `const { n } = fixture` pattern used by the rest of the test suite.