### PR TITLE
fix: do not ring atoms inside a node-selected block

### DIFF
--- a/packages/core/src/extensions/atom-mark-navigation.ts
+++ b/packages/core/src/extensions/atom-mark-navigation.ts
@@ -1,6 +1,7 @@
 import {
   defineKeymap,
   definePlugin,
+  isNodeSelection,
   isTextSelection,
   Priority,
   union,
@@ -175,6 +176,9 @@ function createSelectionPlugin(marks: AtomMarks): Plugin {
       decorations: (state) => {
         const markNames = activeMarkNames(marks, state)
         if (markNames.length === 0) return
+        // A node selection already outlines the whole block; atom rings inside
+        // it would read as a second, nested selection.
+        if (isNodeSelection(state.selection)) return
         const range = getSelectedRange(state, markNames)
         if (range) {
           return DecorationSet.create(state.doc, [

--- a/packages/core/src/extensions/image.test.ts
+++ b/packages/core/src/extensions/image.test.ts
@@ -1,3 +1,4 @@
+import { NodeSelection } from '@prosekit/pm/state'
 import { describe, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 
@@ -115,6 +116,13 @@ describe('image selection ring', () => {
     await userEvent.keyboard('{ArrowLeft}')
     expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(`"ABC❰![img](url)❱DEF"`)
     await expect.element(preview).toHaveStyle({ outlineStyle: 'solid' })
+  })
+
+  it('does not ring the preview inside a node-selected block', async () => {
+    using fixture = setupHidden('ABC![img](url)DEF')
+    const { view } = fixture
+    view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, 0)))
+    await expect.element(preview).toHaveStyle({ outlineStyle: 'none' })
   })
 })
 


### PR DESCRIPTION
Node-selecting a block (e.g. via the block handle) also decorated every atom inside it with `md-atom-selected`, ringing images, wikilinks, files, and embeds on top of the block's own selection outline. The atom selection plugin now skips node selections, so only the block outline shows.