### PR TITLE
refactor: address some TODOs

### DIFF
--- a/packages/core/src/extensions/embed-paste.test.ts
+++ b/packages/core/src/extensions/embed-paste.test.ts
@@ -1,4 +1,3 @@
-import { isApple } from '@prosekit/core'
 import { pasteText } from '@prosekit/core/test'
 import { describe, expect, it } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
@@ -188,10 +187,7 @@ describe('undo restores the raw link', () => {
 
     view.focus()
     // `Mod-z` is bound to undo by defineHistory; exercise the actual binding.
-    // TODO: rewrite this to {ControlOrMeta}
-    await userEvent.keyboard(
-      `{${isApple ? 'Meta' : 'Control'}>}z{/${isApple ? 'Meta' : 'Control'}}`,
-    )
+    await userEvent.keyboard('{ControlOrMeta>}z{/ControlOrMeta}')
     expect(editor.state.doc.textContent).toBe(YT)
     await expect.element(youtubeEmbed).not.toBeInTheDocument()
   })

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.ts
@@ -1,6 +1,6 @@
 import type { Mark } from '@prosekit/pm/model'
 
-import { hostFromUrl, isLinkableBareHost } from '../lezer/autolink-tld.ts'
+import { getAutolinkHref } from '../lezer/autolink-tld.ts'
 import type { InlineElement } from '../lezer/inline.ts'
 import { parseInline } from '../lezer/inline.ts'
 import { LEZER_NODE_IDS } from '../lezer/node-ids.ts'
@@ -87,25 +87,6 @@ export function inlineTextToMarkChunks(
   const out: MarkChunk[] = []
   walk(elements, [], 0, text.length, text, marks, out, options)
   return out
-}
-
-// TODO: move function getAutolinkHref into lezer/autolink-tld.ts
-
-/**
- * Derive the `href` for a bare autolink from its visible text:
- *
- * - a URL with a scheme is used as-is
- * - an email becomes `mailto:`
- * - a `www.` URL gets an implied `https://`
- * - a bare domain on the curated TLD list gets an implied `https://`
- * - anything else returns `undefined`
- */
-export function getAutolinkHref(urlText: string): string | undefined {
-  if (/^[a-z][a-z0-9+.-]*:/i.test(urlText)) return urlText
-  if (/^[^\s@]+@[^\s@]+$/.test(urlText)) return `mailto:${urlText}`
-  if (/^www\./i.test(urlText)) return `https://${urlText}`
-  if (isLinkableBareHost(hostFromUrl(urlText))) return `https://${urlText}`
-  return undefined
 }
 
 /** Drop the surrounding `"" '' ()` delimiters of a `LinkTitle` slice and unescape. */

--- a/packages/core/src/extensions/link-commands.ts
+++ b/packages/core/src/extensions/link-commands.ts
@@ -2,10 +2,10 @@ import { defineCommands, defineKeymap, isTextSelection, type PlainExtension } fr
 import type { Command, EditorState } from '@prosekit/pm/state'
 import { TextSelection } from '@prosekit/pm/state'
 
+import { getAutolinkHref } from '../lezer/autolink-tld.ts'
 import type { PositionRange } from '../utils/range.ts'
 
 import { getLinkUnitAt, type LinkUnit } from './get-link-unit-at.ts'
-import { getAutolinkHref } from './inline-text-to-mark-chunks.ts'
 import { trimRange } from './inline-toggle.ts'
 
 export interface LinkAttrs {

--- a/packages/core/src/extensions/wikilink.test.ts
+++ b/packages/core/src/extensions/wikilink.test.ts
@@ -149,9 +149,7 @@ describe('wikilink vertical caret navigation', () => {
     )
     fixture.view.focus()
     const steps = await traceKeySelection(fixture, 'ArrowDown', 7)
-    const uniqueSteps = Array.from(new Set(steps))
-
-    return uniqueSteps.map((step) => '\n' + step + '\n').join('-'.repeat(10))
+    return steps.map((step) => '\n' + step + '\n').join('-'.repeat(10))
   }
 
   it('can ArrowDown from the first paragraph to the last paragraph in hide mode', async () => {

--- a/packages/core/src/lezer/autolink-tld.test.ts
+++ b/packages/core/src/lezer/autolink-tld.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { hostFromUrl, isLinkableBareHost } from './autolink-tld.ts'
+import { getAutolinkHref, hostFromUrl, isLinkableBareHost } from './autolink-tld.ts'
 
 describe('hostFromUrl', () => {
   it('returns the whole string when there is no path', () => {
@@ -53,4 +53,26 @@ describe('isLinkableBareHost', () => {
       expect(isLinkableBareHost(host)).toBe(false)
     })
   }
+})
+
+describe('getAutolinkHref', () => {
+  it('keeps a URL with a scheme', () => {
+    expect(getAutolinkHref('https://example.com')).toBe('https://example.com')
+  })
+
+  it('adds mailto for an email', () => {
+    expect(getAutolinkHref('me@example.com')).toBe('mailto:me@example.com')
+  })
+
+  it('adds https for a www URL', () => {
+    expect(getAutolinkHref('www.example.com')).toBe('https://www.example.com')
+  })
+
+  it('adds https for a linkable bare domain', () => {
+    expect(getAutolinkHref('google.com/path')).toBe('https://google.com/path')
+  })
+
+  it('declines a non-linkable bare domain', () => {
+    expect(getAutolinkHref('README.md')).toBeUndefined()
+  })
 })

--- a/packages/core/src/lezer/autolink-tld.ts
+++ b/packages/core/src/lezer/autolink-tld.ts
@@ -53,3 +53,20 @@ export function isLinkableBareHost(host: string): boolean {
   }
   return true
 }
+
+/**
+ * Derive the `href` for an autolink from its visible text:
+ *
+ * - a URL with a scheme is used as-is
+ * - an email becomes `mailto:`
+ * - a `www.` URL gets an implied `https://`
+ * - a bare domain on the curated TLD list gets an implied `https://`
+ * - anything else returns `undefined`
+ */
+export function getAutolinkHref(urlText: string): string | undefined {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(urlText)) return urlText
+  if (/^[^\s@]+@[^\s@]+$/.test(urlText)) return `mailto:${urlText}`
+  if (/^www\./i.test(urlText)) return `https://${urlText}`
+  if (isLinkableBareHost(hostFromUrl(urlText))) return `https://${urlText}`
+  return undefined
+}

--- a/packages/react/src/components/block-handle.test.tsx
+++ b/packages/react/src/components/block-handle.test.tsx
@@ -1,6 +1,5 @@
 import '../testing/index.ts'
 
-import { isFirefox } from '@meowdown/vitest/helpers'
 import { createRef, type Ref } from 'react'
 import { describe, expect, it } from 'vitest'
 import { mouse } from 'vitest-browser-commands/playwright'
@@ -100,10 +99,7 @@ describe('BlockHandle', () => {
     await expect.element(handle).not.toBeInTheDocument()
   })
 
-  it.skipIf(
-    // TODO: Fix the test on Firefox
-    isFirefox(),
-  )('drags a block to a new position, showing the drop indicator', async () => {
+  it('drags a block to a new position, showing the drop indicator', async () => {
     const ref = createRef<EditorHandle>()
     await renderEditor({ ref })
     await hover(pmRoot.getByText('Bravo'))


### PR DESCRIPTION
Replaces the embed paste undo shortcut test's platform-specific Meta/Control branch with Vitest Browser's ControlOrMeta keyboard token. Moves getAutolinkHref into the autolink TLD helper module and adds direct coverage for the moved helper.
