### PR TITLE
fix: keep the autocomplete popup inside the viewport

### DIFF
--- a/packages/react/src/components/autocomplete-menu.module.css
+++ b/packages/react/src/components/autocomplete-menu.module.css
@@ -1,5 +1,9 @@
+/* A flex column, so the popup respects the inline `max-height` the
+ * positioner's viewport-fitting logic writes here when space is short; a
+ * block child would keep its own 25rem cap and overflow the viewport. */
 .Positioner {
-  display: block;
+  display: flex;
+  flex-direction: column;
   z-index: 50;
   width: min(24rem, calc(100vw - 1rem));
   height: min-content;
@@ -13,6 +17,7 @@
   width: 100%;
   min-width: min(15rem, 100%);
   max-width: 100%;
+  min-height: 0;
   max-height: 25rem;
   padding: 0.25rem;
   overflow-x: hidden;

--- a/packages/react/src/components/slash-menu.test.tsx
+++ b/packages/react/src/components/slash-menu.test.tsx
@@ -203,6 +203,25 @@ describe('SlashMenu', () => {
     expect(ref.current?.getMarkdown()).toBe('Hello /\n')
   })
 
+  it('fits inside a short viewport instead of overflowing it', async () => {
+    // Shorter than the popup's natural 25rem, so the positioner's
+    // viewport-fitting max-height must constrain it.
+    await page.viewport(375, 300)
+    try {
+      await render(<ProseKitEditor />)
+      await pmRoot.click()
+      await userEvent.keyboard('/')
+      await expect.element(menu).toBeVisible()
+
+      await expect.poll(() => menu.element().getBoundingClientRect().top).toBeGreaterThanOrEqual(0)
+      await expect
+        .poll(() => menu.element().getBoundingClientRect().bottom)
+        .toBeLessThanOrEqual(300)
+    } finally {
+      await page.viewport(900, 600)
+    }
+  })
+
   it('omits block items inside a table cell but keeps inline items', async () => {
     const ref = createRef<EditorHandle>()
     await render(<ProseKitEditor ref={ref} initialMarkdown={'| a | b |\n| --- | --- |\n|  |  |'} />)


### PR DESCRIPTION
## What

Fixes the slash/tag/wikilink menu popup overflowing the viewport when vertical space is short — e.g. on mobile with the keyboard open, where the menu rendered past the top of the screen and got cut off.

## Why

The autocomplete positioner's viewport-fitting logic (`fitViewport`, on by default) writes an inline `max-height` onto the **positioner** element when the menu doesn't fit. But `.Positioner` was `display: block` with `overflow: visible`, and the `.Popup` child kept its own fixed `max-height: 25rem` — a block child doesn't inherit its parent's max-height, so the popup ignored the constraint, overflowed the positioner box, and escaped the viewport. floating-ui believed everything fit because it only measures the positioner.

Repro (before the fix, 375×500 viewport, caret mid-screen): positioner flips to `top` and gets `max-height: 318px`, sitting correctly inside the viewport — while the popup renders 400px tall, overflowing the positioner by 82px and covering the caret.

## How

Make `.Positioner` a flex column and give `.Popup` `min-height: 0`, so the popup shrinks to the positioner's fitted max-height and scrolls internally. The stylesheet is shared by the slash, tag, and wikilink menus, so all three are fixed.

## Notes for review

- New regression test in `slash-menu.test.tsx` opens the menu in a 375×300 viewport and asserts the popup stays within it; it fails without the CSS change (popup bottom lands ~100px past the viewport) and passes with it.
- There may be a residual upstream factor on iOS (floating-ui's handling of the visual-viewport offset while the keyboard is open), but this fixes the popup escaping the fitted constraint, which is the dominant failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)