### PR TITLE
fix: allow typing before a leading wikilink

### DIFF
--- a/packages/core/src/extensions/virtual-caret.ts
+++ b/packages/core/src/extensions/virtual-caret.ts
@@ -73,10 +73,10 @@ function findCoordsCaretRect(view: EditorView): CaretRect | undefined {
   return undefined
 }
 
-// Step 3: an atom mark view hides its source
-// text with `display: none`, so no position beside it has a box the earlier
-// steps can measure. The preview element standing in for the source is the
-// visible geometry; the caret sits flush against its outer edge.
+// Step 3: an atom mark view collapses its source text to a zero-size box
+// (font-size: 0), so no position beside it has a box the earlier steps can
+// measure. The preview element standing in for the source is the visible
+// geometry; the caret sits flush against its outer edge.
 function findAtomCaretRect(view: EditorView): CaretRect | undefined {
   const state = view.state
   const head = state.selection.head

--- a/packages/core/src/extensions/wikilink-insert-caret.test.ts
+++ b/packages/core/src/extensions/wikilink-insert-caret.test.ts
@@ -93,6 +93,96 @@ describe.each(ALL_MODES)('typing before an inserted wikilink in %s mode', (mode)
   })
 })
 
+// An editor in `mode` showing a single paragraph `text`, caret at the `<a>` tag.
+function setupParagraph(mode: MarkMode, text: string): Fixture {
+  const fixture = setupFixture({ extensionOptions: { markMode: mode } })
+  const { n } = fixture
+  fixture.set(n.doc(n.paragraph(text)))
+  fixture.view.focus()
+  return fixture
+}
+
+// The mirror boundary at the paragraph start: with no editable text before the
+// wikilink, the browser used to relocate the insertion point past the
+// `contenteditable=false` preview, landing the character after the link.
+describe.each(ALL_MODES)('typing before a wikilink at the paragraph start in %s mode', (mode) => {
+  it('types before a lone wikilink', async () => {
+    using fixture = setupParagraph(mode, '<a>[[Note]]')
+    await expect.element(pmRoot).toBeVisible()
+
+    await userEvent.keyboard('B')
+    expect(fixture.doc.textContent).toBe('B[[Note]]')
+    expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(`"B┃[[Note]]"`)
+  })
+
+  it('keeps typing before the wikilink across several characters', async () => {
+    using fixture = setupParagraph(mode, '<a>[[Note]]')
+    await expect.element(pmRoot).toBeVisible()
+
+    await userEvent.keyboard('Bar')
+    expect(fixture.doc.textContent).toBe('Bar[[Note]]')
+    expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(`"Bar┃[[Note]]"`)
+  })
+
+  it('types before a leading wikilink followed by text', async () => {
+    using fixture = setupParagraph(mode, '<a>[[Note]]C')
+    await expect.element(pmRoot).toBeVisible()
+
+    await userEvent.keyboard('B')
+    expect(fixture.doc.textContent).toBe('B[[Note]]C')
+    expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(`"B┃[[Note]]C"`)
+  })
+
+  it('types between two adjacent wikilinks', async () => {
+    using fixture = setupParagraph(mode, '[[One]]<a>[[Two]]')
+    await expect.element(pmRoot).toBeVisible()
+
+    await userEvent.keyboard('B')
+    expect(fixture.doc.textContent).toBe('[[One]]B[[Two]]')
+    expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(`"[[One]]B┃[[Two]]"`)
+  })
+})
+
+// Typing over a unit selected with ArrowLeft replaces the whole source, like
+// typing over any other selection.
+describe.each(ALL_MODES)('typing over a selected wikilink in %s mode', (mode) => {
+  it('replaces a selected lone wikilink', async () => {
+    using fixture = setupParagraph(mode, '[[Note]]<a>')
+    await expect.element(pmRoot).toBeVisible()
+
+    await userEvent.keyboard('{ArrowLeft}')
+    expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(`"❰[[Note]]❱"`)
+
+    await userEvent.keyboard('B')
+    expect(fixture.doc.textContent).toBe('B')
+    expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(`"B┃"`)
+  })
+
+  it('replaces a selected leading wikilink followed by text', async () => {
+    using fixture = setupParagraph(mode, '[[Note]]<a>C')
+    await expect.element(pmRoot).toBeVisible()
+
+    await userEvent.keyboard('{ArrowLeft}')
+    expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(`"❰[[Note]]❱C"`)
+
+    await userEvent.keyboard('B')
+    expect(fixture.doc.textContent).toBe('BC')
+    expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(`"B┃C"`)
+  })
+
+  it('replaces a selected wikilink in the middle of text', async () => {
+    using fixture = setupParagraph(mode, 'A[[Note]]<a>C')
+    await expect.element(pmRoot).toBeVisible()
+
+    await userEvent.keyboard('{ArrowLeft}')
+    expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(`"A❰[[Note]]❱C"`)
+
+    await userEvent.keyboard('B')
+    expect(fixture.doc.textContent).toBe('ABC')
+    expect(getSelectionSnapshot(fixture.state)).toMatchInlineSnapshot(`"AB┃C"`)
+  })
+})
+
 // The mark view renders the label as the stand-in for the source in every mode,
 // the wikilink being atomic everywhere.
 describe('inserted wikilink rendering', () => {

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -724,8 +724,14 @@
       }
     }
 
+    /* The source keeps a zero-width inline box (font-size: 0, same as .md-mark)
+     * instead of leaving the box tree (display: none): a boxless source next to
+     * the contenteditable=false preview makes the browser relocate typing at a
+     * textblock start past the whole mark view. */
     .md-atom-view-content {
-      display: none;
+      font-size: 0;
+      letter-spacing: 0;
+      opacity: 0;
     }
   }
 


### PR DESCRIPTION
With the caret at the left edge of a wikilink that starts a paragraph, a typed character landed after the link, because the browser cannot type at a caret anchored in the atom's `display: none` source and relocates the insertion point past the `contenteditable=false` preview. Hide the atom source with a zero-size box (`font-size: 0`, the same strategy as `.md-mark`) so the caret position stays typable; this also fixes typing over a selected atom unit at the paragraph start.


https://github.com/user-attachments/assets/5a2e82dd-096c-4d8e-8c66-7c80776583dc

