### PR TITLE
fix: canonicalize mark order

### DIFF
--- a/packages/core/src/extensions/batch-set-mark-step.ts
+++ b/packages/core/src/extensions/batch-set-mark-step.ts
@@ -1,4 +1,4 @@
-import type { EditorNode, Schema } from '@prosekit/pm/model'
+import { Mark, type EditorNode, type Schema } from '@prosekit/pm/model'
 import type { Mappable } from '@prosekit/pm/transform'
 import { ReplaceStep, Step, StepResult, Transform } from '@prosekit/pm/transform'
 
@@ -8,6 +8,7 @@ import {
   type MarkChunk,
   type MarkChunkJSON,
 } from './mark-chunk.ts'
+import { marksEqual } from './marks-equal.ts'
 
 interface BatchSetMarkStepJSON {
   stepType: 'batchSetMark'
@@ -38,24 +39,25 @@ export class BatchSetMarkStep extends Step {
       const safeTo = Math.max(safeFrom, Math.min(to, docSize))
       if (safeFrom >= safeTo) continue
 
+      // Rank-sorted like a node's own mark set; equal-rank marks (nested
+      // mdPack) keep the parser's outer-first emit order, so rewriting a node
+      // whose set merely differs in order keeps same-type marks canonical.
+      const expectedSet = Mark.setFrom(expected)
+
       doc.nodesBetween(safeFrom, safeTo, (node, pos) => {
         if (!node.isText) return true
         const nodeFrom = Math.max(safeFrom, pos)
         const nodeTo = Math.min(safeTo, pos + node.nodeSize)
         if (nodeFrom >= nodeTo) return false
         const current = node.marks
+        if (marksEqual(current, expectedSet)) return false
 
+        tr ??= new Transform(doc)
         for (const mark of current) {
-          if (!mark.isInSet(expected)) {
-            tr ??= new Transform(doc)
-            tr.removeMark(nodeFrom, nodeTo, mark)
-          }
+          tr.removeMark(nodeFrom, nodeTo, mark)
         }
-        for (const mark of expected) {
-          if (!mark.isInSet(current)) {
-            tr ??= new Transform(doc)
-            tr.addMark(nodeFrom, nodeTo, mark)
-          }
+        for (const mark of expectedSet) {
+          tr.addMark(nodeFrom, nodeTo, mark)
         }
         return false
       })

--- a/packages/core/src/extensions/batch-set-mark-step.ts
+++ b/packages/core/src/extensions/batch-set-mark-step.ts
@@ -32,7 +32,7 @@ export class BatchSetMarkStep extends Step {
     const docSize = doc.content.size
 
     let tr: Transform | undefined
-    for (const [from, to, expected] of this.chunks) {
+    for (const [from, to, expectedUnsorted] of this.chunks) {
       if (from >= to) continue
 
       const safeFrom = Math.max(0, Math.min(from, docSize))
@@ -42,7 +42,7 @@ export class BatchSetMarkStep extends Step {
       // Rank-sorted like a node's own mark set; equal-rank marks (nested
       // mdPack) keep the parser's outer-first emit order, so rewriting a node
       // whose set merely differs in order keeps same-type marks canonical.
-      const expectedSet = Mark.setFrom(expected)
+      const expected = Mark.setFrom(expectedUnsorted)
 
       doc.nodesBetween(safeFrom, safeTo, (node, pos) => {
         if (!node.isText) return true
@@ -50,13 +50,13 @@ export class BatchSetMarkStep extends Step {
         const nodeTo = Math.min(safeTo, pos + node.nodeSize)
         if (nodeFrom >= nodeTo) return false
         const current = node.marks
-        if (marksEqual(current, expectedSet)) return false
+        if (marksEqual(current, expected)) return false
 
         tr ??= new Transform(doc)
         for (const mark of current) {
           tr.removeMark(nodeFrom, nodeTo, mark)
         }
-        for (const mark of expectedSet) {
+        for (const mark of expected) {
           tr.addMark(nodeFrom, nodeTo, mark)
         }
         return false

--- a/packages/core/src/extensions/get-link-unit-at.test.ts
+++ b/packages/core/src/extensions/get-link-unit-at.test.ts
@@ -71,4 +71,24 @@ describe('getLinkUnitAt', () => {
     fixture.set(n.doc(n.paragraph('plain text')))
     expect(getLinkUnitAt(fixture.state, findText(fixture.doc, 'plain') + 1)).toBeUndefined()
   })
+
+  it('returns undefined inside a non-link unit', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('**bold**')))
+    expect(getLinkUnitAt(fixture.state, findText(fixture.doc, 'bold') + 1)).toBeUndefined()
+  })
+
+  it('resolves the link unit when the link nests inside an emphasis', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    // The italic pack covers the whole `*...*` and sits before the link pack
+    // in the mark set; the lookup must pick the pack by key, not by set order.
+    fixture.set(n.doc(n.paragraph('*[a](http://x.test)*')))
+    const link = getLinkUnitAt(fixture.state, findText(fixture.doc, 'a'))!
+    expect(link.href).toBe('http://x.test')
+    expect(fixture.doc.textBetween(link.unit.from, link.unit.to)).toBe('[a](http://x.test)')
+    expect(fixture.doc.textBetween(link.label!.from, link.label!.to)).toBe('a')
+    expect(fixture.doc.textBetween(link.dest!.from, link.dest!.to)).toBe('http://x.test')
+  })
 })

--- a/packages/core/src/extensions/get-link-unit-at.ts
+++ b/packages/core/src/extensions/get-link-unit-at.ts
@@ -56,10 +56,14 @@ function lastMarkRunIn(
  */
 export function getLinkUnitAt(state: EditorState, pos: number): LinkUnit | undefined {
   const linkText = getMarkRangeAt(state, pos, 'mdLinkText')
-  const pack = getMarkRangeAt(state, pos, 'mdPack')
-  // `[text](url)` carries `mdPack` over the whole unit; bare/GFM autolinks carry
-  // only `mdLinkText`. Prefer the wider `mdPack` unit, falling back to the link
-  // text run so autolinks still resolve.
+  // A position inside nested units carries one `mdPack` per level and the mark
+  // set's order follows edit history, so select the pack by `key` instead of
+  // taking whichever sits first. `[text](url)` and `<url>` carry a pack over
+  // the whole unit; bare/www autolinks carry only `mdLinkText`, so fall back to
+  // that run.
+  const pack =
+    getMarkRangeAt(state, pos, 'mdPack', { key: 'link' } satisfies Partial<MdPackAttrs>) ??
+    getMarkRangeAt(state, pos, 'mdPack', { key: 'autolink' } satisfies Partial<MdPackAttrs>)
   const unit = pack ?? linkText
   if (!unit) return
 

--- a/packages/core/src/extensions/get-mark-range-at.ts
+++ b/packages/core/src/extensions/get-mark-range-at.ts
@@ -1,4 +1,5 @@
 import { getMarkRange, type MarkRange } from '@prosekit/core'
+import type { Attrs } from '@prosekit/pm/model'
 import type { EditorState } from '@prosekit/pm/state'
 
 import type { MarkName } from './mark-names.ts'
@@ -6,16 +7,19 @@ import type { MarkName } from './mark-names.ts'
 /**
  * The `markName` run covering `pos`, or `undefined` when `pos` is not inside a
  * non-code textblock. Centralizes the guard the click finders share: marks only
- * carry inline syntax in regular textblocks, never in code blocks.
+ * carry inline syntax in regular textblocks, never in code blocks. `attrs`
+ * narrows the match to marks whose attrs contain it, which is how callers pick
+ * one `mdPack` level out of a nested unit's stack.
  */
 export function getMarkRangeAt(
   state: EditorState,
   pos: number,
   markName: MarkName,
+  attrs?: Attrs,
 ): MarkRange | undefined {
   const size = state.doc.content.size
   if (pos < 0 || pos > size) return
   const $pos = state.doc.resolve(pos)
   if (!$pos.parent.isTextblock || $pos.parent.type.spec.code) return
-  return getMarkRange($pos, markName)
+  return getMarkRange($pos, markName, attrs)
 }

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -187,6 +187,65 @@ describe('focus mode', () => {
     `)
   })
 
+  it('reveals all six stars after the italic unit forms around an existing bold', () => {
+    using fixture = setupFixture({ extensionOptions: { markMode: 'focus' } })
+    const { n } = fixture
+    // Reach ***bold_and_italic*** through the ***x** strong-only state, like a
+    // left-to-right typist: the bold pack lands first and the italic pack is
+    // added by a later reparse. The reveal must not depend on that history.
+    fixture.set(n.doc(n.paragraph('***bold_and_italic**')))
+    fixture.view.dispatch(fixture.state.tr.insertText('*', 21))
+    const caret = findText(fixture.doc, 'bold_and_italic') + 'bold_and_italic'.length
+    fixture.view.dispatch(fixture.state.tr.setSelection(TextSelection.create(fixture.doc, caret)))
+    expect(fixture.htmlSnapshot).toMatchInlineSnapshot(`
+      "
+      <p>
+        <span
+          class="md-pack"
+          data-key="italic"
+        >
+          <em>
+            <span class="md-mark">
+              <span class="show">
+                *
+              </span>
+            </span>
+          </em>
+          <span
+            class="md-pack"
+            data-key="bold"
+          >
+            <strong>
+              <em>
+                <span class="md-mark">
+                  <span class="show">
+                    **
+                  </span>
+                </span>
+                <span class="show">
+                  bold_and_italic
+                </span>
+                <span class="md-mark">
+                  <span class="show">
+                    **
+                  </span>
+                </span>
+              </em>
+            </strong>
+          </span>
+          <em>
+            <span class="md-mark">
+              <span class="show">
+                *
+              </span>
+            </span>
+          </em>
+        </span>
+      </p>
+      "
+    `)
+  })
+
   it('reveals every link marker when the cursor is in the text', () => {
     expect(renderHTML('focus', 'see [<a>docs](http://x.test)')).toMatchInlineSnapshot(`
       "


### PR DESCRIPTION
In focus mode a caret inside `***text***` could reveal only the inner `**` pair: nested units stack two `mdPack` marks, and incremental re-marking could leave the inner pack first in the mark set, so the reveal depended on edit history. This PR fixes the order at the source: `BatchSetMarkStep` now rewrites a node whose marks differ from the canonical set (outer pack first, matching the parse nesting), which also normalizes the rendered DOM to the fresh-parse structure, and `getLinkUnitAt` selects its pack by `key` so a link nested inside an emphasis resolves its label and dest. Alternative to #238, which fixes the same bug on the read side.


Before:

<img width="314" height="154" alt="image" src="https://github.com/user-attachments/assets/4e1f3dfd-12a8-4398-9acf-dd301a320dd1" />


After:

<img width="325" height="156" alt="image" src="https://github.com/user-attachments/assets/4a796b3a-fa30-4af5-9c7c-fd13510c1750" />
