### PR TITLE
feat: autolink bare custom-scheme URIs

### DIFF
--- a/packages/core/src/extensions/autolink.test.ts
+++ b/packages/core/src/extensions/autolink.test.ts
@@ -22,6 +22,15 @@ describe('autolink rendering', () => {
     await expect.element(pmRoot.getByRole('link', { name: 'google.com' })).toBeInTheDocument()
   })
 
+  it('renders a bare custom-scheme URI as a link', async () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('see x-devonthink-item://40C8E9F8 here')))
+    await expect
+      .element(pmRoot.getByRole('link', { name: 'x-devonthink-item://40C8E9F8' }))
+      .toBeInTheDocument()
+  })
+
   // Locks the product decision: a link is never un-linked by moving the caret
   // into it. The link keeps its blue `<a>` and stays editable.
   it('keeps a scheme autolink a link when the caret is inside it', async () => {

--- a/packages/core/src/extensions/autolink.test.ts
+++ b/packages/core/src/extensions/autolink.test.ts
@@ -25,9 +25,9 @@ describe('autolink rendering', () => {
   it('renders a bare custom-scheme URI as a link', async () => {
     using fixture = setupFixture()
     const { n } = fixture
-    fixture.set(n.doc(n.paragraph('see x-cutsom-schema://ABCD here')))
+    fixture.set(n.doc(n.paragraph('see x-custom-schema://ABCD here')))
     await expect
-      .element(pmRoot.getByRole('link', { name: 'x-cutsom-schema://ABCD' }))
+      .element(pmRoot.getByRole('link', { name: 'x-custom-schema://ABCD' }))
       .toBeInTheDocument()
   })
 

--- a/packages/core/src/extensions/autolink.test.ts
+++ b/packages/core/src/extensions/autolink.test.ts
@@ -25,9 +25,9 @@ describe('autolink rendering', () => {
   it('renders a bare custom-scheme URI as a link', async () => {
     using fixture = setupFixture()
     const { n } = fixture
-    fixture.set(n.doc(n.paragraph('see x-devonthink-item://40C8E9F8 here')))
+    fixture.set(n.doc(n.paragraph('see x-cutsom-schema://ABCD here')))
     await expect
-      .element(pmRoot.getByRole('link', { name: 'x-devonthink-item://40C8E9F8' }))
+      .element(pmRoot.getByRole('link', { name: 'x-cutsom-schema://ABCD' }))
       .toBeInTheDocument()
   })
 

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
@@ -505,11 +505,11 @@ describe('autolink', () => {
   })
 
   it('custom app scheme', () => {
-    expect(parse('a x-devonthink-item://40C8E9F8 b')).toMatchInlineSnapshot(`
+    expect(parse('a x-cutsom-schema://ABCD b')).toMatchInlineSnapshot(`
       "
       [0, 2]
-      [2, 30]  mdLinkText(href=x-devonthink-item://40C8E9F8)
-      [30, 32]
+      [2, 24]  mdLinkText(href=x-cutsom-schema://ABCD)
+      [24, 26]
       "
     `)
   })

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
@@ -505,10 +505,10 @@ describe('autolink', () => {
   })
 
   it('custom app scheme', () => {
-    expect(parse('a x-cutsom-schema://ABCD b')).toMatchInlineSnapshot(`
+    expect(parse('a x-custom-schema://ABCD b')).toMatchInlineSnapshot(`
       "
       [0, 2]
-      [2, 24]  mdLinkText(href=x-cutsom-schema://ABCD)
+      [2, 24]  mdLinkText(href=x-custom-schema://ABCD)
       [24, 26]
       "
     `)

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
@@ -497,7 +497,19 @@ describe('autolink', () => {
   it('non-http scheme', () => {
     expect(parse('a ftp://example.com b')).toMatchInlineSnapshot(`
       "
-      [0, 21]
+      [0, 2]
+      [2, 19]  mdLinkText(href=ftp://example.com)
+      [19, 21]
+      "
+    `)
+  })
+
+  it('custom app scheme', () => {
+    expect(parse('a x-devonthink-item://40C8E9F8 b')).toMatchInlineSnapshot(`
+      "
+      [0, 2]
+      [2, 30]  mdLinkText(href=x-devonthink-item://40C8E9F8)
+      [30, 32]
       "
     `)
   })

--- a/packages/core/src/extensions/link-paste.test.ts
+++ b/packages/core/src/extensions/link-paste.test.ts
@@ -21,7 +21,7 @@ function useLinkPaste(fixture: Fixture): void {
 describe('detectLinkUrl', () => {
   it.each([
     ['https://example.com/page?q=1', 'https://example.com/page?q=1'],
-    ['x-devonthink-item://40C8E9F8-DEAD-BEEF', 'x-devonthink-item://40C8E9F8-DEAD-BEEF'],
+    ['x-devonthink-item://ABCD-1234', 'x-devonthink-item://ABCD-1234'],
     ['obsidian://open?vault=notes', 'obsidian://open?vault=notes'],
     ['www.example.com', 'https://www.example.com'],
     ['google.com/path', 'https://google.com/path'],
@@ -81,8 +81,8 @@ describe('paste a URL over a selection', () => {
     const { editor, n, view } = fixture
     useLinkPaste(fixture)
     fixture.set(n.doc(n.paragraph('<a>my note<b>')))
-    pasteText(view, 'x-devonthink-item://40C8E9F8')
-    expect(editor.state.doc.textContent).toBe('[my note](x-devonthink-item://40C8E9F8)')
+    pasteText(view, 'x-cutsom-schema://ABCD-1234')
+    expect(editor.state.doc.textContent).toBe('[my note](x-cutsom-schema://ABCD-1234)')
   })
 
   it('wraps only the trimmed selection, keeping edge whitespace as text', () => {

--- a/packages/core/src/extensions/link-paste.test.ts
+++ b/packages/core/src/extensions/link-paste.test.ts
@@ -81,8 +81,8 @@ describe('paste a URL over a selection', () => {
     const { editor, n, view } = fixture
     useLinkPaste(fixture)
     fixture.set(n.doc(n.paragraph('<a>my note<b>')))
-    pasteText(view, 'x-cutsom-schema://ABCD-1234')
-    expect(editor.state.doc.textContent).toBe('[my note](x-cutsom-schema://ABCD-1234)')
+    pasteText(view, 'x-custom-schema://ABCD-1234')
+    expect(editor.state.doc.textContent).toBe('[my note](x-custom-schema://ABCD-1234)')
   })
 
   it('wraps only the trimmed selection, keeping edge whitespace as text', () => {

--- a/packages/core/src/lezer/bare-autolink.ts
+++ b/packages/core/src/lezer/bare-autolink.ts
@@ -19,7 +19,7 @@ const DOMAIN_RE = /^[a-z0-9-]+(?:\.[a-z0-9-]+)+(?:\/[^\s<]*)?/i
 // `( * _ ~`. Mirrors GFM's "start of line, after whitespace, or one of these"
 // boundary rule. A `.`, `-`, alphanumeric, or `@` before the match means we are
 // mid-word or mid-email, so no autolink starts there.
-const BOUNDARY_BEFORE_RE = /[\s(*_~]/
+export const BOUNDARY_BEFORE_RE = /[\s(*_~]/
 
 function isDomainStartChar(code: number): boolean {
   return (
@@ -44,7 +44,7 @@ function countChar(text: string, end: number, ch: string): number {
 // Returns the kept length of `matched`.
 //
 // Ported from https://code.haverbeke.berlin/lezer/markdown/src/commit/1.6.4/src/extension.ts#L179-L195
-function trimAutolinkEnd(matched: string): number {
+export function trimAutolinkEnd(matched: string): number {
   let end = matched.length
   for (;;) {
     const last = matched[end - 1]

--- a/packages/core/src/lezer/parser.ts
+++ b/packages/core/src/lezer/parser.ts
@@ -4,6 +4,7 @@ import { bareAutolink } from './bare-autolink.ts'
 import { hashtag } from './hashtag.ts'
 import { highlight } from './highlight.ts'
 import { math } from './math.ts'
+import { schemeAutolink } from './scheme-autolink.ts'
 import { wikilink } from './wikilink.ts'
 
 /**
@@ -20,14 +21,16 @@ function consumeAllInline(cx: InlineContext): number {
 /**
  * `@lezer/markdown` parser configured with GFM (table, strikethrough,
  * task list, autolink) plus meowdown's `Hashtag`, `Wikilink`, bare
- * domain autolink, `==Highlight==`, and `$math$` inline syntax. Use when
- * both block and inline structure must be recognized.
+ * domain autolink, bare `scheme://` autolink, `==Highlight==`, and
+ * `$math$` inline syntax. Use when both block and inline structure must
+ * be recognized.
  */
 export const gfmParser = defaultParser.configure([
   GFM,
   hashtag,
   wikilink,
   bareAutolink,
+  schemeAutolink,
   highlight,
   math,
 ])

--- a/packages/core/src/lezer/scheme-autolink.test.ts
+++ b/packages/core/src/lezer/scheme-autolink.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+
+import { collectInlineElements, parseInline } from './inline.ts'
+import { LEZER_NODE_IDS } from './node-ids.ts'
+
+/** Every `URL` node the parser emits for `text`, as `[from, to, slice]`. */
+function urls(text: string): Array<[number, number, string]> {
+  const elements = parseInline(text)
+  const nodes = collectInlineElements(elements, (node) => node.type === LEZER_NODE_IDS.URL)
+  return nodes.map((node) => [node.from, node.to, text.slice(node.from, node.to)])
+}
+
+describe('schemeAutolink', () => {
+  describe('detects a bare custom-scheme URI', () => {
+    it('at the start of the text', () => {
+      expect(urls('x-devonthink-item://40C8E9F8')).toEqual([
+        [0, 28, 'x-devonthink-item://40C8E9F8'],
+      ])
+    })
+
+    it('after whitespace', () => {
+      expect(urls('open obsidian://open?vault=notes now')).toEqual([
+        [5, 32, 'obsidian://open?vault=notes'],
+      ])
+    })
+
+    it('with an uppercase scheme', () => {
+      expect(urls('X-DevonThink-Item://ABC')).toEqual([[0, 23, 'X-DevonThink-Item://ABC']])
+    })
+
+    it('with digits and plus in the scheme', () => {
+      expect(urls('web+app://thing and s3://bucket/key')).toEqual([
+        [0, 15, 'web+app://thing'],
+        [20, 35, 's3://bucket/key'],
+      ])
+    })
+
+    it('right after an opening paren', () => {
+      expect(urls('(note://abc)')).toEqual([[1, 11, 'note://abc']])
+    })
+
+    it('picks up scheme URLs that GFM Autolink declines', () => {
+      expect(urls('https://localhost:3000')).toEqual([[0, 22, 'https://localhost:3000']])
+    })
+  })
+
+  describe('ignores text that is not a linkable scheme URI', () => {
+    for (const text of [
+      'note://', // no tail
+      'note:// then words', // tail must be adjacent
+      'note:target', // no `//`
+      'word:note://x', // mid-word (after `:`)
+      '1note://x', // scheme must start with a letter
+    ]) {
+      it(text, () => {
+        expect(urls(text)).toEqual([])
+      })
+    }
+  })
+
+  describe('trims trailing punctuation', () => {
+    it('drops a sentence-ending period', () => {
+      expect(urls('See note://abc.')).toEqual([[4, 14, 'note://abc']])
+    })
+
+    it('drops a trailing comma', () => {
+      expect(urls('note://abc, then more')).toEqual([[0, 10, 'note://abc']])
+    })
+
+    it('drops an unbalanced closing paren', () => {
+      expect(urls('(see note://abc)')).toEqual([[5, 15, 'note://abc']])
+    })
+
+    it('keeps balanced parens inside the tail', () => {
+      expect(urls('note://abc(1)')).toEqual([[0, 13, 'note://abc(1)']])
+    })
+
+    it('declines when trimming leaves no tail', () => {
+      expect(urls('note://...')).toEqual([])
+    })
+  })
+
+  describe('leaves GFM-claimed shapes and other contexts alone', () => {
+    it('keeps the GFM end rule for an http URL (query needs a path)', () => {
+      expect(urls('https://example.com?q=1')).toEqual([[0, 19, 'https://example.com']])
+    })
+
+    it('leaves a mailto autolink to GFM', () => {
+      expect(urls('mailto:a@google.com')).toEqual([[0, 19, 'mailto:a@google.com']])
+    })
+
+    it('does not link the label of an explicit link', () => {
+      expect(urls('[note://x](http://y)')).toEqual([[11, 19, 'http://y']])
+    })
+
+    it('does not link inside inline code', () => {
+      expect(urls('`note://abc`')).toEqual([])
+    })
+
+    it('does not link inside a wikilink', () => {
+      expect(urls('[[note://abc]]')).toEqual([])
+    })
+  })
+})

--- a/packages/core/src/lezer/scheme-autolink.test.ts
+++ b/packages/core/src/lezer/scheme-autolink.test.ts
@@ -13,12 +13,12 @@ function urls(text: string): Array<[number, number, string]> {
 describe('schemeAutolink', () => {
   describe('detects a bare custom-scheme URI', () => {
     it('at the start of the text', () => {
-      expect(urls('x-cutsom-schema://ABCD-1234')).toEqual([[0, 27, 'x-cutsom-schema://ABCD-1234']])
+      expect(urls('x-custom-schema://ABCD-1234')).toEqual([[0, 27, 'x-custom-schema://ABCD-1234']])
     })
 
     it('after whitespace', () => {
-      expect(urls('open x-cutsom-schema://sub?key=value now')).toEqual([
-        [5, 36, 'x-cutsom-schema://sub?key=value'],
+      expect(urls('open x-custom-schema://sub?key=value now')).toEqual([
+        [5, 36, 'x-custom-schema://sub?key=value'],
       ])
     })
 

--- a/packages/core/src/lezer/scheme-autolink.test.ts
+++ b/packages/core/src/lezer/scheme-autolink.test.ts
@@ -13,19 +13,17 @@ function urls(text: string): Array<[number, number, string]> {
 describe('schemeAutolink', () => {
   describe('detects a bare custom-scheme URI', () => {
     it('at the start of the text', () => {
-      expect(urls('x-devonthink-item://40C8E9F8')).toEqual([
-        [0, 28, 'x-devonthink-item://40C8E9F8'],
-      ])
+      expect(urls('x-cutsom-schema://ABCD-1234')).toEqual([[0, 27, 'x-cutsom-schema://ABCD-1234']])
     })
 
     it('after whitespace', () => {
-      expect(urls('open obsidian://open?vault=notes now')).toEqual([
-        [5, 32, 'obsidian://open?vault=notes'],
+      expect(urls('open x-cutsom-schema://sub?key=value now')).toEqual([
+        [5, 36, 'x-cutsom-schema://sub?key=value'],
       ])
     })
 
     it('with an uppercase scheme', () => {
-      expect(urls('X-DevonThink-Item://ABC')).toEqual([[0, 23, 'X-DevonThink-Item://ABC']])
+      expect(urls('X-Custom-Schema://abc')).toEqual([[0, 21, 'X-Custom-Schema://abc']])
     })
 
     it('with digits and plus in the scheme', () => {

--- a/packages/core/src/lezer/scheme-autolink.ts
+++ b/packages/core/src/lezer/scheme-autolink.ts
@@ -1,0 +1,59 @@
+import type { MarkdownConfig } from '@lezer/markdown'
+
+import {
+  CHAR_LOWERCASE_A,
+  CHAR_LOWERCASE_Z,
+  CHAR_UPPERCASE_A,
+  CHAR_UPPERCASE_Z,
+} from '../unicode.ts'
+
+import { BOUNDARY_BEFORE_RE, trimAutolinkEnd } from './bare-autolink.ts'
+
+// `scheme://` plus a non-space tail. The scheme follows RFC 3986 (a letter,
+// then letters, digits, `+`, `.`, `-`); requiring the `//` and a non-empty
+// tail keeps `note:` prose and a dangling `scheme://` plain text.
+const SCHEME_URI_RE = /^[a-z][a-z0-9+.-]*:\/\/[^\s<]+/i
+
+function isSchemeStartChar(code: number): boolean {
+  return (
+    (code >= CHAR_UPPERCASE_A && code <= CHAR_UPPERCASE_Z) ||
+    (code >= CHAR_LOWERCASE_A && code <= CHAR_LOWERCASE_Z)
+  )
+}
+
+/**
+ * Inline parser for a bare custom-scheme URI such as
+ * `x-devonthink-item://40C8…` or `obsidian://open?vault=notes`. GFM's own
+ * `Autolink` only recognizes `www.`/`http(s)://`/`mailto:`/`xmpp:`/email
+ * forms, so an app URI typed or pasted as plain text stayed unlinkified.
+ *
+ * Registered `after: 'Autolink'` so GFM keeps first claim on the shapes it
+ * knows (its `http(s)` domain and end rules stay authoritative); this parser
+ * only picks up what GFM declines. It follows `bareAutolink`'s boundary rules
+ * and emits the shared `URL` node, so the existing mark walk renders it like
+ * any other autolink.
+ */
+export const schemeAutolink: MarkdownConfig = {
+  parseInline: [
+    {
+      name: 'SchemeAutolink',
+      after: 'Autolink',
+      parse(cx, next, pos) {
+        if (!isSchemeStartChar(next) || cx.hasOpenLink) return -1
+
+        const before = cx.slice(pos - 1, pos)
+        if (before !== '' && !BOUNDARY_BEFORE_RE.test(before)) return -1
+
+        const match = SCHEME_URI_RE.exec(cx.slice(pos, cx.end))
+        if (!match) return -1
+
+        const length = trimAutolinkEnd(match[0])
+        // Trailing-punctuation trimming may leave a tail-less `scheme://`.
+        const tailStart = match[0].indexOf('://') + 3
+        if (length <= tailStart) return -1
+
+        return cx.addElement(cx.elt('URL', pos, pos + length))
+      },
+    },
+  ],
+}

--- a/packages/core/src/lezer/scheme-autolink.ts
+++ b/packages/core/src/lezer/scheme-autolink.ts
@@ -23,7 +23,7 @@ function isSchemeStartChar(code: number): boolean {
 
 /**
  * Inline parser for a bare custom-scheme URI such as
- * `x-devonthink-item://40C8…` or `obsidian://open?vault=notes`. GFM's own
+ * `x-devonthink-item://ABCD-1234` or `obsidian://open?vault=notes`. GFM's own
  * `Autolink` only recognizes `www.`/`http(s)://`/`mailto:`/`xmpp:`/email
  * forms, so an app URI typed or pasted as plain text stayed unlinkified.
  *


### PR DESCRIPTION
Two editing-ergonomics features, in separate commits:

## 1. Paste a URL over selected text → markdown link

Pasting a URL while text is selected now wraps the selection as `[selected text](url)` instead of replacing it — the common "make this word a link" flow no longer requires typing the syntax by hand.

- New `defineLinkPaste` extension (`packages/core/src/extensions/link-paste.ts`), modeled on `defineEmbedPaste`: same `handlePaste` shape, same clipboard-text fallback for Firefox, skips code blocks.
- Triggers only when the clipboard holds **exactly one URL** — recognized via the existing `getAutolinkHref` (any `scheme:` URI, `www.`, curated bare-TLD domains, emails) — and the selection is a non-empty text selection within one textblock (reuses `getWrapRange` from the link commands, so edge whitespace is trimmed the same way `Mod-K` does it). `www.`/bare-domain/email pastes get the same normalized href the link dialog would produce.
- Empty selection or anything else falls through, so embed paste and plain paste are unchanged.
- **Ordering vs. embed paste:** registered with `Priority.high`, so a tweet/YouTube URL pasted *over a selection* becomes a link (the selection wins); pasted at a caret it still embeds. Covered by tests.
- Applied in `@meowdown/react` via a new `linkPaste` prop (on by default), mirroring `embedPaste`.
- One undo restores the plain selected text.

## 2. Autolink bare custom-scheme URIs

Typing or pasting an app URI like `x-devonthink-item://40C8…` or `obsidian://open?vault=notes` as plain text was not linkified: lezer's GFM `Autolink` only recognizes `www.`/`http(s)://`/`mailto:`/`xmpp:`/email forms, even though `getAutolinkHref` already maps any `scheme:` text to a clickable href.

- New `schemeAutolink` inline parser (`packages/core/src/lezer/scheme-autolink.ts`) recognizing `[a-z][a-z0-9+.-]*://` plus a non-space tail, emitting the shared `URL` node so the existing mark walk renders it like any other autolink.
- Registered `after: 'Autolink'`, so GFM keeps first claim on the shapes it knows — its `http(s)` domain/end rules stay authoritative and existing behavior is untouched (locked by a `https://example.com?q=1` regression test).
- Conservative boundaries: follows `bareAutolink`'s boundary-before rule and trailing-punctuation trimming, requires a non-empty tail, so mid-word `word:note://x` and a dangling `note://` stay plain text.
- Intentional side effect: `scheme://` URLs GFM declines (`ftp://example.com`, `https://localhost:3000`) are now linkified — one inline snapshot documenting the old `ftp://` gap was updated accordingly.

Context: prompted by a Reflect user report that DEVONthink-style app URIs are cumbersome — copy/paste yields plain text and `[desc](url)` has to be typed inside-out.

## Testing

- New test suites: `link-paste.test.ts` (25 tests, incl. embed-ordering and fall-through cases) and `scheme-autolink.test.ts` (21 tests), plus editor-level rendering cases in `autolink.test.ts`.
- Full `@meowdown/core` + `@meowdown/react` suites pass (83 files, 1582 tests), `tsc -b`, eslint, oxfmt, and knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
