### PR TITLE
fix: draw the virtual caret at an atom mark edge

### DIFF
--- a/packages/core/src/extensions/atom-mark-navigation.ts
+++ b/packages/core/src/extensions/atom-mark-navigation.ts
@@ -16,6 +16,12 @@ import { getMarkRangeAt } from './get-mark-range-at.ts'
 import { getMarkMode, type MarkMode } from './mark-mode.ts'
 import type { MarkName } from './mark-names.ts'
 
+/**
+ * The source marks whose mark views hide the raw text behind a rendered
+ * preview (`.md-atom-view-preview`) and act as one caret stop.
+ */
+export const ATOM_SOURCE_MARK_NAMES: readonly MarkName[] = ['mdImage', 'mdWikilink', 'mdFile']
+
 type AtomMarks = Array<{ name: MarkName; modes: ReadonlyArray<MarkMode> }>
 
 export interface AtomMarkNavigationOptions {

--- a/packages/core/src/extensions/extension.ts
+++ b/packages/core/src/extensions/extension.ts
@@ -12,7 +12,7 @@ import { defineModClickPrevention } from '@prosekit/extensions/mod-click-prevent
 import { defineText } from '@prosekit/extensions/text'
 import { defineVirtualSelection } from '@prosekit/extensions/virtual-selection'
 
-import { defineAtomMarkNavigation } from './atom-mark-navigation.ts'
+import { ATOM_SOURCE_MARK_NAMES, defineAtomMarkNavigation } from './atom-mark-navigation.ts'
 import { defineCodeBlockSyntaxHighlight } from './code-block-highlight.ts'
 import { defineCodeBlock } from './code-block.ts'
 import { defineEditorCommands } from './commands.ts'
@@ -64,11 +64,7 @@ function defineEditorExtensionImpl(options: EditorExtensionOptions) {
     defineVirtualCaret(),
     defineHiddenRunCaret(),
     defineAtomMarkNavigation({
-      marks: [
-        { name: 'mdImage', modes: ['hide', 'focus', 'show'] },
-        { name: 'mdWikilink', modes: ['hide', 'focus', 'show'] },
-        { name: 'mdFile', modes: ['hide', 'focus', 'show'] },
-      ],
+      marks: ATOM_SOURCE_MARK_NAMES.map((name) => ({ name, modes: ['hide', 'focus', 'show'] })),
     }),
 
     // others

--- a/packages/core/src/extensions/virtual-caret.test.ts
+++ b/packages/core/src/extensions/virtual-caret.test.ts
@@ -3,6 +3,7 @@ import { page, userEvent } from 'vitest/browser'
 
 import { setupFixture, type Fixture } from '../testing/index.ts'
 
+import { defineFileView } from './file-view.ts'
 import { defineMarkMode, type MarkMode } from './mark-mode.ts'
 
 const caret = page.getByTestId('virtual-caret')
@@ -124,6 +125,88 @@ describe('virtual caret geometry next to hidden runs (hide mode)', () => {
     editor.use(defineMarkMode('hide'))
     fixture.set(n.doc(n.paragraph()))
     fixture.view.focus()
+    await expect.element(caret).toBeVisible()
+  })
+})
+
+describe('virtual caret next to atom marks', () => {
+  const wikilink = page.getByTestId('wikilink')
+
+  function setupFilePill(text: string): Fixture {
+    const fixture = setupFixture({
+      extensionOptions: { resolveFileLink: ({ href }) => href.startsWith('assets/') },
+    })
+    const { editor, n } = fixture
+    editor.use(defineFileView({}))
+    editor.use(defineMarkMode('hide'))
+    fixture.set(n.doc(n.paragraph(text)))
+    fixture.view.focus()
+    return fixture
+  }
+
+  it('is visible at the end of a paragraph holding only a wikilink', async () => {
+    using fixture = setupMode('hide', '[[note]]<a>')
+    void fixture
+    await expect.element(caret).toBeVisible()
+  })
+
+  it('is visible at the start of a paragraph holding only a wikilink', async () => {
+    using fixture = setupMode('hide', '<a>[[note]]')
+    void fixture
+    await expect.element(caret).toBeVisible()
+  })
+
+  it('is visible at the end of a wikilink preceded by text', async () => {
+    using fixture = setupMode('hide', 'head [[note]]<a>')
+    void fixture
+    await expect.element(caret).toBeVisible()
+  })
+
+  it('is visible at the start of a wikilink followed by text', async () => {
+    using fixture = setupMode('hide', '<a>[[note]] tail')
+    void fixture
+    await expect.element(caret).toBeVisible()
+  })
+
+  it('is visible at the end of a wikilink followed by text', async () => {
+    using fixture = setupMode('hide', '[[note]]<a> tail')
+    void fixture
+    await expect.element(caret).toBeVisible()
+  })
+
+  it('is visible between two adjacent wikilinks', async () => {
+    using fixture = setupMode('hide', '[[a]]<a>[[b]]')
+    void fixture
+    await expect.element(caret).toBeVisible()
+  })
+
+  it('is visible at the end of a lone wikilink in show mode', async () => {
+    using fixture = setupMode('show', '[[note]]<a>')
+    void fixture
+    await expect.element(caret).toBeVisible()
+  })
+
+  it('draws the caret flush against the wikilink label right edge', async () => {
+    using fixture = setupMode('hide', 'head [[note]]<a>')
+    void fixture
+    await expect.element(caret).toBeVisible()
+    const previewRight = () => wikilink.element().getBoundingClientRect().right
+    const caretLeft = () => getCaretElement().getBoundingClientRect().left
+    await expect.poll(() => Math.abs(caretLeft() - previewRight())).toBeLessThanOrEqual(2)
+  })
+
+  it('draws the caret flush against the wikilink label left edge', async () => {
+    using fixture = setupMode('hide', '<a>[[note]] tail')
+    void fixture
+    await expect.element(caret).toBeVisible()
+    const previewLeft = () => wikilink.element().getBoundingClientRect().left
+    const caretLeft = () => getCaretElement().getBoundingClientRect().left
+    await expect.poll(() => Math.abs(caretLeft() - previewLeft())).toBeLessThanOrEqual(2)
+  })
+
+  it('is visible at the end of a paragraph holding only a file pill', async () => {
+    using fixture = setupFilePill('[report.pdf](assets/report.pdf)<a>')
+    void fixture
     await expect.element(caret).toBeVisible()
   })
 })

--- a/packages/core/src/extensions/virtual-caret.ts
+++ b/packages/core/src/extensions/virtual-caret.ts
@@ -14,6 +14,7 @@ import {
   type CaretTail,
 } from './hidden-run.ts'
 import { getMarkMode } from './mark-mode.ts'
+import { forceReflow } from '../utils/force-reflow.ts'
 
 const key = new PluginKey('meowdown-virtual-caret')
 
@@ -99,19 +100,15 @@ function findAtomPreviewElement(view: EditorView, insidePos: number): Element | 
   return preview ?? undefined
 }
 
-function measureCaretRect(view: EditorView): CaretRect | undefined {
-  const rect = findNativeCaretRect(view) ?? findCoordsCaretRect(view)
-  if (rect != null) return stretchCaretRect(rect)
-  return findAtomCaretRect(view)
-}
-
 function stretchCaretRect(rect: CaretRect): CaretRect {
   const extra = rect.height * (CARET_STRETCH - 1)
   return { left: rect.left, top: rect.top - extra / 2, height: rect.height + extra }
 }
 
-function forceReflow(element: HTMLElement): void {
-  void element.offsetWidth
+function measureCaretRect(view: EditorView): CaretRect | undefined {
+  const rect = findNativeCaretRect(view) ?? findCoordsCaretRect(view)
+  if (rect != null) return stretchCaretRect(rect)
+  return findAtomCaretRect(view)
 }
 
 function sameRect(left: CaretRect | undefined, right: CaretRect | undefined): boolean {

--- a/packages/core/src/extensions/virtual-caret.ts
+++ b/packages/core/src/extensions/virtual-caret.ts
@@ -19,6 +19,10 @@ const key = new PluginKey('meowdown-virtual-caret')
 
 const BLINK_ANIMATIONS = ['md-virtual-caret-blink', 'md-virtual-caret-blink2'] as const
 
+// The measured rect is the glyph box, which reads short against the airy
+// line-height; stand the caret taller around its center.
+const CARET_STRETCH = 1.4
+
 interface CaretRect {
   left: number
   top: number
@@ -68,17 +72,10 @@ function findCoordsCaretRect(view: EditorView): CaretRect | undefined {
   return undefined
 }
 
-// Step 3: an atom mark view (image, wikilink, file pill) hides its source
+// Step 3: an atom mark view hides its source
 // text with `display: none`, so no position beside it has a box the earlier
 // steps can measure. The preview element standing in for the source is the
 // visible geometry; the caret sits flush against its outer edge.
-function findAtomPreviewElement(view: EditorView, insidePos: number): Element | undefined {
-  const { node } = view.domAtPos(insidePos, 0)
-  const element = node instanceof Element ? node : node.parentElement
-  const preview = element?.closest('.md-atom-view')?.querySelector('.md-atom-view-preview')
-  return preview ?? undefined
-}
-
 function findAtomCaretRect(view: EditorView): CaretRect | undefined {
   const state = view.state
   const head = state.selection.head
@@ -95,19 +92,22 @@ function findAtomCaretRect(view: EditorView): CaretRect | undefined {
   return undefined
 }
 
-// The measured rect is the glyph box, which reads short against the airy
-// line-height; stand the caret taller around its center.
-const CARET_STRETCH = 1.4
-
-function stretchCaretRect(rect: CaretRect): CaretRect {
-  const extra = rect.height * (CARET_STRETCH - 1)
-  return { left: rect.left, top: rect.top - extra / 2, height: rect.height + extra }
+function findAtomPreviewElement(view: EditorView, insidePos: number): Element | undefined {
+  const { node } = view.domAtPos(insidePos, 0)
+  const element = node instanceof Element ? node : node.parentElement
+  const preview = element?.closest('.md-atom-view')?.querySelector('.md-atom-view-preview')
+  return preview ?? undefined
 }
 
 function measureCaretRect(view: EditorView): CaretRect | undefined {
   const rect = findNativeCaretRect(view) ?? findCoordsCaretRect(view)
   if (rect != null) return stretchCaretRect(rect)
   return findAtomCaretRect(view)
+}
+
+function stretchCaretRect(rect: CaretRect): CaretRect {
+  const extra = rect.height * (CARET_STRETCH - 1)
+  return { left: rect.left, top: rect.top - extra / 2, height: rect.height + extra }
 }
 
 function forceReflow(element: HTMLElement): void {

--- a/packages/core/src/extensions/virtual-caret.ts
+++ b/packages/core/src/extensions/virtual-caret.ts
@@ -5,6 +5,8 @@ import type { EditorView } from '@prosekit/pm/view'
 
 import { tryCoordsAtPos } from '../utils/caret-coords.ts'
 
+import { ATOM_SOURCE_MARK_NAMES } from './atom-mark-navigation.ts'
+import { getMarkRangeAt } from './get-mark-range-at.ts'
 import {
   getCaretTail,
   getHiddenRunAfter,
@@ -66,6 +68,33 @@ function findCoordsCaretRect(view: EditorView): CaretRect | undefined {
   return undefined
 }
 
+// Step 3: an atom mark view (image, wikilink, file pill) hides its source
+// text with `display: none`, so no position beside it has a box the earlier
+// steps can measure. The preview element standing in for the source is the
+// visible geometry; the caret sits flush against its outer edge.
+function findAtomPreviewElement(view: EditorView, insidePos: number): Element | undefined {
+  const { node } = view.domAtPos(insidePos, 0)
+  const element = node instanceof Element ? node : node.parentElement
+  const preview = element?.closest('.md-atom-view')?.querySelector('.md-atom-view-preview')
+  return preview ?? undefined
+}
+
+function findAtomCaretRect(view: EditorView): CaretRect | undefined {
+  const state = view.state
+  const head = state.selection.head
+  for (const markName of ATOM_SOURCE_MARK_NAMES) {
+    const range = getMarkRangeAt(state, head, markName)
+    if (range == null || (range.from !== head && range.to !== head)) continue
+    const preview = findAtomPreviewElement(view, range.from + 1)
+    if (preview == null) continue
+    const rect = preview.getBoundingClientRect()
+    if (rect.height === 0) continue
+    const left = range.to === head ? rect.right : rect.left
+    return { left, top: rect.top, height: rect.height }
+  }
+  return undefined
+}
+
 // The measured rect is the glyph box, which reads short against the airy
 // line-height; stand the caret taller around its center.
 const CARET_STRETCH = 1.4
@@ -77,7 +106,8 @@ function stretchCaretRect(rect: CaretRect): CaretRect {
 
 function measureCaretRect(view: EditorView): CaretRect | undefined {
   const rect = findNativeCaretRect(view) ?? findCoordsCaretRect(view)
-  return rect == null ? undefined : stretchCaretRect(rect)
+  if (rect != null) return stretchCaretRect(rect)
+  return findAtomCaretRect(view)
 }
 
 function forceReflow(element: HTMLElement): void {

--- a/packages/core/src/extensions/virtual-caret.ts
+++ b/packages/core/src/extensions/virtual-caret.ts
@@ -4,6 +4,7 @@ import { Plugin, PluginKey } from '@prosekit/pm/state'
 import type { EditorView } from '@prosekit/pm/view'
 
 import { tryCoordsAtPos } from '../utils/caret-coords.ts'
+import { forceReflow } from '../utils/force-reflow.ts'
 
 import { ATOM_SOURCE_MARK_NAMES } from './atom-mark-navigation.ts'
 import { getMarkRangeAt } from './get-mark-range-at.ts'
@@ -14,7 +15,6 @@ import {
   type CaretTail,
 } from './hidden-run.ts'
 import { getMarkMode } from './mark-mode.ts'
-import { forceReflow } from '../utils/force-reflow.ts'
 
 const key = new PluginKey('meowdown-virtual-caret')
 
@@ -55,17 +55,17 @@ function findCoordsCaretRect(view: EditorView): CaretRect | undefined {
   const head = state.selection.head
   const runBefore = getHiddenRunBefore(state, head)
   const runAfter = getHiddenRunAfter(state, head)
-  const preferredSide: -1 | 1 = runBefore == null ? -1 : 1
+  const preferredBeforeSide: boolean = runBefore == null
   // `side` picks which neighbor to measure: -1 the character before the
   // position, 1 the character after it.
-  const probes: [pos: number, side: -1 | 1][] = [
-    [head, preferredSide],
-    [head, -preferredSide as -1 | 1],
+  const probes: [pos: number, beforeSide: boolean][] = [
+    [head, preferredBeforeSide],
+    [head, !preferredBeforeSide],
   ]
-  if (runBefore != null) probes.push([runBefore.from, -1])
-  if (runAfter != null) probes.push([runAfter.to, 1])
-  for (const [pos, side] of probes) {
-    const coords = tryCoordsAtPos(view, pos, side)
+  if (runBefore != null) probes.push([runBefore.from, true])
+  if (runAfter != null) probes.push([runAfter.to, false])
+  for (const [pos, beforeSide] of probes) {
+    const coords = tryCoordsAtPos(view, pos, beforeSide ? -1 : 1)
     if (coords != null && coords.bottom > coords.top) {
       return { left: coords.left, top: coords.top, height: coords.bottom - coords.top }
     }

--- a/packages/core/src/utils/force-reflow.ts
+++ b/packages/core/src/utils/force-reflow.ts
@@ -1,0 +1,3 @@
+export function forceReflow(element: HTMLElement): void {
+  void element.offsetWidth
+}


### PR DESCRIPTION
With the caret at the edge of a wikilink or file pill and no visible text beside it (e.g. a paragraph holding only `[[note]]`), the virtual caret disappeared: the atom mark view hides its source text with `display: none`, so neither the native selection nor `coordsAtPos` can measure a caret rect there. Add a third measurement step that falls back to the atom view's preview element and places the caret flush against its outer edge.