### PR TITLE
fix: keep empty paragraphs across the markdown roundtrip

### DIFF
--- a/packages/core/src/converters/check-roundtrip.test.ts
+++ b/packages/core/src/converters/check-roundtrip.test.ts
@@ -58,12 +58,13 @@ describe('checkRoundTrip', () => {
     '    indented',
     // a tilde fence keeps its fence character
     '~~~\ntilde\n~~~',
+    // extra blank lines round-trip as empty paragraphs
+    'a\n\n\nb',
   ])('reports exact for %j', (markdown) => {
     expect(checkRoundTrip(markdown)).toBe('exact')
   })
 
   it.each([
-    'a\n\n\nb', // extra blank lines collapse to one
     '- a\n\n- b', // a loose list serializes tight
     '- [ ] Asdf\n- [ ]\n- [ ] ', // a trailing space on an empty task is normalized away
     'trailing spaces   ', // trailing whitespace is insignificant

--- a/packages/core/src/converters/md-to-pm.test.ts
+++ b/packages/core/src/converters/md-to-pm.test.ts
@@ -36,6 +36,27 @@ function tableShape(markdown: string): Array<Array<{ type: string; text: string 
 }
 
 describe('markdownToDoc', () => {
+  it('materializes empty paragraphs from a blank-line run', () => {
+    expect(markdownToDoc('a\n\n\n\nb').toJSON()).toEqual({
+      type: 'doc',
+      attrs: { frontmatter: null },
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'a' }] },
+        { type: 'paragraph' },
+        { type: 'paragraph' },
+        { type: 'paragraph', content: [{ type: 'text', text: 'b' }] },
+      ],
+    })
+  })
+
+  it('skips leading and trailing blank lines', () => {
+    expect(markdownToDoc('\n\na\n\n\n').toJSON()).toEqual({
+      type: 'doc',
+      attrs: { frontmatter: null },
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'a' }] }],
+    })
+  })
+
   it('keeps a heading', () => {
     expect(markdownToDoc('# Hello').toJSON()).toEqual({
       type: 'doc',
@@ -230,7 +251,7 @@ describe('markdownToDoc', () => {
 
   it('keeps different markers for tasks', () => {
     // `-` parses as a square checkbox task, `+` as a circle checkbox task.
-    expect(markdownToDoc('- [x] Square Task\n\n\n+ [ ] Circle Task').toJSON()).toEqual({
+    expect(markdownToDoc('- [x] Square Task\n\n+ [ ] Circle Task').toJSON()).toEqual({
       type: 'doc',
       attrs: { frontmatter: null },
       content: [

--- a/packages/core/src/converters/md-to-pm.ts
+++ b/packages/core/src/converters/md-to-pm.ts
@@ -13,6 +13,7 @@ import {
   CHAR_EQUAL,
   CHAR_HASH,
   CHAR_HYPHEN_MINUS,
+  CHAR_LINE_FEED,
   CHAR_LOWERCASE_X,
   CHAR_PLUS,
   CHAR_RIGHT_PARENTHESIS,
@@ -99,11 +100,35 @@ function collectBlocks(
 ): ProseMirrorNode[] {
   const out: ProseMirrorNode[] = []
   if (!cursor.firstChild()) return out
+  let previousTo: number | undefined
   do {
+    if (previousTo != null) appendGapParagraphs(out, nodes, text, previousTo, cursor.from)
+    previousTo = cursor.to
     out.push(...convertBlock(nodes, cursor, text))
   } while (cursor.nextSibling())
   cursor.parent()
   return out
+}
+
+/**
+ * Blank lines between two sibling blocks are content: a run of K blank lines
+ * is one block separator plus K-1 empty paragraphs. The gap slice between the
+ * siblings' ranges holds only line terminators and structural prefixes
+ * (indent, blockquote `>`), so counting newlines is enough - the gap has K+1
+ * of them (the previous block's own terminator plus one per blank line).
+ */
+function appendGapParagraphs(
+  out: ProseMirrorNode[],
+  nodes: TypedNodeBuilders,
+  text: string,
+  gapFrom: number,
+  gapTo: number,
+): void {
+  let newlineCount = 0
+  for (let i = gapFrom; i < gapTo; i++) {
+    if (text.charCodeAt(i) === CHAR_LINE_FEED) newlineCount++
+  }
+  for (let i = 2; i < newlineCount; i++) out.push(nodes.paragraph())
 }
 
 function convertBlock(
@@ -364,8 +389,11 @@ function convertBlockquote(
 ): ProseMirrorNode {
   const content: ProseMirrorNode[] = []
   if (cursor.firstChild()) {
+    let previousTo: number | undefined
     do {
       if (cursor.type.id === LEZER_NODE_IDS.QuoteMark) continue
+      if (previousTo != null) appendGapParagraphs(content, nodes, text, previousTo, cursor.from)
+      previousTo = cursor.to
       content.push(...convertBlock(nodes, cursor, text))
     } while (cursor.nextSibling())
     cursor.parent()

--- a/packages/core/src/converters/pm-to-md.test.ts
+++ b/packages/core/src/converters/pm-to-md.test.ts
@@ -17,6 +17,21 @@ describe('docToMarkdown', () => {
     expect(markdown).toBe('hello world\n')
   })
 
+  it('keeps an empty paragraph between paragraphs', () => {
+    const doc = n.doc(n.paragraph('a'), n.paragraph(), n.paragraph('b'))
+    expect(docToMarkdown(doc)).toBe('a\n\n\nb\n')
+  })
+
+  it('drops a leading empty paragraph', () => {
+    const doc = n.doc(n.paragraph(), n.paragraph('a'))
+    expect(docToMarkdown(doc)).toBe('a\n')
+  })
+
+  it('drops a trailing empty paragraph', () => {
+    const doc = n.doc(n.paragraph('a'), n.paragraph())
+    expect(docToMarkdown(doc)).toBe('a\n')
+  })
+
   it('keeps a level-1 heading', () => {
     const doc = n.doc(n.heading({ level: 1 }, 'Level 1'))
     const markdown = docToMarkdown(doc)

--- a/packages/core/src/converters/pm-to-md.ts
+++ b/packages/core/src/converters/pm-to-md.ts
@@ -137,6 +137,25 @@ class MdOut {
     }
   }
 
+  /**
+   * End a block that owns no line of its own (an empty paragraph): flush the
+   * blank line owed by the previous block now and owe the next block a fresh
+   * one, so each empty block yields one extra blank line. A marker-bearing
+   * block (an empty list item's `- `) still owns its first line and falls
+   * through to `closeBlock`. At the very start of the output there is no
+   * blank line to flush or owe - leading empty blocks vanish, mirroring the
+   * parser, which materializes empty paragraphs only between sibling blocks.
+   */
+  closeEmptyBlock(): void {
+    if (!this.atLineStart || this.pendingFirst !== null) {
+      this.closeBlock()
+      return
+    }
+    if (this.parts.length === 0) return
+    this.emitDeferredBlankLine()
+    this.deferredBlankPrefix = this.linePrefix
+  }
+
   /** End the current block; the next write gets a blank line before it. */
   closeBlock(): void {
     // An empty block (e.g. an empty list item `- `) still owns a line: flush
@@ -215,6 +234,10 @@ function emit(node: ProseMirrorNode, out: MdOut): void {
       emitBlockChildren(node, out)
       return
     case 'paragraph':
+      if (node.childCount === 0) {
+        out.closeEmptyBlock()
+        return
+      }
       emitInlineChildren(node, out)
       out.closeBlock()
       return

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
+import { setupFixture } from '../testing/index.ts'
+
 import { markdownToDoc } from './md-to-pm.ts'
 import { docToMarkdown } from './pm-to-md.ts'
+
+const fixture = setupFixture({ mount: false })
+const { n } = fixture
 
 function roundtrip(markdown: string, options?: { frontmatter?: boolean }): string {
   return docToMarkdown(markdownToDoc(markdown, options), options)
@@ -752,6 +757,18 @@ describe('escapes and whitespace', () => {
   it.fails('keeps internal blank-line runs', () => {
     const md = ['a', '', '', '', 'b'].join('\n')
     expect(roundtrip(md)).toBe(md + '\n')
+  })
+
+  it.fails('keeps typed empty paragraphs', () => {
+    const doc = n.doc(
+      n.paragraph('Foo'),
+      n.paragraph(),
+      n.paragraph(),
+      n.paragraph(),
+      n.paragraph('Bar'),
+    )
+    const reparsed = markdownToDoc(docToMarkdown(doc))
+    expect(reparsed.toJSON()).toEqual(doc.toJSON())
   })
 
   it('keeps YAML frontmatter', () => {

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -287,6 +287,10 @@ describe('blockquotes', () => {
     expect(roundtrip('> p1\n>\n> p2')).toBe('> p1\n>\n> p2\n')
   })
 
+  it('keeps an inner blank-line run', () => {
+    expect(roundtrip('> p1\n>\n>\n> p2')).toBe('> p1\n>\n>\n> p2\n')
+  })
+
   it('keeps an empty quote marker', () => {
     expect(roundtrip('>')).toBe('>\n')
   })
@@ -754,12 +758,12 @@ describe('escapes and whitespace', () => {
     expect(roundtrip('   ')).toBe('   \n')
   })
 
-  it.fails('keeps internal blank-line runs', () => {
+  it('keeps internal blank-line runs', () => {
     const md = ['a', '', '', '', 'b'].join('\n')
     expect(roundtrip(md)).toBe(md + '\n')
   })
 
-  it.fails('keeps typed empty paragraphs', () => {
+  it('keeps typed empty paragraphs', () => {
     const doc = n.doc(
       n.paragraph('Foo'),
       n.paragraph(),
@@ -794,6 +798,11 @@ describe('escapes and whitespace', () => {
 describe('mixed structures', () => {
   it('keeps a paragraph-list-paragraph sequence', () => {
     const md = ['para', '', '- list', '', 'para2'].join('\n')
+    expect(roundtrip(md)).toBe(md + '\n')
+  })
+
+  it('keeps a blank-line run after a list', () => {
+    const md = ['- a', '', '', 'x'].join('\n')
     expect(roundtrip(md)).toBe(md + '\n')
   })
 
@@ -847,6 +856,16 @@ describe('idempotency', () => {
 
   it('keeps a marker-gap bullet stable', () => {
     const once = roundtrip('-  x')
+    expect(roundtrip(once)).toBe(once)
+  })
+
+  it('keeps a blank-line run stable', () => {
+    const once = roundtrip(['a', '', '', '', 'b'].join('\n'))
+    expect(roundtrip(once)).toBe(once)
+  })
+
+  it('keeps a normalized leading blank line stable', () => {
+    const once = roundtrip('\n\nhello')
     expect(roundtrip(once)).toBe(once)
   })
 


### PR DESCRIPTION
Typed empty paragraphs vanished after a markdown round trip: the serializer emitted nothing for them, and the parser collapsed blank-line runs between blocks. A run of K blank lines now maps to one block separator plus K-1 empty paragraphs on both sides, covering the doc top level and blockquote children; leading and trailing runs still normalize away.