### PR TITLE
fix: make `Mod-ArrowUp` reach the document start when the doc begins with a list

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -53,32 +53,36 @@ const markdown = docToMarkdown(editor.state.doc)
 
 `Mod` is Cmd on macOS and Ctrl elsewhere. Each formatting shortcut inserts or removes the literal Markdown delimiters around the selection; each heading shortcut toggles the current block to that level (or back to a paragraph).
 
-| Key               | Action                                                    | Markdown            |
-| ----------------- | --------------------------------------------------------- | ------------------- |
-| `Mod-B`           | Bold                                                      | `**bold**`          |
-| `Mod-I`           | Italic                                                    | `*italic*`          |
-| `Mod-E`           | Inline code                                               | `` `code` ``        |
-| `Mod-Shift-X`     | Strikethrough                                             | `~~strikethrough~~` |
-| `Mod-Shift-H`     | Highlight                                                 | `==highlight==`     |
-| `Mod-K`           | Link                                                      | `[text](url)`       |
-| `Mod-Shift-K`     | Insert a wikilink                                         | `[[target]]`        |
-| `Mod-1`           | Heading 1                                                 | `# heading`         |
-| `Mod-2`           | Heading 2                                                 | `## heading`        |
-| `Mod-3`           | Heading 3                                                 | `### heading`       |
-| `Mod-4`           | Heading 4                                                 | `#### heading`      |
-| `Mod-5`           | Heading 5                                                 | `##### heading`     |
-| `Mod-6`           | Heading 6                                                 | `###### heading`    |
-| `Mod-.`           | Fold or unfold a bullet                                   |                     |
-| `Mod-Enter`       | Follow the link under the caret, or cycle a checkbox task | `- [ ]` / `- [x]`   |
-| `Mod-Shift-Enter` | Cycle a circle checkbox task                              | `+ [ ]` / `+ [x]`   |
-| `Mod-Shift-7`     | Ordered list                                              | `1. item`           |
-| `Mod-Shift-8`     | Bullet list                                               | `- item`            |
-| `Mod-Shift-9`     | Checkbox task list                                        | `- [ ] item`        |
-| `Alt-ArrowUp`     | Move the block or list item up                            |                     |
-| `Alt-ArrowDown`   | Move the block or list item down                          |                     |
-| `Escape`          | Collapse the selection                                    |                     |
+| Key                    | Action                                                    | Markdown            |
+| ---------------------- | --------------------------------------------------------- | ------------------- |
+| `Mod-B`                | Bold                                                      | `**bold**`          |
+| `Mod-I`                | Italic                                                    | `*italic*`          |
+| `Mod-E`                | Inline code                                               | `` `code` ``        |
+| `Mod-Shift-X`          | Strikethrough                                             | `~~strikethrough~~` |
+| `Mod-Shift-H`          | Highlight                                                 | `==highlight==`     |
+| `Mod-K`                | Link                                                      | `[text](url)`       |
+| `Mod-Shift-K`          | Insert a wikilink                                         | `[[target]]`        |
+| `Mod-1`                | Heading 1                                                 | `# heading`         |
+| `Mod-2`                | Heading 2                                                 | `## heading`        |
+| `Mod-3`                | Heading 3                                                 | `### heading`       |
+| `Mod-4`                | Heading 4                                                 | `#### heading`      |
+| `Mod-5`                | Heading 5                                                 | `##### heading`     |
+| `Mod-6`                | Heading 6                                                 | `###### heading`    |
+| `Mod-.`                | Fold or unfold a bullet                                   |                     |
+| `Mod-Enter`            | Follow the link under the caret, or cycle a checkbox task | `- [ ]` / `- [x]`   |
+| `Mod-Shift-Enter`      | Cycle a circle checkbox task                              | `+ [ ]` / `+ [x]`   |
+| `Mod-Shift-7`          | Ordered list                                              | `1. item`           |
+| `Mod-Shift-8`          | Bullet list                                               | `- item`            |
+| `Mod-Shift-9`          | Checkbox task list                                        | `- [ ] item`        |
+| `Alt-ArrowUp`          | Move the block or list item up                            |                     |
+| `Alt-ArrowDown`        | Move the block or list item down                          |                     |
+| `Meta-ArrowUp`         | Move the caret to the document start                      |                     |
+| `Meta-ArrowDown`       | Move the caret to the document end                        |                     |
+| `Shift-Meta-ArrowUp`   | Select to the document start                              |                     |
+| `Shift-Meta-ArrowDown` | Select to the document end                                |                     |
+| `Escape`               | Collapse the selection                                    |                     |
 
-The list-type toggles wrap the current block, convert a list of a different kind in place, and unwrap a list of the same kind back to a paragraph. `Mod-Shift-7/8/9` follow the physical digit key, so they work on layouts where Shift+digit types punctuation. `Alt-ArrowUp`/`Alt-ArrowDown` move a list item together with its nested children, or swap a non-list block with its neighbor. Typing `[` over a selection wraps it into an open wikilink (`[[selection`) with the wikilink menu searching it.
+The list-type toggles wrap the current block, convert a list of a different kind in place, and unwrap a list of the same kind back to a paragraph. `Mod-Shift-7/8/9` follow the physical digit key, so they work on layouts where Shift+digit types punctuation. `Alt-ArrowUp`/`Alt-ArrowDown` move a list item together with its nested children, or swap a non-list block with its neighbor. The `Meta-Arrow` document-boundary motions (Cmd on macOS) are bound explicitly because browsers do not reliably perform the native move (WebKit gives up when the document starts with a list marker). Typing `[` over a selection wraps it into an open wikilink (`[[selection`) with the wikilink menu searching it.
 
 `EDITOR_KEY_BINDINGS` is a literal (`as const`) object mapping every key above to its description, for host settings UIs and keybinding-collision checks.
 

--- a/packages/core/src/extensions/extension.ts
+++ b/packages/core/src/extensions/extension.ts
@@ -32,6 +32,7 @@ import { defineMarkMode, type MarkMode } from './mark-mode.ts'
 import { defineMoveBlock } from './move-block.ts'
 import { defineMeowdownParagraph } from './paragraph.ts'
 import { definePendingReplacement } from './pending-replacement.ts'
+import { defineSelectDocBoundary } from './select-doc-boundary.ts'
 import { defineTable } from './table.ts'
 import { defineVirtualCaret } from './virtual-caret.ts'
 import { defineWikilink } from './wikilink.ts'
@@ -58,6 +59,7 @@ function defineEditorExtensionImpl(options: EditorExtensionOptions) {
     defineCodeBlockSyntaxHighlight(),
     defineEscapeCollapse(),
     defineMoveBlock(),
+    defineSelectDocBoundary(),
     defineInlineMarkPlugin(options),
     defineInlineToggle(),
     defineLinkCommands(),

--- a/packages/core/src/extensions/key-bindings.test.ts
+++ b/packages/core/src/extensions/key-bindings.test.ts
@@ -9,6 +9,8 @@ describe('EDITOR_KEY_BINDINGS', () => {
         "Alt-ArrowDown": "Move the block or list item down",
         "Alt-ArrowUp": "Move the block or list item up",
         "Escape": "Collapse the selection",
+        "Meta-ArrowDown": "Move the caret to the document end",
+        "Meta-ArrowUp": "Move the caret to the document start",
         "Mod-.": "Fold or unfold a bullet",
         "Mod-1": "Heading 1",
         "Mod-2": "Heading 2",
@@ -28,6 +30,8 @@ describe('EDITOR_KEY_BINDINGS', () => {
         "Mod-e": "Inline code",
         "Mod-i": "Italic",
         "Mod-k": "Link",
+        "Shift-Meta-ArrowDown": "Select to the document end",
+        "Shift-Meta-ArrowUp": "Select to the document start",
       }
     `)
   })

--- a/packages/core/src/extensions/key-bindings.ts
+++ b/packages/core/src/extensions/key-bindings.ts
@@ -21,5 +21,9 @@ export const EDITOR_KEY_BINDINGS = {
   'Mod-Shift-9': 'Checkbox task list',
   'Alt-ArrowUp': 'Move the block or list item up',
   'Alt-ArrowDown': 'Move the block or list item down',
+  'Meta-ArrowUp': 'Move the caret to the document start',
+  'Meta-ArrowDown': 'Move the caret to the document end',
+  'Shift-Meta-ArrowUp': 'Select to the document start',
+  'Shift-Meta-ArrowDown': 'Select to the document end',
   Escape: 'Collapse the selection',
 } as const

--- a/packages/core/src/extensions/select-doc-boundary.test.ts
+++ b/packages/core/src/extensions/select-doc-boundary.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+
+import { setupFixture, type Fixture } from '../testing/index.ts'
+
+import { defineExitBoundaryHandler, type ExitBoundaryHandler } from './exit-boundary.ts'
+
+// The Meta-Arrow document-boundary motions are a macOS convention, so these
+// tests only run on Apple hosts (the mac-chromium and mac-webkit CI jobs).
+const applePlatform = /Mac|iP(hone|[oa]d)/.test(navigator.platform)
+
+function setup(): Fixture {
+  return setupFixture({ extensionOptions: { markMode: 'hide' } })
+}
+
+describe.runIf(applePlatform)('Meta-ArrowUp / Meta-ArrowDown', () => {
+  it('moves the caret to the document start when the document begins with a task list', async () => {
+    using fixture = setup()
+    const { n } = fixture
+    fixture.set(
+      n.doc(
+        n.list({ kind: 'task', checked: false }, n.paragraph('todo one')),
+        n.list({ kind: 'task', checked: false }, n.paragraph('todo two')),
+        n.paragraph('tail<a>'),
+      ),
+    )
+    fixture.view.focus()
+    await userEvent.keyboard('{Meta>}{ArrowUp}{/Meta}')
+    const selection = fixture.state.selection
+    expect(selection.empty).toBe(true)
+    expect(selection.$head.parent.textContent).toBe('todo one')
+    expect(selection.$head.parentOffset).toBe(0)
+  })
+
+  it('moves the caret to the document start when the document begins with a bullet list', async () => {
+    using fixture = setup()
+    const { n } = fixture
+    fixture.set(
+      n.doc(
+        n.list({ kind: 'bullet' }, n.paragraph('bullet one')),
+        n.paragraph('middle'),
+        n.paragraph('tail<a>'),
+      ),
+    )
+    fixture.view.focus()
+    await userEvent.keyboard('{Meta>}{ArrowUp}{/Meta}')
+    const selection = fixture.state.selection
+    expect(selection.empty).toBe(true)
+    expect(selection.$head.parent.textContent).toBe('bullet one')
+    expect(selection.$head.parentOffset).toBe(0)
+  })
+
+  it('moves the caret to the document start in a plain paragraph document, even right after focus', async () => {
+    using fixture = setup()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('alpha'), n.paragraph('beta<a>')))
+    fixture.view.focus()
+    await userEvent.keyboard('{Meta>}{ArrowUp}{/Meta}')
+    const selection = fixture.state.selection
+    expect(selection.empty).toBe(true)
+    expect(selection.head).toBe(1)
+  })
+
+  it('rests before a hidden run when the document starts with one', async () => {
+    using fixture = setup()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('**bold** first'), n.paragraph('tail<a>')))
+    fixture.view.focus()
+    await userEvent.keyboard('{Meta>}{ArrowUp}{/Meta}')
+    const selection = fixture.state.selection
+    expect(selection.empty).toBe(true)
+    expect(selection.head).toBe(1)
+  })
+
+  it('moves the caret to the document end when the document ends with a task list', async () => {
+    using fixture = setup()
+    const { n } = fixture
+    fixture.set(
+      n.doc(
+        n.paragraph('<a>alpha'),
+        n.list({ kind: 'task', checked: false }, n.paragraph('todo one')),
+        n.list({ kind: 'task', checked: false }, n.paragraph('todo two')),
+      ),
+    )
+    fixture.view.focus()
+    await userEvent.keyboard('{Meta>}{ArrowDown}{/Meta}')
+    const selection = fixture.state.selection
+    expect(selection.empty).toBe(true)
+    expect(selection.$head.parent.textContent).toBe('todo two')
+    expect(selection.$head.parentOffset).toBe(selection.$head.parent.content.size)
+  })
+
+  it('extends the selection to the document start on Shift-Meta-ArrowUp', async () => {
+    using fixture = setup()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('alpha'), n.paragraph('beta<a>')))
+    fixture.view.focus()
+    const anchor = fixture.state.selection.anchor
+    await userEvent.keyboard('{Shift>}{Meta>}{ArrowUp}{/Meta}{/Shift}')
+    const selection = fixture.state.selection
+    expect(selection.anchor).toBe(anchor)
+    expect(selection.head).toBe(1)
+  })
+
+  it('extends the selection to the document end on Shift-Meta-ArrowDown', async () => {
+    using fixture = setup()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>alpha'), n.paragraph('beta')))
+    fixture.view.focus()
+    const anchor = fixture.state.selection.anchor
+    await userEvent.keyboard('{Shift>}{Meta>}{ArrowDown}{/Meta}{/Shift}')
+    const selection = fixture.state.selection
+    expect(selection.anchor).toBe(anchor)
+    expect(selection.head).toBe(fixture.doc.content.size - 1)
+  })
+
+  it('does not fire the exit-boundary handler from the document start', async () => {
+    const onExitBoundary = vi.fn<ExitBoundaryHandler>()
+    using fixture = setup()
+    fixture.editor.use(defineExitBoundaryHandler(onExitBoundary))
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>alpha'), n.paragraph('beta')))
+    fixture.view.focus()
+    await userEvent.keyboard('{Meta>}{ArrowUp}{/Meta}')
+    expect(onExitBoundary).not.toHaveBeenCalled()
+    expect(fixture.state.selection.head).toBe(1)
+  })
+})

--- a/packages/core/src/extensions/select-doc-boundary.test.ts
+++ b/packages/core/src/extensions/select-doc-boundary.test.ts
@@ -5,15 +5,11 @@ import { setupFixture, type Fixture } from '../testing/index.ts'
 
 import { defineExitBoundaryHandler, type ExitBoundaryHandler } from './exit-boundary.ts'
 
-// The Meta-Arrow document-boundary motions are a macOS convention, so these
-// tests only run on Apple hosts (the mac-chromium and mac-webkit CI jobs).
-const applePlatform = /Mac|iP(hone|[oa]d)/.test(navigator.platform)
-
 function setup(): Fixture {
   return setupFixture({ extensionOptions: { markMode: 'hide' } })
 }
 
-describe.runIf(applePlatform)('Meta-ArrowUp / Meta-ArrowDown', () => {
+describe('Meta-ArrowUp / Meta-ArrowDown', () => {
   it('moves the caret to the document start when the document begins with a task list', async () => {
     using fixture = setup()
     const { n } = fixture

--- a/packages/core/src/extensions/select-doc-boundary.ts
+++ b/packages/core/src/extensions/select-doc-boundary.ts
@@ -19,19 +19,15 @@ function selectDocBoundary(direction: -1 | 1, extend: boolean): Command {
  * move the caret to the document start / end; the Shift variants extend the
  * selection there). Bound explicitly instead of relying on the browser's
  * native handling: WebKit gives up the native move when the document starts
- * with a `contenteditable=false` element (a list marker or checkbox), and
- * prosemirror-view rolls a native move to the document start back within
- * 200ms of a focus event.
+ * with a `contenteditable=false` element (a list marker or checkbox).
+ *
+ * See also https://bugs.webkit.org/show_bug.cgi?id=108987
  */
 export function defineSelectDocBoundary(): PlainExtension {
-  return defineKeymap(
-    isApple
-      ? {
-          'Meta-ArrowUp': selectDocBoundary(-1, false),
-          'Meta-ArrowDown': selectDocBoundary(1, false),
-          'Shift-Meta-ArrowUp': selectDocBoundary(-1, true),
-          'Shift-Meta-ArrowDown': selectDocBoundary(1, true),
-        }
-      : {},
-  )
+  return defineKeymap({
+    'Meta-ArrowUp': selectDocBoundary(-1, false),
+    'Meta-ArrowDown': selectDocBoundary(1, false),
+    'Shift-Meta-ArrowUp': selectDocBoundary(-1, true),
+    'Shift-Meta-ArrowDown': selectDocBoundary(1, true),
+  })
 }

--- a/packages/core/src/extensions/select-doc-boundary.ts
+++ b/packages/core/src/extensions/select-doc-boundary.ts
@@ -1,4 +1,4 @@
-import { defineKeymap, isApple, type PlainExtension } from '@prosekit/core'
+import { defineKeymap, type PlainExtension } from '@prosekit/core'
 import { Selection, TextSelection, type Command } from '@prosekit/pm/state'
 
 function selectDocBoundary(direction: -1 | 1, extend: boolean): Command {

--- a/packages/core/src/extensions/select-doc-boundary.ts
+++ b/packages/core/src/extensions/select-doc-boundary.ts
@@ -1,4 +1,4 @@
-import { defineKeymap, type PlainExtension } from '@prosekit/core'
+import { defineKeymap, isApple, type PlainExtension } from '@prosekit/core'
 import { Selection, TextSelection, type Command } from '@prosekit/pm/state'
 
 function selectDocBoundary(direction: -1 | 1, extend: boolean): Command {
@@ -24,10 +24,14 @@ function selectDocBoundary(direction: -1 | 1, extend: boolean): Command {
  * 200ms of a focus event.
  */
 export function defineSelectDocBoundary(): PlainExtension {
-  return defineKeymap({
-    'Meta-ArrowUp': selectDocBoundary(-1, false),
-    'Meta-ArrowDown': selectDocBoundary(1, false),
-    'Shift-Meta-ArrowUp': selectDocBoundary(-1, true),
-    'Shift-Meta-ArrowDown': selectDocBoundary(1, true),
-  })
+  return defineKeymap(
+    isApple
+      ? {
+          'Meta-ArrowUp': selectDocBoundary(-1, false),
+          'Meta-ArrowDown': selectDocBoundary(1, false),
+          'Shift-Meta-ArrowUp': selectDocBoundary(-1, true),
+          'Shift-Meta-ArrowDown': selectDocBoundary(1, true),
+        }
+      : {},
+  )
 }

--- a/packages/core/src/extensions/select-doc-boundary.ts
+++ b/packages/core/src/extensions/select-doc-boundary.ts
@@ -1,0 +1,33 @@
+import { defineKeymap, type PlainExtension } from '@prosekit/core'
+import { Selection, TextSelection, type Command } from '@prosekit/pm/state'
+
+function selectDocBoundary(direction: -1 | 1, extend: boolean): Command {
+  return (state, dispatch) => {
+    const boundary = direction < 0 ? Selection.atStart(state.doc) : Selection.atEnd(state.doc)
+    const selection = extend
+      ? TextSelection.between(state.selection.$anchor, boundary.$head)
+      : boundary
+    if (!state.selection.eq(selection)) {
+      dispatch?.(state.tr.setSelection(selection).scrollIntoView())
+    }
+    return true
+  }
+}
+
+/**
+ * Binds the macOS document-boundary motions (`Meta-ArrowUp` / `Meta-ArrowDown`
+ * move the caret to the document start / end; the Shift variants extend the
+ * selection there). Bound explicitly instead of relying on the browser's
+ * native handling: WebKit gives up the native move when the document starts
+ * with a `contenteditable=false` element (a list marker or checkbox), and
+ * prosemirror-view rolls a native move to the document start back within
+ * 200ms of a focus event.
+ */
+export function defineSelectDocBoundary(): PlainExtension {
+  return defineKeymap({
+    'Meta-ArrowUp': selectDocBoundary(-1, false),
+    'Meta-ArrowDown': selectDocBoundary(1, false),
+    'Shift-Meta-ArrowUp': selectDocBoundary(-1, true),
+    'Shift-Meta-ArrowDown': selectDocBoundary(1, true),
+  })
+}


### PR DESCRIPTION
Bind the macOS document-boundary caret motions explicitly, because the native `Cmd-ArrowUp` move silently fails when the document starts with a list (WebKit: any list; Chromium: a task list) and prosemirror-view rolls the move back within 200ms of a focus event.



https://github.com/user-attachments/assets/47e5d569-ad74-4bcf-a3a7-46c0388b97bc


https://github.com/user-attachments/assets/58d30362-afe5-48b9-94c1-be28768952b5

