### PR TITLE
feat: support GFM table column alignment

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -40,7 +40,7 @@ const markdown = docToMarkdown(editor.state.doc)
   - Links (`[text](url)`), images (`![alt](src)`), and autolinks (`<https://example.com>`)
   - Hard line breaks
 - GitHub Flavored Markdown (GFM)
-  - Tables
+  - Tables, including column alignment (`:--`, `:-:`, `--:`)
   - Strikethrough (`~~text~~`)
   - Task lists (`- [ ]`, `- [x]`)
   - Autolinks for `www.`, scheme, and email URLs
@@ -117,6 +117,8 @@ Pasted or dropped files persist through [`defineFilePaste`](https://npmx.dev/pac
 A host can render chosen file links as inline **file pills**: pass `resolveFileLink` to [`defineEditorExtension`](https://npmx.dev/package-docs/@meowdown%2Fcore#function-defineEditorExtension) (or `@meowdown/react`'s `resolveFileLink` prop) to claim links by their href (e.g. everything under `assets/`), and add [`defineFileView`](https://npmx.dev/package-docs/@meowdown%2Fcore#function-defineFileView) to render each claimed link as a pill: a file-kind icon, the name, and the size supplied (possibly async) by `resolveFileInfo`. The markdown text is untouched, and a claimed link behaves like an image: one caret unit with an editable source, clicks (and `Mod-Enter` with the caret on it) reported through [`defineFileClickHandler`](https://npmx.dev/package-docs/@meowdown%2Fcore#function-defineFileClickHandler) (`@meowdown/react`'s `onFileClick`) rather than the link click handler, and no link hover or edit menu.
 
 Rendered images are resizable: drag the corner handle and the chosen size is written back into the source as a trailing comment, `![alt](src)<!-- {"width":320,"height":240} -->`, which round-trips as plain Markdown. A comment immediately after an image is folded into its mark and drives the image's `width` and `height` attributes, so the box keeps its dimensions before the image loads; any other comment stays literal text.
+
+GFM table column alignment (`| :-: |` in the delimiter row) is kept as an `align` attribute on every cell and rendered through a `data-align` DOM attribute (`text-align` in the bundled stylesheet). Alignment is a column property: the header row's cells carry the source of truth, data cells (including rows inserted later) follow it automatically. Change it with the `setTableColumnAlign` command (`editor.commands.setTableColumnAlign('center')`, `null` resets to `---`), and read the alignment of the selection's column with [`getTableColumnAlign`](https://npmx.dev/package-docs/@meowdown%2Fcore#function-getTableColumnAlign).
 
 Pasting a lone tweet or YouTube link can auto-embed it: [`defineEmbedPaste`](https://npmx.dev/package-docs/@meowdown%2Fcore#function-defineEmbedPaste) (`@meowdown/react`'s `embedPaste` prop, on by default).
 

--- a/packages/core/src/converters/md-to-pm.test.ts
+++ b/packages/core/src/converters/md-to-pm.test.ts
@@ -1,8 +1,24 @@
 import dedent from 'dedent'
 import { describe, expect, it } from 'vitest'
 
+import type { MeowdownTableCellAttrs, TableColumnAlign } from '../extensions/table-column-align.ts'
+
 import { dedentContinuation, markdownToDoc, measureContentColumn, sliceColumn } from './md-to-pm.ts'
 import { sampleContent, sampleContentMarkdown } from './sample-content.ts'
+
+function tableAligns(markdown: string): Array<Array<TableColumnAlign | null | undefined>> {
+  const table = markdownToDoc(markdown).child(0)
+  const rows: Array<Array<TableColumnAlign | null | undefined>> = []
+  for (let r = 0; r < table.childCount; r++) {
+    const row = table.child(r)
+    const cells: Array<TableColumnAlign | null | undefined> = []
+    for (let c = 0; c < row.childCount; c++) {
+      cells.push((row.child(c).attrs as MeowdownTableCellAttrs).align)
+    }
+    rows.push(cells)
+  }
+  return rows
+}
 
 function tableShape(markdown: string): Array<Array<{ type: string; text: string }>> {
   const table = markdownToDoc(markdown).child(0)
@@ -385,7 +401,7 @@ describe('markdownToDoc', () => {
               content: [
                 {
                   type: 'tableHeaderCell',
-                  attrs: { colspan: 1, rowspan: 1, colwidth: null },
+                  attrs: { colspan: 1, rowspan: 1, colwidth: null, align: null },
                   content: [
                     {
                       type: 'paragraph',
@@ -395,7 +411,7 @@ describe('markdownToDoc', () => {
                 },
                 {
                   type: 'tableHeaderCell',
-                  attrs: { colspan: 1, rowspan: 1, colwidth: null },
+                  attrs: { colspan: 1, rowspan: 1, colwidth: null, align: null },
                   content: [
                     {
                       type: 'paragraph',
@@ -410,7 +426,7 @@ describe('markdownToDoc', () => {
               content: [
                 {
                   type: 'tableCell',
-                  attrs: { colspan: 1, rowspan: 1, colwidth: null },
+                  attrs: { colspan: 1, rowspan: 1, colwidth: null, align: null },
                   content: [
                     {
                       type: 'paragraph',
@@ -420,7 +436,7 @@ describe('markdownToDoc', () => {
                 },
                 {
                   type: 'tableCell',
-                  attrs: { colspan: 1, rowspan: 1, colwidth: null },
+                  attrs: { colspan: 1, rowspan: 1, colwidth: null, align: null },
                   content: [
                     {
                       type: 'paragraph',
@@ -434,6 +450,30 @@ describe('markdownToDoc', () => {
         },
       ],
     })
+  })
+
+  it('parses column alignment from the delimiter row', () => {
+    const md = dedent`
+      | a | b | c | d |
+      | :-- | :-: | --: | --- |
+      | 1 |  | 3 | 4 |
+    `
+    expect(tableAligns(md)).toEqual([
+      ['left', 'center', 'right', null],
+      ['left', 'center', 'right', null],
+    ])
+  })
+
+  it('parses alignment regardless of delimiter width', () => {
+    const md = dedent`
+      | a | b |
+      | :----: | -----: |
+      | 1 | 2 |
+    `
+    expect(tableAligns(md)).toEqual([
+      ['center', 'right'],
+      ['center', 'right'],
+    ])
   })
 
   it('keeps empty table cells', () => {

--- a/packages/core/src/converters/md-to-pm.ts
+++ b/packages/core/src/converters/md-to-pm.ts
@@ -4,6 +4,7 @@ import type { ProseMirrorNode } from '@prosekit/pm/model'
 import type { CodeBlockFenceStyle } from '../extensions/code-block.ts'
 import type { ListMarker, MeowdownListAttrs, TaskMarker } from '../extensions/list.ts'
 import { getNodeBuilders, type TypedNodeBuilders } from '../extensions/schema.ts'
+import type { TableColumnAlign } from '../extensions/table-column-align.ts'
 import { LEZER_NODE_IDS } from '../lezer/node-ids.ts'
 import { gfmBlockOnlyParser } from '../lezer/parser.ts'
 import {
@@ -523,13 +524,14 @@ function convertCodeBlock(
 function convertTable(nodes: TypedNodeBuilders, cursor: TreeCursor, text: string): ProseMirrorNode {
   // The delimiter row (a `TableDelimiter` that is a direct child of `Table`)
   // is the only source that always encodes every column, so it drives the
-  // column count. `@lezer/markdown` emits no `TableCell` for an empty cell, so
-  // counting per-row cells would drop empty columns and misalign the rest.
-  let columnCount = 0
+  // column count and the column alignment. `@lezer/markdown` emits no
+  // `TableCell` for an empty cell, so counting per-row cells would drop empty
+  // columns and misalign the rest.
+  let aligns: Array<TableColumnAlign | null> = []
   if (cursor.firstChild()) {
     do {
       if (cursor.type.id === LEZER_NODE_IDS.TableDelimiter) {
-        columnCount = countDelimiterColumns(text.slice(cursor.from, cursor.to))
+        aligns = parseDelimiterAligns(text.slice(cursor.from, cursor.to))
       }
     } while (cursor.nextSibling())
     cursor.parent()
@@ -540,9 +542,9 @@ function convertTable(nodes: TypedNodeBuilders, cursor: TreeCursor, text: string
     do {
       const id = cursor.type.id
       if (id === LEZER_NODE_IDS.TableHeader) {
-        rows.push(convertTableRow(nodes, cursor, text, true, columnCount))
+        rows.push(convertTableRow(nodes, cursor, text, true, aligns))
       } else if (id === LEZER_NODE_IDS.TableRow) {
-        rows.push(convertTableRow(nodes, cursor, text, false, columnCount))
+        rows.push(convertTableRow(nodes, cursor, text, false, aligns))
       }
     } while (cursor.nextSibling())
     cursor.parent()
@@ -550,8 +552,19 @@ function convertTable(nodes: TypedNodeBuilders, cursor: TreeCursor, text: string
   return nodes.table(rows)
 }
 
-function countDelimiterColumns(separator: string): number {
-  return separator.split('|').filter((segment) => segment.trim() !== '').length
+function parseDelimiterAligns(separator: string): Array<TableColumnAlign | null> {
+  return separator
+    .split('|')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment !== '')
+    .map((segment) => {
+      const left = segment.startsWith(':')
+      const right = segment.endsWith(':')
+      if (left && right) return 'center'
+      if (left) return 'left'
+      if (right) return 'right'
+      return null
+    })
 }
 
 function convertTableRow(
@@ -559,8 +572,9 @@ function convertTableRow(
   cursor: TreeCursor,
   text: string,
   isHeader: boolean,
-  columnCount: number,
+  aligns: ReadonlyArray<TableColumnAlign | null>,
 ): ProseMirrorNode {
+  const columnCount = aligns.length
   const cellTexts: string[] = Array<string>(columnCount).fill('')
   if (cursor.firstChild()) {
     const hasLeadingPipe = cursor.type.id === LEZER_NODE_IDS.TableDelimiter
@@ -582,9 +596,10 @@ function convertTableRow(
     cursor.parent()
   }
 
-  const cells = cellTexts.map((cellText) => {
+  const cells = cellTexts.map((cellText, column) => {
     const paragraph = nodes.paragraph(cellText)
-    return isHeader ? nodes.tableHeaderCell(paragraph) : nodes.tableCell(paragraph)
+    const attrs = { align: aligns[column] }
+    return isHeader ? nodes.tableHeaderCell(attrs, paragraph) : nodes.tableCell(attrs, paragraph)
   })
   return nodes.tableRow(cells)
 }

--- a/packages/core/src/converters/pm-to-md.test.ts
+++ b/packages/core/src/converters/pm-to-md.test.ts
@@ -250,6 +250,38 @@ describe('docToMarkdown', () => {
     expect(markdown).toBe('| A | B |\n| --- | --- |\n| 1 | 2 |\n')
   })
 
+  it('emits column alignment from the header row', () => {
+    const doc = n.doc(
+      n.table(
+        n.tableRow(
+          n.tableHeaderCell({ align: 'left' }, n.paragraph('A')),
+          n.tableHeaderCell({ align: 'center' }, n.paragraph('B')),
+          n.tableHeaderCell({ align: 'right' }, n.paragraph('C')),
+        ),
+        n.tableRow(
+          n.tableCell(n.paragraph('1')),
+          n.tableCell(n.paragraph('2')),
+          n.tableCell(n.paragraph('3')),
+        ),
+      ),
+    )
+    const markdown = docToMarkdown(doc)
+    expect(markdown).toBe('| A | B | C |\n| :-- | :-: | --: |\n| 1 | 2 | 3 |\n')
+  })
+
+  it('emits column alignment from the first row of a headerless table', () => {
+    const doc = n.doc(
+      n.table(
+        n.tableRow(
+          n.tableCell({ align: 'center' }, n.paragraph('1')),
+          n.tableCell(n.paragraph('2')),
+        ),
+      ),
+    )
+    const markdown = docToMarkdown(doc)
+    expect(markdown).toBe('|  |  |\n| :-: | --- |\n| 1 | 2 |\n')
+  })
+
   it('keeps a nested bullet', () => {
     const doc = n.doc(
       n.list({ kind: 'bullet' }, n.paragraph('a'), n.list({ kind: 'bullet' }, n.paragraph('b'))),

--- a/packages/core/src/converters/pm-to-md.ts
+++ b/packages/core/src/converters/pm-to-md.ts
@@ -7,6 +7,7 @@ import type { MeowdownHorizontalRuleAttrs } from '../extensions/horizontal-rule.
 import type { MeowdownHTMLCommentAttrs } from '../extensions/html-comment.ts'
 import type { MeowdownListAttrs } from '../extensions/list.ts'
 import type { NodeName } from '../extensions/node-names.ts'
+import type { MeowdownTableCellAttrs, TableColumnAlign } from '../extensions/table-column-align.ts'
 import { CHAR_BACKTICK, CHAR_TILDE } from '../unicode.ts'
 import { longestCharRun } from '../utils/backticks.ts'
 
@@ -437,8 +438,17 @@ function emitTable(node: ProseMirrorNode, out: MdOut): void {
   if (colCount === 0) return
 
   // GFM requires a header row + separator. Synthesize an empty header if
-  // there isn't one in the source (rare but possible).
-  const separator = '| ' + new Array(colCount).fill('---').join(' | ') + ' |'
+  // there isn't one in the source (rare but possible). The alignment row
+  // (header row, or the first row of a headerless table) drives the
+  // delimiter row's `:` markers.
+  const alignmentRow = node.child(headerIdx >= 0 ? headerIdx : 0)
+  const delimiters: string[] = []
+  for (let c = 0; c < colCount; c++) {
+    const cell = c < alignmentRow.childCount ? alignmentRow.child(c) : undefined
+    const align = cell ? (cell.attrs as MeowdownTableCellAttrs).align : undefined
+    delimiters.push(formatDelimiter(align))
+  }
+  const separator = '| ' + delimiters.join(' | ') + ' |'
   const headRow = headerIdx >= 0 ? rows[headerIdx] : new Array(colCount).fill('')
 
   out.write(formatTableRow(headRow, colCount))
@@ -450,6 +460,19 @@ function emitTable(node: ProseMirrorNode, out: MdOut): void {
     out.write(formatTableRow(rows[r], colCount))
   }
   out.closeBlock()
+}
+
+function formatDelimiter(align: TableColumnAlign | null | undefined): string {
+  switch (align) {
+    case 'left':
+      return ':--'
+    case 'center':
+      return ':-:'
+    case 'right':
+      return '--:'
+    default:
+      return '---'
+  }
 }
 
 function formatTableRow(cells: ReadonlyArray<string>, colCount: number): string {

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -697,9 +697,21 @@ describe('tables', () => {
     )
   })
 
-  it.fails('keeps column alignment', () => {
+  it('keeps column alignment', () => {
     expect(roundtrip('| a | b |\n| :-- | --: |\n| 1 | 2 |')).toBe(
       '| a | b |\n| :-- | --: |\n| 1 | 2 |\n',
+    )
+  })
+
+  it('keeps center alignment', () => {
+    expect(roundtrip('| a | b | c |\n| :-- | :-: | --: |\n| 1 | 2 | 3 |')).toBe(
+      '| a | b | c |\n| :-- | :-: | --: |\n| 1 | 2 | 3 |\n',
+    )
+  })
+
+  it('normalizes delimiter width to three characters', () => {
+    expect(roundtrip('| a | b |\n| :---: | ----: |\n| 1 | 2 |')).toBe(
+      '| a | b |\n| :-: | --: |\n| 1 | 2 |\n',
     )
   })
 

--- a/packages/core/src/converters/sample-content.ts
+++ b/packages/core/src/converters/sample-content.ts
@@ -184,7 +184,7 @@ export const sampleContent: NodeJSON = {
           content: [
             {
               type: 'tableHeaderCell',
-              attrs: { colspan: 1, rowspan: 1, colwidth: null },
+              attrs: { colspan: 1, rowspan: 1, colwidth: null, align: null },
               content: [
                 {
                   type: 'paragraph',
@@ -194,7 +194,7 @@ export const sampleContent: NodeJSON = {
             },
             {
               type: 'tableHeaderCell',
-              attrs: { colspan: 1, rowspan: 1, colwidth: null },
+              attrs: { colspan: 1, rowspan: 1, colwidth: null, align: null },
               content: [
                 {
                   type: 'paragraph',
@@ -209,7 +209,7 @@ export const sampleContent: NodeJSON = {
           content: [
             {
               type: 'tableCell',
-              attrs: { colspan: 1, rowspan: 1, colwidth: null },
+              attrs: { colspan: 1, rowspan: 1, colwidth: null, align: null },
               content: [
                 {
                   type: 'paragraph',
@@ -219,7 +219,7 @@ export const sampleContent: NodeJSON = {
             },
             {
               type: 'tableCell',
-              attrs: { colspan: 1, rowspan: 1, colwidth: null },
+              attrs: { colspan: 1, rowspan: 1, colwidth: null, align: null },
               content: [
                 {
                   type: 'paragraph',
@@ -234,7 +234,7 @@ export const sampleContent: NodeJSON = {
           content: [
             {
               type: 'tableCell',
-              attrs: { colspan: 1, rowspan: 1, colwidth: null },
+              attrs: { colspan: 1, rowspan: 1, colwidth: null, align: null },
               content: [
                 {
                   type: 'paragraph',
@@ -244,7 +244,7 @@ export const sampleContent: NodeJSON = {
             },
             {
               type: 'tableCell',
-              attrs: { colspan: 1, rowspan: 1, colwidth: null },
+              attrs: { colspan: 1, rowspan: 1, colwidth: null, align: null },
               content: [
                 {
                   type: 'paragraph',

--- a/packages/core/src/extensions/extension.test.ts
+++ b/packages/core/src/extensions/extension.test.ts
@@ -157,6 +157,7 @@ describe('defineEditorExtension', () => {
                 "content": [
                   {
                     "attrs": {
+                      "align": null,
                       "colspan": 1,
                       "colwidth": null,
                       "rowspan": 1,
@@ -176,6 +177,7 @@ describe('defineEditorExtension', () => {
                   },
                   {
                     "attrs": {
+                      "align": null,
                       "colspan": 1,
                       "colwidth": null,
                       "rowspan": 1,
@@ -200,6 +202,7 @@ describe('defineEditorExtension', () => {
                 "content": [
                   {
                     "attrs": {
+                      "align": null,
                       "colspan": 1,
                       "colwidth": null,
                       "rowspan": 1,
@@ -219,6 +222,7 @@ describe('defineEditorExtension', () => {
                   },
                   {
                     "attrs": {
+                      "align": null,
                       "colspan": 1,
                       "colwidth": null,
                       "rowspan": 1,

--- a/packages/core/src/extensions/table-column-align.test.ts
+++ b/packages/core/src/extensions/table-column-align.test.ts
@@ -1,11 +1,26 @@
 import type { EditorNode } from '@prosekit/pm/model'
 import { describe, expect, it } from 'vitest'
 
+import { docToMarkdown } from '../converters/pm-to-md.ts'
 import { setupFixture } from '../testing/index.ts'
 
-import type { MeowdownTableCellAttrs, TableColumnAlign } from './table-column-align.ts'
+import {
+  getTableColumnAlign,
+  type MeowdownTableCellAttrs,
+  type TableColumnAlign,
+} from './table-column-align.ts'
 
 type Builders = ReturnType<typeof setupFixture>['n']
+
+/** An unaligned table with the caret in the first data cell. */
+function plainTable(n: Builders): EditorNode {
+  return n.doc(
+    n.table(
+      n.tableRow(n.tableHeaderCell(n.paragraph('a')), n.tableHeaderCell(n.paragraph('b'))),
+      n.tableRow(n.tableCell(n.paragraph('<a>1')), n.tableCell(n.paragraph('2'))),
+    ),
+  )
+}
 
 /** A table whose first column is centered, with the caret in the first data cell. */
 function alignedTable(n: Builders): EditorNode {
@@ -48,6 +63,18 @@ function getFirstDataCellPos(doc: EditorNode): number {
     return true
   })
   return found
+}
+
+function getCellHitPositions(doc: EditorNode): number[] {
+  const positions: number[] = []
+  doc.descendants((node, pos) => {
+    if (node.type.name === 'tableCell' || node.type.name === 'tableHeaderCell') {
+      positions.push(pos + 1)
+      return false
+    }
+    return true
+  })
+  return positions
 }
 
 describe('table align sync', () => {
@@ -94,5 +121,98 @@ describe('table align sync', () => {
       ['center', null],
       ['center', null],
     ])
+  })
+})
+
+describe('setTableColumnAlign', () => {
+  it('aligns the column at the caret', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(plainTable(n))
+
+    editor.commands.setTableColumnAlign('center')
+
+    expect(getCellAligns(fixture.doc)).toEqual([
+      ['center', null],
+      ['center', null],
+    ])
+    expect(docToMarkdown(fixture.doc)).toBe('| a | b |\n| :-: | --- |\n| 1 | 2 |\n')
+  })
+
+  it('aligns every column a cell selection touches', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(plainTable(n))
+
+    const [headerA, headerB] = getCellHitPositions(fixture.doc)
+    editor.commands.selectTableRow({ anchor: headerA, head: headerB })
+    editor.commands.setTableColumnAlign('right')
+
+    expect(getCellAligns(fixture.doc)).toEqual([
+      ['right', 'right'],
+      ['right', 'right'],
+    ])
+  })
+
+  it('clears alignment with null', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(alignedTable(n))
+
+    editor.commands.setTableColumnAlign(null)
+
+    expect(getCellAligns(fixture.doc)).toEqual([
+      [null, null],
+      [null, null],
+    ])
+    expect(docToMarkdown(fixture.doc)).toBe('| a | b |\n| --- | --- |\n| 1 | 2 |\n')
+  })
+
+  it('cannot exec outside a table', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>outside')))
+
+    expect(editor.commands.setTableColumnAlign.canExec('left')).toBe(false)
+  })
+
+  it('undoes the alignment and its sync in one step', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(plainTable(n))
+
+    editor.commands.setTableColumnAlign('center')
+    editor.commands.undo()
+
+    expect(getCellAligns(fixture.doc)).toEqual([
+      [null, null],
+      [null, null],
+    ])
+  })
+})
+
+describe('getTableColumnAlign', () => {
+  it('reads the alignment of the caret column', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(alignedTable(n))
+
+    expect(getTableColumnAlign(editor.state)).toBe('center')
+  })
+
+  it('returns undefined for an unaligned column', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(plainTable(n))
+
+    expect(getTableColumnAlign(editor.state)).toBeUndefined()
+  })
+
+  it('returns undefined outside a table', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>outside')))
+
+    expect(getTableColumnAlign(editor.state)).toBeUndefined()
   })
 })

--- a/packages/core/src/extensions/table-column-align.test.ts
+++ b/packages/core/src/extensions/table-column-align.test.ts
@@ -1,0 +1,98 @@
+import type { EditorNode } from '@prosekit/pm/model'
+import { describe, expect, it } from 'vitest'
+
+import { setupFixture } from '../testing/index.ts'
+
+import type { MeowdownTableCellAttrs, TableColumnAlign } from './table-column-align.ts'
+
+type Builders = ReturnType<typeof setupFixture>['n']
+
+/** A table whose first column is centered, with the caret in the first data cell. */
+function alignedTable(n: Builders): EditorNode {
+  return n.doc(
+    n.table(
+      n.tableRow(
+        n.tableHeaderCell({ align: 'center' }, n.paragraph('a')),
+        n.tableHeaderCell(n.paragraph('b')),
+      ),
+      n.tableRow(
+        n.tableCell({ align: 'center' }, n.paragraph('<a>1')),
+        n.tableCell(n.paragraph('2')),
+      ),
+    ),
+  )
+}
+
+function getCellAligns(doc: EditorNode): Array<Array<TableColumnAlign | null>> {
+  const rows: Array<Array<TableColumnAlign | null>> = []
+  doc.descendants((node) => {
+    if (node.type.name !== 'tableRow') return true
+    const cells: Array<TableColumnAlign | null> = []
+    node.forEach((cell) => {
+      cells.push((cell.attrs as MeowdownTableCellAttrs).align ?? null)
+    })
+    rows.push(cells)
+    return false
+  })
+  return rows
+}
+
+function getFirstDataCellPos(doc: EditorNode): number {
+  let found = -1
+  doc.descendants((node, pos) => {
+    if (found >= 0) return false
+    if (node.type.name === 'tableCell') {
+      found = pos
+      return false
+    }
+    return true
+  })
+  return found
+}
+
+describe('table align sync', () => {
+  it('inherits column alignment when a row is inserted', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(alignedTable(n))
+
+    editor.commands.addTableRowBelow()
+
+    expect(getCellAligns(fixture.doc)).toEqual([
+      ['center', null],
+      ['center', null],
+      ['center', null],
+    ])
+  })
+
+  it('leaves an inserted column unaligned', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(alignedTable(n))
+
+    editor.commands.addTableColumnAfter()
+
+    expect(getCellAligns(fixture.doc)).toEqual([
+      ['center', null, null],
+      ['center', null, null],
+    ])
+  })
+
+  it('restores a data cell align that drifts from the alignment row', () => {
+    using fixture = setupFixture()
+    const { n, view } = fixture
+    fixture.set(alignedTable(n))
+
+    const cellPos = getFirstDataCellPos(view.state.doc)
+    const cell = view.state.doc.nodeAt(cellPos)
+    if (cell == null) throw new Error('missing data cell')
+    view.dispatch(
+      view.state.tr.setNodeMarkup(cellPos, undefined, { ...cell.attrs, align: 'right' }),
+    )
+
+    expect(getCellAligns(fixture.doc)).toEqual([
+      ['center', null],
+      ['center', null],
+    ])
+  })
+})

--- a/packages/core/src/extensions/table-column-align.ts
+++ b/packages/core/src/extensions/table-column-align.ts
@@ -1,4 +1,13 @@
-import { defineNodeAttr, union, type Extension, type Union } from '@prosekit/core'
+import {
+  defineNodeAttr,
+  definePlugin,
+  union,
+  type Extension,
+  type PlainExtension,
+  type Union,
+} from '@prosekit/core'
+import type { ProseMirrorNode } from '@prosekit/pm/model'
+import { Plugin, PluginKey, type Transaction } from '@prosekit/pm/state'
 
 import type { NodeName } from './node-names.ts'
 
@@ -49,10 +58,111 @@ function defineTableHeaderCellAlignAttr(): TableHeaderCellAlignExtension {
   })
 }
 
+/**
+ * The row whose `align` attrs define the column alignment of the whole table:
+ * the header row, or the first row of a headerless table. Matches the row the
+ * serializer reads when it writes the delimiter row.
+ */
+function findAlignmentRow(table: ProseMirrorNode): ProseMirrorNode {
+  for (let rowIndex = 0; rowIndex < table.childCount; rowIndex++) {
+    const row = table.child(rowIndex)
+    for (let column = 0; column < row.childCount; column++) {
+      if (row.child(column).type.name === ('tableHeaderCell' satisfies NodeName)) return row
+    }
+  }
+  return table.child(0)
+}
+
+function getCellAlign(row: ProseMirrorNode, column: number): TableColumnAlign | null {
+  if (column >= row.childCount) return null
+  return (row.child(column).attrs as MeowdownTableCellAttrs).align ?? null
+}
+
+function syncTableAligns(table: ProseMirrorNode, tablePos: number, tr: Transaction): void {
+  if (table.childCount === 0) return
+  const alignmentRow = findAlignmentRow(table)
+  let rowPos = tablePos + 1
+  for (let rowIndex = 0; rowIndex < table.childCount; rowIndex++) {
+    const row = table.child(rowIndex)
+    let cellPos = rowPos + 1
+    for (let column = 0; column < row.childCount; column++) {
+      const cell = row.child(column)
+      const align = getCellAlign(alignmentRow, column)
+      if (((cell.attrs as MeowdownTableCellAttrs).align ?? null) !== align) {
+        // `setNodeMarkup` keeps node sizes, so positions computed up front
+        // stay valid across fixes.
+        tr.setNodeMarkup(cellPos, undefined, { ...cell.attrs, align })
+      }
+      cellPos += cell.nodeSize
+    }
+    rowPos += row.nodeSize
+  }
+}
+
+/**
+ * The union of changed ranges across `transactions`, in the coordinates of the
+ * final document.
+ */
+function unionOfChangedRanges(
+  transactions: readonly Transaction[],
+): { from: number; to: number } | undefined {
+  let from: number | undefined
+  let to: number | undefined
+  for (const transaction of transactions) {
+    if (!transaction.docChanged) continue
+    if (from != null && to != null) {
+      from = transaction.mapping.map(from, -1)
+      to = transaction.mapping.map(to, 1)
+    }
+    const mapping = transaction.mapping
+    for (const [index, stepMap] of mapping.maps.entries()) {
+      const remaining = mapping.slice(index + 1)
+      stepMap.forEach((_oldStart, _oldEnd, newStart, newEnd) => {
+        const start = remaining.map(newStart, -1)
+        const end = remaining.map(newEnd, 1)
+        from = from == null ? start : Math.min(from, start)
+        to = to == null ? end : Math.max(to, end)
+      })
+    }
+  }
+  if (from == null || to == null) return undefined
+  return { from, to }
+}
+
+// Rendering needs the `align` attr on every cell, but the alignment row is
+// the semantic source (GFM alignment is a column property). Copy it to the
+// data cells after every doc change, so inserted rows and pasted cells
+// inherit their column's alignment.
+function createTableAlignSyncPlugin(): Plugin {
+  return new Plugin({
+    key: new PluginKey('table-align-sync'),
+    appendTransaction(transactions, _oldState, newState) {
+      if (!transactions.some((transaction) => transaction.docChanged)) return
+      const range = unionOfChangedRanges(transactions)
+      if (!range) return
+      const doc = newState.doc
+      const from = Math.max(0, Math.min(range.from, doc.content.size))
+      const to = Math.max(from, Math.min(range.to, doc.content.size))
+      let tr: Transaction | undefined
+      doc.nodesBetween(from, to, (node, pos) => {
+        if (node.type.name !== ('table' satisfies NodeName)) return true
+        tr ??= newState.tr
+        syncTableAligns(node, pos, tr)
+        return false
+      })
+      return tr?.docChanged ? tr : undefined
+    },
+  })
+}
+
+function defineTableAlignSync(): PlainExtension {
+  return definePlugin(createTableAlignSyncPlugin())
+}
+
 export type TableColumnAlignExtension = Union<
-  [TableCellAlignExtension, TableHeaderCellAlignExtension]
+  [TableCellAlignExtension, TableHeaderCellAlignExtension, PlainExtension]
 >
 
 export function defineTableColumnAlign(): TableColumnAlignExtension {
-  return union(defineTableCellAlignAttr(), defineTableHeaderCellAlignAttr())
+  return union(defineTableCellAlignAttr(), defineTableHeaderCellAlignAttr(), defineTableAlignSync())
 }

--- a/packages/core/src/extensions/table-column-align.ts
+++ b/packages/core/src/extensions/table-column-align.ts
@@ -1,4 +1,5 @@
 import {
+  defineCommands,
   defineNodeAttr,
   definePlugin,
   union,
@@ -6,8 +7,15 @@ import {
   type PlainExtension,
   type Union,
 } from '@prosekit/core'
+import { isCellSelection } from '@prosekit/extensions/table'
 import type { ProseMirrorNode } from '@prosekit/pm/model'
-import { Plugin, PluginKey, type Transaction } from '@prosekit/pm/state'
+import {
+  Plugin,
+  PluginKey,
+  type Command,
+  type EditorState,
+  type Transaction,
+} from '@prosekit/pm/state'
 
 import type { NodeName } from './node-names.ts'
 
@@ -34,7 +42,7 @@ type TableHeaderCellAlignExtension = Extension<{
   Nodes: { tableHeaderCell: MeowdownTableCellAttrs }
 }>
 
-export function parseTableColumnAlign(value: string | null): TableColumnAlign | null {
+function parseTableColumnAlign(value: string | null): TableColumnAlign | null {
   return value === 'left' || value === 'center' || value === 'right' ? value : null
 }
 
@@ -63,14 +71,18 @@ function defineTableHeaderCellAlignAttr(): TableHeaderCellAlignExtension {
  * the header row, or the first row of a headerless table. Matches the row the
  * serializer reads when it writes the delimiter row.
  */
-function findAlignmentRow(table: ProseMirrorNode): ProseMirrorNode {
+function findAlignmentRowIndex(table: ProseMirrorNode): number {
   for (let rowIndex = 0; rowIndex < table.childCount; rowIndex++) {
     const row = table.child(rowIndex)
     for (let column = 0; column < row.childCount; column++) {
-      if (row.child(column).type.name === ('tableHeaderCell' satisfies NodeName)) return row
+      if (row.child(column).type.name === ('tableHeaderCell' satisfies NodeName)) return rowIndex
     }
   }
-  return table.child(0)
+  return 0
+}
+
+function findAlignmentRow(table: ProseMirrorNode): ProseMirrorNode {
+  return table.child(findAlignmentRowIndex(table))
 }
 
 function getCellAlign(row: ProseMirrorNode, column: number): TableColumnAlign | null {
@@ -159,10 +171,117 @@ function defineTableAlignSync(): PlainExtension {
   return definePlugin(createTableAlignSyncPlugin())
 }
 
+interface SelectedColumns {
+  table: ProseMirrorNode
+  tablePos: number
+  firstColumn: number
+  lastColumn: number
+}
+
+/**
+ * The table and column range the selection acts on. Cells are always 1x1 in a
+ * GFM table, so a cell's index within its row is its column index.
+ */
+function findSelectedColumns(state: EditorState): SelectedColumns | undefined {
+  const { selection } = state
+  if (isCellSelection(selection)) {
+    const { $anchorCell, $headCell } = selection
+    const tableDepth = $anchorCell.depth - 1
+    const anchorColumn = $anchorCell.index()
+    const headColumn = $headCell.index()
+    return {
+      table: $anchorCell.node(tableDepth),
+      tablePos: $anchorCell.before(tableDepth),
+      firstColumn: Math.min(anchorColumn, headColumn),
+      lastColumn: Math.max(anchorColumn, headColumn),
+    }
+  }
+  const { $from } = selection
+  for (let depth = $from.depth; depth > 2; depth--) {
+    const name = $from.node(depth).type.name
+    if (
+      name === ('tableCell' satisfies NodeName) ||
+      name === ('tableHeaderCell' satisfies NodeName)
+    ) {
+      const column = $from.index(depth - 1)
+      return {
+        table: $from.node(depth - 2),
+        tablePos: $from.before(depth - 2),
+        firstColumn: column,
+        lastColumn: column,
+      }
+    }
+  }
+  return undefined
+}
+
+/**
+ * Set the column alignment of every column the selection touches. Writes only
+ * the alignment row's cells; the align sync plugin copies the value to the
+ * data cells in the same dispatch. Pass null to reset a column to the
+ * unaligned `---` delimiter.
+ */
+function setTableColumnAlign(align: TableColumnAlign | null): Command {
+  return (state, dispatch) => {
+    const selected = findSelectedColumns(state)
+    if (!selected || selected.table.childCount === 0) return false
+    if (dispatch) {
+      const { table, tablePos, firstColumn, lastColumn } = selected
+      const rowIndex = findAlignmentRowIndex(table)
+      let rowPos = tablePos + 1
+      for (let i = 0; i < rowIndex; i++) rowPos += table.child(i).nodeSize
+      const row = table.child(rowIndex)
+      const tr = state.tr
+      let cellPos = rowPos + 1
+      for (let column = 0; column < row.childCount; column++) {
+        const cell = row.child(column)
+        const inRange = column >= firstColumn && column <= lastColumn
+        if (inRange && ((cell.attrs as MeowdownTableCellAttrs).align ?? null) !== align) {
+          tr.setNodeMarkup(cellPos, undefined, { ...cell.attrs, align })
+        }
+        cellPos += cell.nodeSize
+      }
+      dispatch(tr)
+    }
+    return true
+  }
+}
+
+/**
+ * The column alignment of the table column the selection sits in, or
+ * undefined when the selection is outside a table or the column has no
+ * alignment.
+ */
+export function getTableColumnAlign(state: EditorState): TableColumnAlign | undefined {
+  const selected = findSelectedColumns(state)
+  if (!selected || selected.table.childCount === 0) return undefined
+  return getCellAlign(findAlignmentRow(selected.table), selected.lastColumn) ?? undefined
+}
+
+type TableColumnAlignCommandsExtension = Extension<{
+  Commands: {
+    setTableColumnAlign: [align: TableColumnAlign | null]
+  }
+}>
+
+function defineTableColumnAlignCommands(): TableColumnAlignCommandsExtension {
+  return defineCommands({ setTableColumnAlign })
+}
+
 export type TableColumnAlignExtension = Union<
-  [TableCellAlignExtension, TableHeaderCellAlignExtension, PlainExtension]
+  [
+    TableCellAlignExtension,
+    TableHeaderCellAlignExtension,
+    PlainExtension,
+    TableColumnAlignCommandsExtension,
+  ]
 >
 
 export function defineTableColumnAlign(): TableColumnAlignExtension {
-  return union(defineTableCellAlignAttr(), defineTableHeaderCellAlignAttr(), defineTableAlignSync())
+  return union(
+    defineTableCellAlignAttr(),
+    defineTableHeaderCellAlignAttr(),
+    defineTableAlignSync(),
+    defineTableColumnAlignCommands(),
+  )
 }

--- a/packages/core/src/extensions/table-column-align.ts
+++ b/packages/core/src/extensions/table-column-align.ts
@@ -1,0 +1,58 @@
+import { defineNodeAttr, union, type Extension, type Union } from '@prosekit/core'
+
+import type { NodeName } from './node-names.ts'
+
+/**
+ * Column alignment of a GFM table, encoded by the delimiter row: `:--` for
+ * left, `:-:` for center, `--:` for right.
+ */
+export type TableColumnAlign = 'left' | 'center' | 'right'
+
+export interface MeowdownTableCellAttrs {
+  /**
+   * The column alignment this cell renders with. Defaults to null, which
+   * renders with the default left alignment and serializes the delimiter
+   * column as `---`.
+   */
+  align?: TableColumnAlign | null
+}
+
+type TableCellAlignExtension = Extension<{
+  Nodes: { tableCell: MeowdownTableCellAttrs }
+}>
+
+type TableHeaderCellAlignExtension = Extension<{
+  Nodes: { tableHeaderCell: MeowdownTableCellAttrs }
+}>
+
+export function parseTableColumnAlign(value: string | null): TableColumnAlign | null {
+  return value === 'left' || value === 'center' || value === 'right' ? value : null
+}
+
+function defineTableCellAlignAttr(): TableCellAlignExtension {
+  return defineNodeAttr<'tableCell', 'align', TableColumnAlign | null>({
+    type: 'tableCell' satisfies NodeName,
+    attr: 'align',
+    default: null,
+    toDOM: (value) => (value ? ['data-align', value] : null),
+    parseDOM: (node) => parseTableColumnAlign(node.getAttribute('data-align')),
+  })
+}
+
+function defineTableHeaderCellAlignAttr(): TableHeaderCellAlignExtension {
+  return defineNodeAttr<'tableHeaderCell', 'align', TableColumnAlign | null>({
+    type: 'tableHeaderCell' satisfies NodeName,
+    attr: 'align',
+    default: null,
+    toDOM: (value) => (value ? ['data-align', value] : null),
+    parseDOM: (node) => parseTableColumnAlign(node.getAttribute('data-align')),
+  })
+}
+
+export type TableColumnAlignExtension = Union<
+  [TableCellAlignExtension, TableHeaderCellAlignExtension]
+>
+
+export function defineTableColumnAlign(): TableColumnAlignExtension {
+  return union(defineTableCellAlignAttr(), defineTableHeaderCellAlignAttr())
+}

--- a/packages/core/src/extensions/table.ts
+++ b/packages/core/src/extensions/table.ts
@@ -20,6 +20,7 @@ import {
 import type { Command, EditorState } from '@prosekit/pm/state'
 
 import type { NodeName } from './node-names.ts'
+import { defineTableColumnAlign } from './table-column-align.ts'
 
 /**
  * Whether the selection sits inside a table cell (data or header). Useful for
@@ -79,6 +80,7 @@ export function defineTable() {
     defineTableCellSpec(),
     defineTableHeaderCellSpec(),
     defineTableCellContent(),
+    defineTableColumnAlign(),
     defineTableEditingPlugin({ allowTableNodeSelection: true }),
     defineTableCommands(),
     defineTableDropIndicator(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -107,6 +107,11 @@ export {
 export { getMarkBuilders, type TypedMarkBuilders } from './extensions/schema.ts'
 export { isSelectionInTableCell } from './extensions/table.ts'
 export {
+  getTableColumnAlign,
+  type MeowdownTableCellAttrs,
+  type TableColumnAlign,
+} from './extensions/table-column-align.ts'
+export {
   defineTagClickHandler,
   type TagClickHandler,
   type TagClickPayload,

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -526,6 +526,16 @@
     background: var(--meowdown-table-header-bg);
   }
 
+  .ProseMirror td[data-align='center'],
+  .ProseMirror th[data-align='center'] {
+    text-align: center;
+  }
+
+  .ProseMirror td[data-align='right'],
+  .ProseMirror th[data-align='right'] {
+    text-align: right;
+  }
+
   .ProseMirror table.ProseMirror-selectednode td,
   .ProseMirror table.ProseMirror-selectednode th {
     border-color: var(--meowdown-node-outline);

--- a/packages/react/src/components/table-handle.module.css
+++ b/packages/react/src/components/table-handle.module.css
@@ -145,4 +145,11 @@
     color: var(--meowdown-muted);
     opacity: 0.8;
   }
+
+  svg {
+    display: block;
+    width: 1rem;
+    height: 1rem;
+    color: var(--meowdown-muted);
+  }
 }

--- a/packages/react/src/components/table-handle.test.tsx
+++ b/packages/react/src/components/table-handle.test.tsx
@@ -90,4 +90,44 @@ describe('TableHandle', () => {
     await columnMenu.getByTestId('table-delete-table-column').click()
     expect(ref.current?.getMarkdown().includes('|')).toBe(false)
   })
+
+  it('aligns a column to the center', async () => {
+    const ref = createRef<EditorHandle>()
+    await renderEditor(ref)
+    await hover(firstBodyCell())
+    await columnHandle.click()
+    await columnMenu.getByTestId('table-align-center').click()
+    expect(ref.current?.getMarkdown()).toBe('| a | b |\n| :-: | --- |\n| 1 | 2 |\n')
+    await expect.element(pmRoot.locate('th[data-align="center"]')).toBeVisible()
+    await expect.element(pmRoot.locate('td[data-align="center"]')).toBeVisible()
+  })
+
+  it('marks the active alignment and clears it on a second click', async () => {
+    const ref = createRef<EditorHandle>()
+    await renderEditor(ref)
+    await hover(firstBodyCell())
+    await columnHandle.click()
+    await columnMenu.getByTestId('table-align-right').click()
+    expect(ref.current?.getMarkdown()).toBe('| a | b |\n| --: | --- |\n| 1 | 2 |\n')
+
+    await hover(firstBodyCell())
+    await columnHandle.click()
+    await expect.element(columnMenu.getByTestId('table-align-right')).toHaveAttribute('data-active')
+    await columnMenu.getByTestId('table-align-right').click()
+    expect(ref.current?.getMarkdown()).toBe('| a | b |\n| --- | --- |\n| 1 | 2 |\n')
+  })
+
+  it('keeps the column alignment in an inserted row', async () => {
+    const ref = createRef<EditorHandle>()
+    await renderEditor(ref)
+    await hover(firstBodyCell())
+    await columnHandle.click()
+    await columnMenu.getByTestId('table-align-center').click()
+
+    await hover(firstBodyCell())
+    await rowHandle.click()
+    await rowMenu.getByTestId('table-insert-below').click()
+    expect(ref.current?.getMarkdown()).toBe('| a | b |\n| :-: | --- |\n| 1 | 2 |\n|  |  |\n')
+    await expect.element(pmRoot.locate('tr').last().locate('td[data-align="center"]')).toBeVisible()
+  })
 })

--- a/packages/react/src/components/table-handle.tsx
+++ b/packages/react/src/components/table-handle.tsx
@@ -1,4 +1,4 @@
-import type { EditorExtension } from '@meowdown/core'
+import { getTableColumnAlign, type EditorExtension, type TableColumnAlign } from '@meowdown/core'
 import type { Editor } from '@prosekit/core'
 import { useEditorDerivedValue } from '@prosekit/react'
 import { MenuItem, MenuPopup, MenuPositioner } from '@prosekit/react/menu'
@@ -15,13 +15,21 @@ import {
   TableHandleRowPopup,
   TableHandleRowPositioner,
 } from '@prosekit/react/table-handle'
-import { GripHorizontalIcon, GripVerticalIcon } from 'lucide-react'
+import { CheckIcon, GripHorizontalIcon, GripVerticalIcon } from 'lucide-react'
 
 import styles from './table-handle.module.css'
 
 function getTableHandleState(editor: Editor<EditorExtension>) {
   const commands = editor.commands
+  const columnAlign = getTableColumnAlign(editor.state)
   return {
+    columnAlign,
+    setTableColumnAlign: {
+      canExec: commands.setTableColumnAlign.canExec('left'),
+      // Selecting the current alignment again clears it back to `---`.
+      command: (align: TableColumnAlign) =>
+        commands.setTableColumnAlign(columnAlign === align ? null : align),
+    },
     addTableColumnBefore: {
       canExec: commands.addTableColumnBefore.canExec(),
       command: () => commands.addTableColumnBefore(),
@@ -55,6 +63,35 @@ function getTableHandleState(editor: Editor<EditorExtension>) {
       command: () => commands.deleteTable(),
     },
   }
+}
+
+const COLUMN_ALIGN_LABELS: Record<TableColumnAlign, string> = {
+  left: 'Align Left',
+  center: 'Align Center',
+  right: 'Align Right',
+}
+
+function ColumnAlignMenuItem({
+  align,
+  columnAlign,
+  onSelect,
+}: {
+  align: TableColumnAlign
+  columnAlign: TableColumnAlign | undefined
+  onSelect: () => void
+}) {
+  const active = columnAlign === align
+  return (
+    <MenuItem
+      className={styles.MenuItem}
+      data-testid={`table-align-${align}`}
+      data-active={active ? '' : undefined}
+      onSelect={onSelect}
+    >
+      <span>{COLUMN_ALIGN_LABELS[align]}</span>
+      {active && <CheckIcon />}
+    </MenuItem>
+  )
 }
 
 export function TableHandle() {
@@ -93,6 +130,25 @@ export function TableHandle() {
                   >
                     <span>Insert Right</span>
                   </MenuItem>
+                )}
+                {state.setTableColumnAlign.canExec && (
+                  <>
+                    <ColumnAlignMenuItem
+                      align="left"
+                      columnAlign={state.columnAlign}
+                      onSelect={() => state.setTableColumnAlign.command('left')}
+                    />
+                    <ColumnAlignMenuItem
+                      align="center"
+                      columnAlign={state.columnAlign}
+                      onSelect={() => state.setTableColumnAlign.command('center')}
+                    />
+                    <ColumnAlignMenuItem
+                      align="right"
+                      columnAlign={state.columnAlign}
+                      onSelect={() => state.setTableColumnAlign.command('right')}
+                    />
+                  </>
                 )}
                 {state.deleteCellSelection.canExec && (
                   <MenuItem


### PR DESCRIPTION
Parse and serialize GFM table column alignment (`:--` / `:-:` / `--:`) through an `align` attr on table cells; this was the only GFM syntax that lost data on a markdown round trip. A sync plugin keeps data cells following the header row alignment (so inserted rows inherit it), and the table handle column menu gains Align Left / Center / Right items, with a second click on the active item clearing the alignment.