### PR TITLE
feat: round the virtual caret caps

### DIFF
--- a/packages/core/src/extensions/virtual-caret.ts
+++ b/packages/core/src/extensions/virtual-caret.ts
@@ -22,7 +22,7 @@ const BLINK_ANIMATIONS = ['md-virtual-caret-blink', 'md-virtual-caret-blink2'] a
 
 // The measured rect is the glyph box, which reads short against the airy
 // line-height; stand the caret taller around its center.
-const CARET_STRETCH = 1.4
+const CARET_STRETCH = 1.2
 
 interface CaretRect {
   left: number

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -139,12 +139,13 @@
   .md-virtual-caret-layer .md-virtual-caret {
     position: absolute;
     display: none;
-    /* Pinned: hosts often reset `*` to border-box (Tailwind preflight), and the
-     * tail geometry below depends on the outer width. */
+    /* Pinned so a host `*` box-sizing reset (Tailwind preflight) cannot
+     * change the box math. */
     box-sizing: border-box;
-    width: 0;
-    border-left: 2px solid var(--meowdown-caret);
+    width: 2px;
     margin-left: -1px;
+    border-radius: 999px;
+    background: var(--meowdown-caret);
     pointer-events: none;
     user-select: none;
     -webkit-user-select: none;
@@ -167,18 +168,24 @@
 
   /* Typing-affinity tails: the foot points to the side a typed character
    * would join, disambiguating the two coincident positions at a hidden run
-   * boundary. The vertical bar stays exactly on the caret x. */
-  .md-virtual-caret-layer .md-virtual-caret[data-tail='left'] {
+   * boundary. The vertical bar stays exactly on the caret x; the foot is a
+   * round-capped dash extending from the bar toward the pointed side. */
+  .md-virtual-caret-layer .md-virtual-caret[data-tail]::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
     width: 8px;
-    margin-left: -7px;
-    border-left: none;
-    border-right: 2px solid var(--meowdown-caret);
-    border-bottom: 2px solid var(--meowdown-caret);
+    height: 2px;
+    border-radius: 999px;
+    background: var(--meowdown-caret);
   }
 
-  .md-virtual-caret-layer .md-virtual-caret[data-tail='right'] {
-    width: 8px;
-    border-bottom: 2px solid var(--meowdown-caret);
+  .md-virtual-caret-layer .md-virtual-caret[data-tail='left']::after {
+    right: 0;
+  }
+
+  .md-virtual-caret-layer .md-virtual-caret[data-tail='right']::after {
+    left: 0;
   }
 
   /* macOS-style blink: dwell solid, fade out, dwell off, fade back in.

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -174,7 +174,7 @@
     content: '';
     position: absolute;
     bottom: 0;
-    width: 8px;
+    width: 6px;
     height: 2px;
     border-radius: 999px;
     background: var(--meowdown-caret);


### PR DESCRIPTION
The virtual caret was a square-cornered L drawn with borders. This paints the bar as a rounded background box and the tail foot as a round-capped `::after` dash, keeping the exact same geometry (2px bar centered on the caret x, 8px foot toward the typing-affinity side).