### PR TITLE
fix: reveal every marker of nested inline units in focus mode

### DIFF
--- a/packages/core/src/extensions/get-link-unit-at.test.ts
+++ b/packages/core/src/extensions/get-link-unit-at.test.ts
@@ -71,4 +71,24 @@ describe('getLinkUnitAt', () => {
     fixture.set(n.doc(n.paragraph('plain text')))
     expect(getLinkUnitAt(fixture.state, findText(fixture.doc, 'plain') + 1)).toBeUndefined()
   })
+
+  it('returns undefined inside a non-link unit', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('**bold**')))
+    expect(getLinkUnitAt(fixture.state, findText(fixture.doc, 'bold') + 1)).toBeUndefined()
+  })
+
+  it('resolves the link unit when the link nests inside an emphasis', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    // The italic pack covers the whole `*...*` and sits before the link pack
+    // in the mark set; the lookup must pick the pack by key, not by set order.
+    fixture.set(n.doc(n.paragraph('*[a](http://x.test)*')))
+    const link = getLinkUnitAt(fixture.state, findText(fixture.doc, 'a'))!
+    expect(link.href).toBe('http://x.test')
+    expect(fixture.doc.textBetween(link.unit.from, link.unit.to)).toBe('[a](http://x.test)')
+    expect(fixture.doc.textBetween(link.label!.from, link.label!.to)).toBe('a')
+    expect(fixture.doc.textBetween(link.dest!.from, link.dest!.to)).toBe('http://x.test')
+  })
 })

--- a/packages/core/src/extensions/get-link-unit-at.ts
+++ b/packages/core/src/extensions/get-link-unit-at.ts
@@ -56,10 +56,14 @@ function lastMarkRunIn(
  */
 export function getLinkUnitAt(state: EditorState, pos: number): LinkUnit | undefined {
   const linkText = getMarkRangeAt(state, pos, 'mdLinkText')
-  const pack = getMarkRangeAt(state, pos, 'mdPack')
-  // `[text](url)` carries `mdPack` over the whole unit; bare/GFM autolinks carry
-  // only `mdLinkText`. Prefer the wider `mdPack` unit, falling back to the link
-  // text run so autolinks still resolve.
+  // A position inside nested units carries one `mdPack` per level and the mark
+  // set's order follows edit history, so select the pack by `key` instead of
+  // taking whichever sits first. `[text](url)` and `<url>` carry a pack over
+  // the whole unit; bare/www autolinks carry only `mdLinkText`, so fall back to
+  // that run.
+  const pack =
+    getMarkRangeAt(state, pos, 'mdPack', { key: 'link' } satisfies Partial<MdPackAttrs>) ??
+    getMarkRangeAt(state, pos, 'mdPack', { key: 'autolink' } satisfies Partial<MdPackAttrs>)
   const unit = pack ?? linkText
   if (!unit) return
 

--- a/packages/core/src/extensions/get-mark-range-at.ts
+++ b/packages/core/src/extensions/get-mark-range-at.ts
@@ -1,4 +1,5 @@
 import { getMarkRange, type MarkRange } from '@prosekit/core'
+import type { Attrs } from '@prosekit/pm/model'
 import type { EditorState } from '@prosekit/pm/state'
 
 import type { MarkName } from './mark-names.ts'
@@ -6,16 +7,19 @@ import type { MarkName } from './mark-names.ts'
 /**
  * The `markName` run covering `pos`, or `undefined` when `pos` is not inside a
  * non-code textblock. Centralizes the guard the click finders share: marks only
- * carry inline syntax in regular textblocks, never in code blocks.
+ * carry inline syntax in regular textblocks, never in code blocks. `attrs`
+ * narrows the match to marks whose attrs contain it, which is how callers pick
+ * one `mdPack` level out of a nested unit's stack.
  */
 export function getMarkRangeAt(
   state: EditorState,
   pos: number,
   markName: MarkName,
+  attrs?: Attrs,
 ): MarkRange | undefined {
   const size = state.doc.content.size
   if (pos < 0 || pos > size) return
   const $pos = state.doc.resolve(pos)
   if (!$pos.parent.isTextblock || $pos.parent.type.spec.code) return
-  return getMarkRange($pos, markName)
+  return getMarkRange($pos, markName, attrs)
 }

--- a/packages/core/src/extensions/hidden-run.test.ts
+++ b/packages/core/src/extensions/hidden-run.test.ts
@@ -8,6 +8,7 @@ import {
   getHiddenRunAfter,
   getHiddenRunBefore,
   getInnermostPackRangeAt,
+  getOutermostPackRangeAt,
   getRestPosition,
   getUnitMarkerRuns,
   isHiddenChar,
@@ -116,6 +117,27 @@ describe('getInnermostPackRangeAt', () => {
     const posX = findText(fixture.doc, 'x')
     const pack = getInnermostPackRangeAt(fixture.state, posX + 3)
     expect(runText(fixture, pack)).toBe('***x***')
+  })
+})
+
+describe('getOutermostPackRangeAt', () => {
+  it('resolves a nested unit character to the outer unit', () => {
+    using fixture = setup('**a *b* c**')
+    const posB = findText(fixture.doc, 'b')
+    const pack = getOutermostPackRangeAt(fixture.state, posB)
+    expect(runText(fixture, pack)).toBe('**a *b* c**')
+  })
+
+  it('resolves the text of a triple unit to the outer unit', () => {
+    using fixture = setup('***x***')
+    const posX = findText(fixture.doc, 'x')
+    const pack = getOutermostPackRangeAt(fixture.state, posX)
+    expect(runText(fixture, pack)).toBe('***x***')
+  })
+
+  it('is undefined on plain text', () => {
+    using fixture = setup('plain **x**')
+    expect(getOutermostPackRangeAt(fixture.state, 1)).toBeUndefined()
   })
 })
 

--- a/packages/core/src/extensions/hidden-run.ts
+++ b/packages/core/src/extensions/hidden-run.ts
@@ -79,32 +79,55 @@ function charHasMark(state: EditorState, pos: number, mark: Mark): boolean {
   return marks != null && mark.isInSet(marks)
 }
 
-// The range of the smallest mdPack unit containing the character at `charPos`.
-// mdPack uses `excludes: ''`, so a nested unit's character carries up to two
-// pack marks; expand each instance separately and keep the smallest.
-export function getInnermostPackRangeAt(
-  state: EditorState,
-  charPos: number,
-): HiddenRun | undefined {
+// The identity run of every mdPack instance on the character at `charPos`.
+// mdPack uses `excludes: ''`, so a nested unit's character carries one pack
+// per level; each instance expands to its own unit's range. The order of
+// same-type marks in a mark set follows edit history, so callers must never
+// rely on it: pick the smallest or largest range instead.
+function getPackRangesAt(state: EditorState, charPos: number): HiddenRun[] {
   const marks = getCharMarks(state, charPos)
-  if (marks == null) return undefined
+  if (marks == null) return []
   const packType = getMarkType(state.schema, 'mdPack' satisfies MarkName)
   const packs = marks.filter((mark) => mark.type === packType)
-  if (packs.length === 0) return undefined
+  if (packs.length === 0) return []
   const $pos = state.doc.resolve(charPos)
   const blockStart = $pos.start()
   const blockEnd = $pos.end()
-  let innermost: HiddenRun | undefined
-  for (const pack of packs) {
+  return packs.map((pack) => {
     let from = charPos
     while (from > blockStart && charHasMark(state, from - 1, pack)) from--
     let to = charPos + 1
     while (to < blockEnd && charHasMark(state, to, pack)) to++
-    if (innermost == null || to - from < innermost.to - innermost.from) {
-      innermost = { from, to }
+    return { from, to }
+  })
+}
+
+/** The range of the smallest mdPack unit containing the character at `charPos`. */
+export function getInnermostPackRangeAt(
+  state: EditorState,
+  charPos: number,
+): HiddenRun | undefined {
+  let innermost: HiddenRun | undefined
+  for (const range of getPackRangesAt(state, charPos)) {
+    if (innermost == null || range.to - range.from < innermost.to - innermost.from) {
+      innermost = range
     }
   }
   return innermost
+}
+
+/** The range of the largest mdPack unit containing the character at `charPos`. */
+export function getOutermostPackRangeAt(
+  state: EditorState,
+  charPos: number,
+): HiddenRun | undefined {
+  let outermost: HiddenRun | undefined
+  for (const range of getPackRangesAt(state, charPos)) {
+    if (outermost == null || range.to - range.from > outermost.to - outermost.from) {
+      outermost = range
+    }
+  }
+  return outermost
 }
 
 function isPackOuterEdge(state: EditorState, run: HiddenRun, edge: 'from' | 'to'): boolean {

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -187,6 +187,76 @@ describe('focus mode', () => {
     `)
   })
 
+  it('reveals all six stars after the italic unit forms around an existing bold', () => {
+    using fixture = setupFixture({ extensionOptions: { markMode: 'focus' } })
+    const { n } = fixture
+    // Reach ***bold_and_italic*** through the ***x** strong-only state, like a
+    // left-to-right typist: the bold pack lands first and the italic pack is
+    // added by a later reparse, so the italic pack sits after the bold pack in
+    // the mark set. The reveal must not depend on that order.
+    fixture.set(n.doc(n.paragraph('***bold_and_italic**')))
+    fixture.view.dispatch(fixture.state.tr.insertText('*', 21))
+    const caret = findText(fixture.doc, 'bold_and_italic') + 'bold_and_italic'.length
+    fixture.view.dispatch(fixture.state.tr.setSelection(TextSelection.create(fixture.doc, caret)))
+    expect(fixture.htmlSnapshot).toMatchInlineSnapshot(`
+      "
+      <p>
+        <span
+          class="md-pack"
+          data-key="italic"
+        >
+          <em>
+            <span class="md-mark">
+              <span class="show">
+                *
+              </span>
+            </span>
+          </em>
+        </span>
+        <span
+          class="md-pack"
+          data-key="bold"
+        >
+          <span
+            class="md-pack"
+            data-key="italic"
+          >
+            <strong>
+              <em>
+                <span class="md-mark">
+                  <span class="show">
+                    **
+                  </span>
+                </span>
+                <span class="show">
+                  bold_and_italic
+                </span>
+                <span class="md-mark">
+                  <span class="show">
+                    **
+                  </span>
+                </span>
+              </em>
+            </strong>
+          </span>
+        </span>
+        <span
+          class="md-pack"
+          data-key="italic"
+        >
+          <em>
+            <span class="md-mark">
+              <span class="show">
+                *
+              </span>
+            </span>
+          </em>
+        </span>
+      </p>
+      "
+    `)
+  })
+
   it('reveals every link marker when the cursor is in the text', () => {
     expect(renderHTML('focus', 'see [<a>docs](http://x.test)')).toMatchInlineSnapshot(`
       "

--- a/packages/core/src/extensions/mark-mode.ts
+++ b/packages/core/src/extensions/mark-mode.ts
@@ -1,9 +1,10 @@
-import { defineCommands, definePlugin, getMarkRange, getMarkType, union } from '@prosekit/core'
+import { defineCommands, definePlugin, union } from '@prosekit/core'
 import type { Mark, Slice } from '@prosekit/pm/model'
 import type { Command, EditorState } from '@prosekit/pm/state'
 import { Plugin, PluginKey } from '@prosekit/pm/state'
 import { Decoration, DecorationSet } from '@prosekit/pm/view'
 
+import { getOutermostPackRangeAt } from './hidden-run.ts'
 import type { MarkName } from './mark-names.ts'
 
 /**
@@ -99,11 +100,13 @@ function cleanCopySerializer(slice: Slice): string {
  * In focus mode, reveal the markdown syntax of the inline unit under the caret.
  *
  * Every revealable unit (emphasis, strong, code, strikethrough, link, autolink,
- * image) carries one `mdPack` mark spanning it, so a single boundary-inclusive
- * `getMarkRange` finds the unit, returning the outermost when units nest. One
- * decoration over its range flips the hidden punctuation/url/source visible via
- * the `.show` CSS rule. Because the range covers the whole unit, a caret at
- * either edge (e.g. right after a link's `)`) still reveals it. Wikilink and
+ * image) carries one `mdPack` mark spanning it. Nested units stack one pack per
+ * level and the order of same-type marks in a mark set follows edit history,
+ * so the reveal expands every pack instance on the caret's character and takes
+ * the outermost range. One decoration over that range flips the hidden
+ * punctuation/url/source visible via the `.show` CSS rule. The character after
+ * the caret is preferred, falling back to the one before, so a caret at either
+ * edge (e.g. right after a link's `)`) still reveals the unit. Wikilink and
  * `#tag` carry no `mdPack`, so they never reveal.
  */
 function computeFocusDecorations(state: EditorState): DecorationSet {
@@ -114,7 +117,8 @@ function computeFocusDecorations(state: EditorState): DecorationSet {
   const { parent } = $pos
   if (!parent.isTextblock || parent.type.spec.code) return DecorationSet.empty
 
-  const range = getMarkRange($pos, getMarkType(state.schema, 'mdPack' satisfies MarkName))
+  const range =
+    getOutermostPackRangeAt(state, $pos.pos) ?? getOutermostPackRangeAt(state, $pos.pos - 1)
   if (!range) return DecorationSet.empty
 
   return DecorationSet.create(state.doc, [


### PR DESCRIPTION
In focus mode a caret inside `***text***` could reveal only the inner `**` pair: nested units stack two `mdPack` marks whose order in the mark set follows edit history, so the reveal picked whichever pack happened to sit first. Focus mode now expands every pack instance at the caret and reveals the outermost range, and `getLinkUnitAt` selects its pack by `key` instead of set order, so a link nested inside an emphasis resolves its label and dest again.