### PR TITLE
fix: keep code block fence style and length through a round-trip

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -33,7 +33,8 @@ const markdown = docToMarkdown(editor.state.doc)
   - Bullet lists (`- item`, `* item`, `+ item`)
   - Ordered lists (`1. item`, `2) item`, etc.)
   - Blockquotes (`> quote`)
-  - Fenced code blocks (` ```lang\ncode\n``` `)
+  - Fenced code blocks (` ```lang\ncode\n``` `), keeping tilde fences (`~~~`) and fence lengths through a round-trip
+  - Indented code blocks (four leading spaces)
   - Thematic breaks (`---`, `***`, `___`)
   - Bold (`**bold**`), italic (`*italic*`), and inline code
   - Links (`[text](url)`), images (`![alt](src)`), and autolinks (`<https://example.com>`)

--- a/packages/core/src/converters/check-roundtrip.test.ts
+++ b/packages/core/src/converters/check-roundtrip.test.ts
@@ -53,6 +53,11 @@ describe('checkRoundTrip', () => {
           line one
           line two
     `,
+
+    // an indented code block keeps its indented form
+    '    indented',
+    // a tilde fence keeps its fence character
+    '~~~\ntilde\n~~~',
   ])('reports exact for %j', (markdown) => {
     expect(checkRoundTrip(markdown)).toBe('exact')
   })
@@ -72,8 +77,7 @@ describe('checkRoundTrip', () => {
   })
 
   it.each([
-    '    indented', // an indented code block becomes a fence: the non-blank line count grows
-    '~~~\ntilde\n~~~', // a tilde fence becomes a backtick fence: same line count, content differs
+    '| a |\n| :---: |\n| b |', // table column alignment is dropped: same line count, content differs
   ])('reports lossy for %j', (markdown) => {
     expect(checkRoundTrip(markdown)).toBe('lossy')
   })

--- a/packages/core/src/converters/md-to-pm.test.ts
+++ b/packages/core/src/converters/md-to-pm.test.ts
@@ -298,7 +298,7 @@ describe('markdownToDoc', () => {
       content: [
         {
           type: 'codeBlock',
-          attrs: { language: 'js' },
+          attrs: { language: 'js', fenceStyle: null, fenceLength: null },
           content: [{ type: 'text', text: 'console.log(1)' }],
         },
       ],
@@ -335,7 +335,7 @@ describe('markdownToDoc', () => {
             { type: 'paragraph', content: [{ type: 'text', text: 'x' }] },
             {
               type: 'codeBlock',
-              attrs: { language: '' },
+              attrs: { language: '', fenceStyle: null, fenceLength: null },
               content: [{ type: 'text', text: 'line1\nline2\nline3' }],
             },
           ],
@@ -613,7 +613,7 @@ describe('markdownToDoc', () => {
       content: [
         {
           type: 'codeBlock',
-          attrs: { language: '' },
+          attrs: { language: '', fenceStyle: 'indented', fenceLength: null },
           content: [{ type: 'text', text: 'indented' }],
         },
       ],
@@ -625,7 +625,25 @@ describe('markdownToDoc', () => {
       type: 'doc',
       attrs: { frontmatter: null },
       content: [
-        { type: 'codeBlock', attrs: { language: '' }, content: [{ type: 'text', text: 'tilde' }] },
+        {
+          type: 'codeBlock',
+          attrs: { language: '', fenceStyle: 'tilde', fenceLength: null },
+          content: [{ type: 'text', text: 'tilde' }],
+        },
+      ],
+    })
+  })
+
+  it('keeps a four-character fence length', () => {
+    expect(markdownToDoc('````\ncode\n````').toJSON()).toEqual({
+      type: 'doc',
+      attrs: { frontmatter: null },
+      content: [
+        {
+          type: 'codeBlock',
+          attrs: { language: '', fenceStyle: null, fenceLength: 4 },
+          content: [{ type: 'text', text: 'code' }],
+        },
       ],
     })
   })

--- a/packages/core/src/converters/md-to-pm.ts
+++ b/packages/core/src/converters/md-to-pm.ts
@@ -1,6 +1,7 @@
 import type { TreeCursor } from '@lezer/common'
 import type { ProseMirrorNode } from '@prosekit/pm/model'
 
+import type { CodeBlockFenceStyle } from '../extensions/code-block.ts'
 import type { ListMarker, MeowdownListAttrs, TaskMarker } from '../extensions/list.ts'
 import { getNodeBuilders, type TypedNodeBuilders } from '../extensions/schema.ts'
 import { LEZER_NODE_IDS } from '../lezer/node-ids.ts'
@@ -16,6 +17,7 @@ import {
   CHAR_RIGHT_PARENTHESIS,
   CHAR_SPACE,
   CHAR_TAB,
+  CHAR_TILDE,
   CHAR_UPPERCASE_X,
   isSpaceChar,
 } from '../unicode.ts'
@@ -486,11 +488,25 @@ function convertCodeBlock(
   cursor: TreeCursor,
   text: string,
 ): ProseMirrorNode {
+  const indented = cursor.type.id === LEZER_NODE_IDS.CodeBlock
   let language = ''
   let code = ''
+  let fenceStyle: CodeBlockFenceStyle | null = indented ? 'indented' : null
+  let fenceLength: number | null = null
+  let sawOpeningMark = false
   if (cursor.firstChild()) {
     do {
       switch (cursor.type.id) {
+        case LEZER_NODE_IDS.CodeMark: {
+          // Only the opening fence sets the style and length; a longer
+          // closing fence is normalized back to the opening length.
+          if (sawOpeningMark) break
+          sawOpeningMark = true
+          if (text.charCodeAt(cursor.from) === CHAR_TILDE) fenceStyle = 'tilde'
+          const markLength = cursor.to - cursor.from
+          if (markLength > 3) fenceLength = markLength
+          break
+        }
         case LEZER_NODE_IDS.CodeInfo:
           language = text.slice(cursor.from, cursor.to)
           break
@@ -501,7 +517,7 @@ function convertCodeBlock(
     } while (cursor.nextSibling())
     cursor.parent()
   }
-  return nodes.codeBlock({ language }, code)
+  return nodes.codeBlock({ language, fenceStyle, fenceLength }, code)
 }
 
 function convertTable(nodes: TypedNodeBuilders, cursor: TreeCursor, text: string): ProseMirrorNode {

--- a/packages/core/src/converters/pm-to-md.test.ts
+++ b/packages/core/src/converters/pm-to-md.test.ts
@@ -193,6 +193,46 @@ describe('docToMarkdown', () => {
     expect(markdown).toBe('````\n```\nnested fence\n```\n````\n')
   })
 
+  it('emits a tilde fence from `fenceStyle`', () => {
+    const doc = n.doc(n.codeBlock({ language: '', fenceStyle: 'tilde' }, 'code'))
+    expect(docToMarkdown(doc)).toBe('~~~\ncode\n~~~\n')
+  })
+
+  it('grows a tilde fence around tilde content', () => {
+    const doc = n.doc(n.codeBlock({ language: '', fenceStyle: 'tilde' }, '~~~\nnested\n~~~'))
+    expect(docToMarkdown(doc)).toBe('~~~~\n~~~\nnested\n~~~\n~~~~\n')
+  })
+
+  it('keeps a recorded fence length', () => {
+    const doc = n.doc(n.codeBlock({ language: '', fenceLength: 5 }, 'code'))
+    expect(docToMarkdown(doc)).toBe('`````\ncode\n`````\n')
+  })
+
+  it('grows a fence beyond the recorded length when the content demands it', () => {
+    const doc = n.doc(n.codeBlock({ language: '', fenceLength: 4 }, '`````'))
+    expect(docToMarkdown(doc)).toBe('``````\n`````\n``````\n')
+  })
+
+  it('emits an indented code block from `fenceStyle`', () => {
+    const doc = n.doc(n.codeBlock({ language: '', fenceStyle: 'indented' }, 'code'))
+    expect(docToMarkdown(doc)).toBe('    code\n')
+  })
+
+  it('falls back to a fence for an indented block with a language', () => {
+    const doc = n.doc(n.codeBlock({ language: 'js', fenceStyle: 'indented' }, 'code'))
+    expect(docToMarkdown(doc)).toBe('```js\ncode\n```\n')
+  })
+
+  it('falls back to a fence for an empty indented block', () => {
+    const doc = n.doc(n.codeBlock({ language: '', fenceStyle: 'indented' }))
+    expect(docToMarkdown(doc)).toBe('```\n```\n')
+  })
+
+  it('falls back to a fence when an indented block starts with a blank line', () => {
+    const doc = n.doc(n.codeBlock({ language: '', fenceStyle: 'indented' }, '\ncode'))
+    expect(docToMarkdown(doc)).toBe('```\n\ncode\n```\n')
+  })
+
   it('keeps a horizontal rule', () => {
     const doc = n.doc(n.horizontalRule())
     const markdown = docToMarkdown(doc)

--- a/packages/core/src/converters/pm-to-md.ts
+++ b/packages/core/src/converters/pm-to-md.ts
@@ -1,13 +1,14 @@
-import type { CodeBlockAttrs } from '@prosekit/extensions/code-block'
 import type { ProseMirrorNode } from '@prosekit/pm/model'
 
+import type { MeowdownCodeBlockAttrs } from '../extensions/code-block.ts'
 import type { Frontmatter } from '../extensions/frontmatter.ts'
 import type { MeowdownHeadingAttrs } from '../extensions/heading.ts'
 import type { MeowdownHorizontalRuleAttrs } from '../extensions/horizontal-rule.ts'
 import type { MeowdownHTMLCommentAttrs } from '../extensions/html-comment.ts'
 import type { MeowdownListAttrs } from '../extensions/list.ts'
 import type { NodeName } from '../extensions/node-names.ts'
-import { longestBacktickRun } from '../utils/backticks.ts'
+import { CHAR_BACKTICK, CHAR_TILDE } from '../unicode.ts'
+import { longestCharRun } from '../utils/backticks.ts'
 
 /** Options for {@link docToMarkdown}. */
 export interface DocToMarkdownOptions {
@@ -362,11 +363,24 @@ function emitList(node: ProseMirrorNode, out: MdOut, tight: boolean): void {
 // ─────────────────────────────────────────────────────────────────────
 
 function emitCodeBlock(node: ProseMirrorNode, out: MdOut): void {
-  const attrs = node.attrs as CodeBlockAttrs
+  const attrs = node.attrs as MeowdownCodeBlockAttrs
   const language: string = attrs.language || ''
   const code = node.textContent
-  // min 2 keeps the fence width >= 3, CommonMark's minimum.
-  const fence = '`'.repeat(longestBacktickRun(code, 2) + 1)
+
+  if (attrs.fenceStyle === 'indented' && !language) {
+    const indentedCode = toIndentedCode(code)
+    if (indentedCode != null) {
+      out.write(indentedCode)
+      out.closeBlock()
+      return
+    }
+  }
+
+  const tilde = attrs.fenceStyle === 'tilde'
+  // min 2 keeps the fence width >= 3, CommonMark's minimum; a recorded
+  // opening-fence length only ever widens it.
+  const minWidth = longestCharRun(code, tilde ? CHAR_TILDE : CHAR_BACKTICK, 2) + 1
+  const fence = (tilde ? '~' : '`').repeat(Math.max(attrs.fenceLength ?? 0, minWidth))
 
   out.write(fence)
   if (language) out.write(language)
@@ -377,6 +391,23 @@ function emitCodeBlock(node: ProseMirrorNode, out: MdOut): void {
   }
   out.write(fence)
   out.closeBlock()
+}
+
+/**
+ * Indent `code` for an indented code block, or return `undefined` for shapes
+ * the indented form cannot express (empty content, or a leading or trailing
+ * blank line), which fall back to a fence. Blank interior lines stay empty so
+ * a round-trip adds no trailing whitespace; `MdOut.write` still prepends the
+ * enclosing `linePrefix` (blockquote or list continuation) per line.
+ */
+function toIndentedCode(code: string): string | undefined {
+  if (code === '') return undefined
+  const lines = code.split('\n')
+  if (lines[0] === '' || lines[lines.length - 1] === '') return undefined
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i] !== '') lines[i] = `    ${lines[i]}`
+  }
+  return lines.join('\n')
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -591,12 +591,57 @@ describe('code blocks', () => {
     expect(roundtrip('```\n```')).toBe('```\n```\n')
   })
 
-  it.fails('keeps a tilde fence', () => {
+  it('keeps a tilde fence', () => {
     expect(roundtrip('~~~\ntilde\n~~~')).toBe('~~~\ntilde\n~~~\n')
   })
 
-  it.fails('keeps an indented code block', () => {
+  it('keeps a tilde fence with a language', () => {
+    expect(roundtrip('~~~js\ncode\n~~~')).toBe('~~~js\ncode\n~~~\n')
+  })
+
+  it('keeps a five-character tilde fence', () => {
+    expect(roundtrip('~~~~~\ncode\n~~~~~')).toBe('~~~~~\ncode\n~~~~~\n')
+  })
+
+  it('keeps a four-character backtick fence', () => {
+    expect(roundtrip('````\ncode\n````')).toBe('````\ncode\n````\n')
+  })
+
+  it('keeps a four-character fence around a nested fence', () => {
+    const md = '````\n```\nnested\n```\n````'
+    expect(roundtrip(md)).toBe(md + '\n')
+  })
+
+  it('normalizes a longer closing fence to the opening length', () => {
+    expect(roundtrip('~~~\ncode\n~~~~~')).toBe('~~~\ncode\n~~~\n')
+  })
+
+  it('keeps an indented code block', () => {
     expect(roundtrip('    indented')).toBe('    indented\n')
+  })
+
+  it('keeps a multi-line indented code block', () => {
+    expect(roundtrip('    line1\n    line2')).toBe('    line1\n    line2\n')
+  })
+
+  it('keeps a blank line inside an indented code block', () => {
+    expect(roundtrip('    line1\n\n    line2')).toBe('    line1\n\n    line2\n')
+  })
+
+  it('keeps extra indentation inside an indented code block', () => {
+    expect(roundtrip('    code\n      more')).toBe('    code\n      more\n')
+  })
+
+  it('keeps an indented code block inside a blockquote', () => {
+    expect(roundtrip('>     code')).toBe('>     code\n')
+  })
+
+  it('keeps an indented code block starting a list item', () => {
+    expect(roundtrip('-     code')).toBe('-     code\n')
+  })
+
+  it('keeps an indented code block after a paragraph', () => {
+    expect(roundtrip('text\n\n    code')).toBe('text\n\n    code\n')
   })
 })
 

--- a/packages/core/src/converters/sample-content.ts
+++ b/packages/core/src/converters/sample-content.ts
@@ -163,7 +163,7 @@ export const sampleContent: NodeJSON = {
     },
     {
       type: 'codeBlock',
-      attrs: { language: 'ts' },
+      attrs: { language: 'ts', fenceStyle: null, fenceLength: null },
       content: [
         {
           type: 'text',

--- a/packages/core/src/extensions/code-block.test.ts
+++ b/packages/core/src/extensions/code-block.test.ts
@@ -1,0 +1,23 @@
+import { DOMParser, DOMSerializer } from '@prosekit/pm/model'
+import { describe, expect, it } from 'vitest'
+
+import { setupFixture } from '../testing/index.ts'
+
+describe('codeBlock attrs', () => {
+  it('keeps `fenceStyle` and `fenceLength` through a DOM round-trip', () => {
+    using fixture = setupFixture()
+    const { schema, n } = fixture
+    const doc = n.doc(n.codeBlock({ language: 'js', fenceStyle: 'tilde', fenceLength: 4 }, 'code'))
+
+    const dom = DOMSerializer.fromSchema(schema).serializeFragment(doc.content)
+    const container = document.createElement('div')
+    container.appendChild(dom)
+
+    const parsed = DOMParser.fromSchema(schema).parse(container)
+    expect(parsed.child(0).attrs).toMatchObject({
+      language: 'js',
+      fenceStyle: 'tilde',
+      fenceLength: 4,
+    })
+  })
+})

--- a/packages/core/src/extensions/code-block.test.ts
+++ b/packages/core/src/extensions/code-block.test.ts
@@ -1,5 +1,6 @@
 import { DOMParser, DOMSerializer } from '@prosekit/pm/model'
 import { describe, expect, it } from 'vitest'
+import { userEvent } from 'vitest/browser'
 
 import { setupFixture } from '../testing/index.ts'
 
@@ -19,5 +20,39 @@ describe('codeBlock attrs', () => {
       fenceStyle: 'tilde',
       fenceLength: 4,
     })
+  })
+})
+
+describe('tilde fence rules', () => {
+  it('creates a tilde code block from `~~~` and Enter', async () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>')))
+    fixture.view.focus()
+    await userEvent.keyboard('~~~')
+    await userEvent.keyboard('{Enter}')
+    const expected = n.doc(n.codeBlock({ language: '', fenceStyle: 'tilde' }))
+    expect(fixture.doc.eq(expected)).toBe(true)
+  })
+
+  it('creates a tilde code block with a language from `~~~js` and Enter', async () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>')))
+    fixture.view.focus()
+    await userEvent.keyboard('~~~js')
+    await userEvent.keyboard('{Enter}')
+    const expected = n.doc(n.codeBlock({ language: 'js', fenceStyle: 'tilde' }))
+    expect(fixture.doc.eq(expected)).toBe(true)
+  })
+
+  it('creates a tilde code block from `~~~` and Space', async () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>')))
+    fixture.view.focus()
+    await userEvent.keyboard('~~~ ')
+    const expected = n.doc(n.codeBlock({ language: '', fenceStyle: 'tilde' }))
+    expect(fixture.doc.eq(expected)).toBe(true)
   })
 })

--- a/packages/core/src/extensions/code-block.ts
+++ b/packages/core/src/extensions/code-block.ts
@@ -1,8 +1,10 @@
-import { defineNodeAttr, union, type Extension } from '@prosekit/core'
+import { defineNodeAttr, union, type Extension, type PlainExtension } from '@prosekit/core'
 import {
   defineCodeBlock as defineBaseCodeBlock,
   type CodeBlockAttrs,
 } from '@prosekit/extensions/code-block'
+import { defineTextBlockEnterRule } from '@prosekit/extensions/enter-rule'
+import { defineTextBlockInputRule } from '@prosekit/extensions/input-rule'
 
 import type { NodeName } from './node-names.ts'
 
@@ -64,6 +66,32 @@ function defineFenceLengthAttr(): FenceLengthExtension {
   })
 }
 
+function getTildeFenceAttrs(match: RegExpMatchArray): MeowdownCodeBlockAttrs {
+  return { language: match[1] || '', fenceStyle: 'tilde' }
+}
+
+function defineTildeFenceInputRule(): PlainExtension {
+  return defineTextBlockInputRule({
+    regex: /^~~~(\S*)\s$/,
+    type: 'codeBlock' satisfies NodeName,
+    attrs: getTildeFenceAttrs,
+  })
+}
+
+function defineTildeFenceEnterRule(): PlainExtension {
+  return defineTextBlockEnterRule({
+    regex: /^~~~(\S*)$/,
+    type: 'codeBlock' satisfies NodeName,
+    attrs: getTildeFenceAttrs,
+  })
+}
+
 export function defineCodeBlock() {
-  return union(defineBaseCodeBlock(), defineFenceStyleAttr(), defineFenceLengthAttr())
+  return union(
+    defineBaseCodeBlock(),
+    defineFenceStyleAttr(),
+    defineFenceLengthAttr(),
+    defineTildeFenceInputRule(),
+    defineTildeFenceEnterRule(),
+  )
 }

--- a/packages/core/src/extensions/code-block.ts
+++ b/packages/core/src/extensions/code-block.ts
@@ -1,0 +1,69 @@
+import { defineNodeAttr, union, type Extension } from '@prosekit/core'
+import {
+  defineCodeBlock as defineBaseCodeBlock,
+  type CodeBlockAttrs,
+} from '@prosekit/extensions/code-block'
+
+import type { NodeName } from './node-names.ts'
+
+export type CodeBlockFenceStyle = 'tilde' | 'indented'
+
+export interface MeowdownCodeBlockAttrs extends CodeBlockAttrs {
+  /**
+   * How the code block was written in the source: a tilde fence (`~~~`) or an
+   * indented block (four leading spaces). `null` (the default) is a backtick
+   * fence, so a block created in the editor serializes to the canonical form.
+   */
+  fenceStyle?: CodeBlockFenceStyle | null
+
+  /**
+   * The number of characters in the opening fence, kept only when it exceeds
+   * CommonMark's three-character minimum. `null` (the default) lets the
+   * serializer pick the shortest fence the content allows.
+   */
+  fenceLength?: number | null
+}
+
+type FenceStyleExtension = Extension<{
+  Nodes: { codeBlock: { fenceStyle?: CodeBlockFenceStyle | null } }
+}>
+
+function defineFenceStyleAttr(): FenceStyleExtension {
+  return defineNodeAttr<'codeBlock', 'fenceStyle', CodeBlockFenceStyle | null>({
+    type: 'codeBlock' satisfies NodeName,
+    attr: 'fenceStyle',
+    default: null,
+    // Only a parsed tilde fence or indented block carries a style; it must
+    // survive an editor DOM re-parse.
+    toDOM: (value) => (value != null ? ['data-fence-style', value] : null),
+    parseDOM: (node) => {
+      const raw = node.getAttribute('data-fence-style')
+      return raw === 'tilde' || raw === 'indented' ? raw : null
+    },
+  })
+}
+
+type FenceLengthExtension = Extension<{
+  Nodes: { codeBlock: { fenceLength?: number | null } }
+}>
+
+function defineFenceLengthAttr(): FenceLengthExtension {
+  return defineNodeAttr<'codeBlock', 'fenceLength', number | null>({
+    type: 'codeBlock' satisfies NodeName,
+    attr: 'fenceLength',
+    default: null,
+    // Only a parsed fence longer than three characters carries a length; it
+    // must survive an editor DOM re-parse.
+    toDOM: (value) => (value != null ? ['data-fence-length', String(value)] : null),
+    parseDOM: (node) => {
+      const raw = node.getAttribute('data-fence-length')
+      if (raw == null) return null
+      const length = Number.parseInt(raw, 10)
+      return Number.isSafeInteger(length) && length > 3 ? length : null
+    },
+  })
+}
+
+export function defineCodeBlock() {
+  return union(defineBaseCodeBlock(), defineFenceStyleAttr(), defineFenceLengthAttr())
+}

--- a/packages/core/src/extensions/extension.test.ts
+++ b/packages/core/src/extensions/extension.test.ts
@@ -139,6 +139,8 @@ describe('defineEditorExtension', () => {
           },
           {
             "attrs": {
+              "fenceLength": null,
+              "fenceStyle": null,
               "language": "ts",
             },
             "content": [

--- a/packages/core/src/extensions/extension.ts
+++ b/packages/core/src/extensions/extension.ts
@@ -6,7 +6,6 @@ import {
   type Editor,
 } from '@prosekit/core'
 import { defineBlockquote } from '@prosekit/extensions/blockquote'
-import { defineCodeBlock } from '@prosekit/extensions/code-block'
 import { defineDoc } from '@prosekit/extensions/doc'
 import { defineGapCursor } from '@prosekit/extensions/gap-cursor'
 import { defineModClickPrevention } from '@prosekit/extensions/mod-click-prevention'
@@ -15,6 +14,7 @@ import { defineVirtualSelection } from '@prosekit/extensions/virtual-selection'
 
 import { defineAtomMarkNavigation } from './atom-mark-navigation.ts'
 import { defineCodeBlockSyntaxHighlight } from './code-block-highlight.ts'
+import { defineCodeBlock } from './code-block.ts'
 import { defineEditorCommands } from './commands.ts'
 import { defineEscapeCollapse } from './escape-collapse.ts'
 import { defineDocFrontmatterAttr } from './frontmatter.ts'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ export {
   type CodeToken,
 } from './extensions/code-block-highlight.ts'
 export { codeBlockLanguages } from './extensions/code-block-languages.ts'
+export type { CodeBlockFenceStyle, MeowdownCodeBlockAttrs } from './extensions/code-block.ts'
 export { defineEmbedPaste } from './extensions/embed-paste.ts'
 export { listenForTweetHeight, matchEmbed, type EmbedDescriptor } from './extensions/embed/index.ts'
 export {

--- a/packages/core/src/unicode.ts
+++ b/packages/core/src/unicode.ts
@@ -39,6 +39,7 @@ export const CHAR_PERCENT = 37 /* % */
 export const CHAR_SEMICOLON = 59 /* ; */
 export const CHAR_CIRCUMFLEX_ACCENT = 94 /* ^ */
 export const CHAR_BACKTICK = 96 /* ` */
+export const CHAR_TILDE = 126 /* ~ */
 export const CHAR_AT = 64 /* @ */
 export const CHAR_AMPERSAND = 38 /* & */
 export const CHAR_EQUAL = 61 /* = */

--- a/packages/core/src/utils/backticks.ts
+++ b/packages/core/src/utils/backticks.ts
@@ -1,11 +1,11 @@
 import { CHAR_BACKTICK } from '../unicode.ts'
 
-/** Length of the longest run of backticks in `text`, at least `min`. */
-export function longestBacktickRun(text: string, min = 0): number {
+/** Length of the longest run of `charCode` in `text`, at least `min`. */
+export function longestCharRun(text: string, charCode: number, min = 0): number {
   let longest = min
   let run = 0
   for (let i = 0; i < text.length; i++) {
-    if (text.charCodeAt(i) === CHAR_BACKTICK) {
+    if (text.charCodeAt(i) === charCode) {
       run++
       if (run > longest) longest = run
     } else {
@@ -13,4 +13,9 @@ export function longestBacktickRun(text: string, min = 0): number {
     }
   }
   return longest
+}
+
+/** Length of the longest run of backticks in `text`, at least `min`. */
+export function longestBacktickRun(text: string, min = 0): number {
+  return longestCharRun(text, CHAR_BACKTICK, min)
 }


### PR DESCRIPTION
Adds `fenceStyle` and `fenceLength` attrs to `codeBlock` so tilde fences, indented code blocks, and longer fences survive a markdown round-trip instead of being normalized to a three-backtick fence. Also adds a `~~~` input rule and enter rule so a tilde fence typed in the editor creates a tilde code block.