### PR TITLE
feat(react): interactive task checkboxes in `MarkdownView`

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -95,6 +95,7 @@ export {
 } from './extensions/link-commands.ts'
 export type { LinkEditHandler, LinkEditOptions } from './extensions/link-commands.ts'
 export { defineLinkHoverHandler, type LinkHoverHandler } from './extensions/link-hover.ts'
+export type { ListMarker, MeowdownListAttrs } from './extensions/list.ts'
 export type { MarkChunk } from './extensions/mark-chunk.ts'
 export type { MarkMode } from './extensions/mark-mode.ts'
 export type { MarkName } from './extensions/mark-names.ts'

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,7 +28,8 @@
     "@prosekit/pm": "^0.1.19-beta.2",
     "@prosekit/react": "^0.8.0-beta.19",
     "clsx": "^2.1.1",
-    "lucide-react": "^1.21.0"
+    "lucide-react": "^1.21.0",
+    "react-property": "^2.0.2"
   },
   "peerDependencies": {
     "react": "^19.0.0",

--- a/packages/react/src/components/attributes-to-props.test.ts
+++ b/packages/react/src/components/attributes-to-props.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+
+import { attributesToProps } from './attributes-to-props.ts'
+
+describe('attributesToProps', () => {
+  it('returns an empty object when called without attributes', () => {
+    expect(attributesToProps()).toEqual({})
+    expect(attributesToProps({})).toEqual({})
+  })
+
+  it('converts HTML attribute names to React prop names', () => {
+    expect(attributesToProps({ class: 'note', for: 'field', tabindex: '0' })).toEqual({
+      className: 'note',
+      htmlFor: 'field',
+      tabIndex: '0',
+    })
+  })
+
+  it('matches attribute names case-insensitively', () => {
+    expect(attributesToProps({ CLASS: 'note' })).toEqual({ className: 'note' })
+  })
+
+  it('converts SVG attribute names to React prop names', () => {
+    expect(attributesToProps({ viewbox: '0 0 24 24', 'stroke-width': '2' })).toEqual({
+      viewBox: '0 0 24 24',
+      strokeWidth: '2',
+    })
+  })
+
+  it('keeps aria attributes unchanged', () => {
+    expect(attributesToProps({ 'aria-label': 'Close' })).toEqual({ 'aria-label': 'Close' })
+  })
+
+  it('keeps data attributes unchanged', () => {
+    expect(attributesToProps({ 'data-testid': 'checkbox' })).toEqual({ 'data-testid': 'checkbox' })
+  })
+
+  it('ignores the style attribute', () => {
+    expect(attributesToProps({ style: 'color: red', class: 'note' })).toEqual({
+      className: 'note',
+    })
+  })
+
+  it('keeps unknown attributes unchanged', () => {
+    expect(attributesToProps({ unknownattribute: 'yes' })).toEqual({ unknownattribute: 'yes' })
+  })
+
+  it('converts boolean attributes to true', () => {
+    expect(attributesToProps({ disabled: '' })).toEqual({ disabled: true })
+    expect(attributesToProps({ disabled: 'disabled' })).toEqual({ disabled: true })
+  })
+
+  it('converts overloaded boolean attributes to true only when empty', () => {
+    expect(attributesToProps({ download: '' })).toEqual({ download: true })
+    expect(attributesToProps({ download: 'archive.zip' })).toEqual({ download: 'archive.zip' })
+  })
+
+  it('keeps checked on an input element', () => {
+    expect(attributesToProps({ type: 'checkbox', checked: '' }, 'input')).toEqual({
+      type: 'checkbox',
+      checked: true,
+    })
+  })
+
+  it('keeps value on an input element', () => {
+    expect(attributesToProps({ type: 'text', value: 'hello' }, 'input')).toEqual({
+      type: 'text',
+      value: 'hello',
+    })
+  })
+
+  it('converts value to defaultValue on a textarea element', () => {
+    expect(attributesToProps({ value: 'hello' }, 'textarea')).toEqual({ defaultValue: 'hello' })
+  })
+
+  it('converts value to defaultValue on a select element', () => {
+    expect(attributesToProps({ value: 'apple' }, 'select')).toEqual({ defaultValue: 'apple' })
+  })
+
+  it('keeps value on elements that are not form controls', () => {
+    expect(attributesToProps({ value: '5' }, 'li')).toEqual({ value: '5' })
+  })
+})

--- a/packages/react/src/components/attributes-to-props.test.ts
+++ b/packages/react/src/components/attributes-to-props.test.ts
@@ -63,6 +63,9 @@ describe('attributesToProps', () => {
     expect(attributesToProps({ type: 'checkbox' }, 'input')).toEqual({
       type: 'checkbox',
     })
+    expect(attributesToProps({ type: 'checkbox', checked: undefined }, 'input')).toEqual({
+      type: 'checkbox',
+    })
   })
 
   it('keeps value on an input element', () => {

--- a/packages/react/src/components/attributes-to-props.test.ts
+++ b/packages/react/src/components/attributes-to-props.test.ts
@@ -60,6 +60,9 @@ describe('attributesToProps', () => {
       type: 'checkbox',
       checked: true,
     })
+    expect(attributesToProps({ type: 'checkbox' }, 'input')).toEqual({
+      type: 'checkbox',
+    })
   })
 
   it('keeps value on an input element', () => {

--- a/packages/react/src/components/attributes-to-props.ts
+++ b/packages/react/src/components/attributes-to-props.ts
@@ -48,7 +48,7 @@ type UncontrolledComponentNames = (typeof UNCONTROLLED_COMPONENT_NAMES)[number]
  * @returns - React props.
  */
 export function attributesToProps(
-  attributes: Record<string, string> = {},
+  attributes: Record<string, string | undefined> = {},
   nodeName?: string,
 ): Record<PropertyKey, string | boolean | number> {
   const props: Record<PropertyKey, string | boolean | number> = {}
@@ -56,13 +56,17 @@ export function attributesToProps(
   const isInputValueOnly = nodeName === 'input' || !!attributes['reset'] || !!attributes['submit']
 
   for (const [attributeName, attributeValue] of Object.entries(attributes)) {
-    // Ignore style attribute
-    if (attributeName === 'style') {
+    if (attributeValue === undefined) {
       continue
     }
 
     // convert HTML/SVG attribute to React prop
     const attributeNameLowerCased = attributeName.toLowerCase()
+
+    // Ignore style attribute
+    if (attributeNameLowerCased === 'style') {
+      continue
+    }
 
     // ARIA (aria-*) or custom data (data-*) attribute
     if (
@@ -105,9 +109,6 @@ export function attributesToProps(
     props[attributeName] = attributeValue
   }
 
-  if (nodeName === 'input') {
-    console.log('attributesToProps', JSON.stringify({ attributes, nodeName, props }, null, 2))
-  }
   return props
 }
 

--- a/packages/react/src/components/attributes-to-props.ts
+++ b/packages/react/src/components/attributes-to-props.ts
@@ -68,6 +68,11 @@ export function attributesToProps(
       continue
     }
 
+    // Ignore contentEditable
+    if (attributeNameLowerCased === 'contenteditable') {
+      continue
+    }
+
     // ARIA (aria-*) or custom data (data-*) attribute
     if (
       attributeNameLowerCased.startsWith('aria-') ||

--- a/packages/react/src/components/attributes-to-props.ts
+++ b/packages/react/src/components/attributes-to-props.ts
@@ -2,7 +2,7 @@
 
 Ported from https://github.com/remarkablemark/html-react-parser/blob/v6.1.4/src/attributes-to-props.ts
 
-License: MIT
+License: https://github.com/remarkablemark/html-react-parser/blob/v6.1.4/LICENSE
 
 The MIT License
 

--- a/packages/react/src/components/attributes-to-props.ts
+++ b/packages/react/src/components/attributes-to-props.ts
@@ -1,0 +1,122 @@
+/*
+
+Ported from https://github.com/remarkablemark/html-react-parser/blob/v6.1.4/src/attributes-to-props.ts
+
+License: MIT
+
+The MIT License
+
+Copyright (c) 2016 Menglin "Mark" Xu <mark@remarkablemark.org>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+import { BOOLEAN, getPropertyInfo, OVERLOADED_BOOLEAN, possibleStandardNames } from 'react-property'
+
+// https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components
+// https://developer.mozilla.org/docs/Web/HTML/Attributes
+const UNCONTROLLED_COMPONENT_ATTRIBUTES = ['checked', 'value'] as const
+const UNCONTROLLED_COMPONENT_NAMES = ['input', 'select', 'textarea'] as const
+
+type UncontrolledComponentAttributes = (typeof UNCONTROLLED_COMPONENT_ATTRIBUTES)[number]
+
+type UncontrolledComponentNames = (typeof UNCONTROLLED_COMPONENT_NAMES)[number]
+
+/**
+ * Converts HTML/SVG DOM attributes to React props.
+ *
+ * @param attributes - HTML/SVG DOM attributes.
+ * @param nodeName - DOM node name.
+ * @returns - React props.
+ */
+export function attributesToProps(
+  attributes: Record<string, string> = {},
+  nodeName?: string,
+): Record<PropertyKey, string | boolean | number> {
+  const props: Record<PropertyKey, string | boolean | number> = {}
+
+  const isInputValueOnly = nodeName === 'input' || !!attributes['reset'] || !!attributes['submit']
+
+  for (const [attributeName, attributeValue] of Object.entries(attributes)) {
+    // Ignore style attribute
+    if (attributeName === 'style') {
+      continue
+    }
+
+    // convert HTML/SVG attribute to React prop
+    const attributeNameLowerCased = attributeName.toLowerCase()
+
+    // ARIA (aria-*) or custom data (data-*) attribute
+    if (
+      attributeNameLowerCased.startsWith('aria-') ||
+      attributeNameLowerCased.startsWith('data-')
+    ) {
+      props[attributeName] = attributeValue
+      continue
+    }
+
+    let propName = getPropName(attributeNameLowerCased)
+
+    if (propName) {
+      const propertyInfo = getPropertyInfo(propName) as { type: number } | undefined
+
+      // convert attribute to uncontrolled component prop (e.g., `value` to `defaultValue`)
+      if (
+        UNCONTROLLED_COMPONENT_ATTRIBUTES.includes(propName as UncontrolledComponentAttributes) &&
+        UNCONTROLLED_COMPONENT_NAMES.includes(nodeName as UncontrolledComponentNames) &&
+        !isInputValueOnly
+      ) {
+        propName = getPropName('default' + attributeNameLowerCased)
+      }
+
+      props[propName] = attributeValue
+
+      switch (propertyInfo?.type) {
+        case BOOLEAN:
+          props[propName] = true
+          break
+        case OVERLOADED_BOOLEAN:
+          if (attributeValue === '') {
+            props[propName] = true
+          }
+          break
+      }
+      continue
+    }
+
+    props[attributeName] = attributeValue
+  }
+
+  if (nodeName === 'input') {
+    console.log('attributesToProps', JSON.stringify({ attributes, nodeName, props }, null, 2))
+  }
+  return props
+}
+
+/**
+ * Gets prop name from lowercased attribute name.
+ *
+ * @param attributeName - Lowercased attribute name.
+ * @returns - Prop name.
+ */
+function getPropName(attributeName: string): string {
+  return possibleStandardNames[attributeName]
+}

--- a/packages/react/src/components/dom-output-spec.tsx
+++ b/packages/react/src/components/dom-output-spec.tsx
@@ -1,22 +1,7 @@
 import type { DOMOutputSpec } from '@prosekit/pm/model'
-import { createElement, Fragment, type ReactNode } from 'react'
-import { attributesToProps } from './attributes-to-props.ts'
-
-// DOM attribute names whose React prop name differs. Covers the node/mark specs
-// the walker renders (tables need colSpan/rowSpan; flat-list markers need the
-// SVG names).
-const ATTR_NAME_MAP: Record<string, string> = {
-  class: 'className',
-  contenteditable: 'contentEditable',
-  colspan: 'colSpan',
-  rowspan: 'rowSpan',
-  for: 'htmlFor',
-  tabindex: 'tabIndex',
-  viewbox: 'viewBox',
-}
 
 // Better type safety than `DOMOutputSpec`
-type TypedDOMOutputSpec =
+export type TypedDOMOutputSpec =
   | HTMLElement
   | { dom: HTMLElement; contentDOM?: HTMLElement }
   | [string, Record<string, string>, ...TypedDOMOutputSpecChild[]]
@@ -44,27 +29,4 @@ export function normalizeDOMOutputSpec(
 
   const rest = spec.slice(childStart)
   return [tag, attrs, rest as TypedDOMOutputSpecChild[]]
-}
-
-/**
- * Convert a ProseMirror `DOMOutputSpec` into a React node, substituting `content`
- * for the spec's content hole (`0`). Reused for every node/mark spec the static
- * walker does not special-case, so blocks and plain marks render off their real
- * `toDOM`, exactly as the editor serializes them.
- */
-export function outputSpecToReact(
-  spec: DOMOutputSpec | 0 | string,
-  content: ReactNode,
-  key: number | string = 0,
-): ReactNode {
-  if (typeof spec === 'string') return spec
-  if (spec === 0) return <Fragment key={key}>{content}</Fragment>
-
-  const normalized = normalizeDOMOutputSpec(spec as TypedDOMOutputSpec)
-  if (!normalized) return null
-
-  const [tag, attrs, rest] = normalized
-  const reactProps = attributesToProps(attrs, tag)
-  const reactChildren = rest.map((child, index) => outputSpecToReact(child, content, index))
-  return createElement(tag, { ...reactProps, key }, ...reactChildren)
 }

--- a/packages/react/src/components/dom-output-spec.tsx
+++ b/packages/react/src/components/dom-output-spec.tsx
@@ -1,5 +1,6 @@
 import type { DOMOutputSpec } from '@prosekit/pm/model'
 import { createElement, Fragment, type ReactNode } from 'react'
+import { attributesToProps } from './attributes-to-props.ts'
 
 // DOM attribute names whose React prop name differs. Covers the node/mark specs
 // the walker renders (tables need colSpan/rowSpan; flat-list markers need the
@@ -14,40 +15,35 @@ const ATTR_NAME_MAP: Record<string, string> = {
   viewbox: 'viewBox',
 }
 
-// The array form of `DOMOutputSpec`, typed precisely so element access does not
-// degrade to `any` (ProseMirror types the tail as `any[]`).
-type SpecChild = DOMOutputSpec | 0 | Record<string, string>
-type SpecArray = readonly [string, ...SpecChild[]]
+// Better type safety than `DOMOutputSpec`
+type TypedDOMOutputSpec =
+  | HTMLElement
+  | { dom: HTMLElement; contentDOM?: HTMLElement }
+  | [string, Record<string, string>, ...TypedDOMOutputSpecChild[]]
+  | [string, ...TypedDOMOutputSpecChild[]]
 
-/**
- * Convert a `DOMOutputSpec` attribute object into React props, mapping the DOM
- * attribute names React spells differently. Exported for renderers that build
- * an element by hand (the static task checkbox) but source their attributes
- * from a node's real `toDOM` — see {@link outputSpecAttrs}.
- */
-export function toReactProps(
-  attrs: Record<string, string> | undefined,
-  key?: number | string,
-): Record<string, string | number> {
-  const props: Record<string, string | number> = key === undefined ? {} : { key }
-  if (!attrs) return props
-  for (const [name, value] of Object.entries(attrs)) {
-    // DOMOutputSpec `style` is a CSS string, which React rejects. Our specs do
-    // not emit inline styles, so dropping it is safe.
-    if (name === 'style') continue
-    props[ATTR_NAME_MAP[name] ?? name] = value
-  }
-  return props
-}
+type TypedDOMOutputSpecChild = TypedDOMOutputSpec | 0 | string
 
-/** The attribute object of an array-form `DOMOutputSpec`, when it carries one. */
-export function outputSpecAttrs(spec: DOMOutputSpec): Record<string, string> | undefined {
-  if (typeof spec === 'string' || !Array.isArray(spec)) return undefined
-  const second = (spec as SpecArray)[1]
+export function normalizeDOMOutputSpec(
+  domSpec: DOMOutputSpec,
+):
+  | [tag: string, attrs: Record<string, string> | undefined, rest: TypedDOMOutputSpecChild[]]
+  | undefined {
+  const spec = domSpec as TypedDOMOutputSpec
+  if (!spec || !Array.isArray(spec)) return
+
+  const tag = spec[0]
+
+  let childStart = 1
+  let attrs: Record<string, string> | undefined
+  const second = spec[1]
   if (second != null && second !== 0 && typeof second === 'object' && !Array.isArray(second)) {
-    return second as Record<string, string>
+    attrs = second as Record<string, string>
+    childStart = 2
   }
-  return undefined
+
+  const rest = spec.slice(childStart)
+  return [tag, attrs, rest as TypedDOMOutputSpecChild[]]
 }
 
 /**
@@ -57,34 +53,18 @@ export function outputSpecAttrs(spec: DOMOutputSpec): Record<string, string> | u
  * `toDOM`, exactly as the editor serializes them.
  */
 export function outputSpecToReact(
-  spec: DOMOutputSpec,
+  spec: DOMOutputSpec | 0 | string,
   content: ReactNode,
   key: number | string = 0,
 ): ReactNode {
   if (typeof spec === 'string') return spec
-  if (!Array.isArray(spec)) return null
+  if (spec === 0) return <Fragment key={key}>{content}</Fragment>
 
-  const array = spec as SpecArray
-  const tag = array[0]
+  const normalized = normalizeDOMOutputSpec(spec as TypedDOMOutputSpec)
+  if (!normalized) return null
 
-  let childStart = 1
-  let attrs: Record<string, string> | undefined
-  const second = array[1]
-  if (second != null && second !== 0 && typeof second === 'object' && !Array.isArray(second)) {
-    attrs = second as Record<string, string>
-    childStart = 2
-  }
-
-  const props = toReactProps(attrs, key)
-  const rest = array.slice(childStart)
-  if (rest.length === 0) return createElement(tag, props)
-
-  const children = rest.map((child, index) =>
-    child === 0 ? (
-      <Fragment key={index}>{content}</Fragment>
-    ) : (
-      outputSpecToReact(child as DOMOutputSpec, content, index)
-    ),
-  )
-  return createElement(tag, props, ...children)
+  const [tag, attrs, rest] = normalized
+  const reactProps = attributesToProps(attrs, tag)
+  const reactChildren = rest.map((child, index) => outputSpecToReact(child, content, index))
+  return createElement(tag, { ...reactProps, key }, ...reactChildren)
 }

--- a/packages/react/src/components/dom-output-spec.tsx
+++ b/packages/react/src/components/dom-output-spec.tsx
@@ -19,11 +19,17 @@ const ATTR_NAME_MAP: Record<string, string> = {
 type SpecChild = DOMOutputSpec | 0 | Record<string, string>
 type SpecArray = readonly [string, ...SpecChild[]]
 
-function toReactProps(
+/**
+ * Convert a `DOMOutputSpec` attribute object into React props, mapping the DOM
+ * attribute names React spells differently. Exported for renderers that build
+ * an element by hand (the static task checkbox) but source their attributes
+ * from a node's real `toDOM` — see {@link outputSpecAttrs}.
+ */
+export function toReactProps(
   attrs: Record<string, string> | undefined,
-  key: number | string,
+  key?: number | string,
 ): Record<string, string | number> {
-  const props: Record<string, string | number> = { key }
+  const props: Record<string, string | number> = key === undefined ? {} : { key }
   if (!attrs) return props
   for (const [name, value] of Object.entries(attrs)) {
     // DOMOutputSpec `style` is a CSS string, which React rejects. Our specs do
@@ -32,6 +38,16 @@ function toReactProps(
     props[ATTR_NAME_MAP[name] ?? name] = value
   }
   return props
+}
+
+/** The attribute object of an array-form `DOMOutputSpec`, when it carries one. */
+export function outputSpecAttrs(spec: DOMOutputSpec): Record<string, string> | undefined {
+  if (typeof spec === 'string' || !Array.isArray(spec)) return undefined
+  const second = (spec as SpecArray)[1]
+  if (second != null && second !== 0 && typeof second === 'object' && !Array.isArray(second)) {
+    return second as Record<string, string>
+  }
+  return undefined
 }
 
 /**

--- a/packages/react/src/components/markdown-view.test.tsx
+++ b/packages/react/src/components/markdown-view.test.tsx
@@ -145,11 +145,11 @@ describe('MarkdownView', () => {
     const onTaskClick = vi.fn()
     await renderView('+ [ ] open', { onTaskClick })
     const box = view.locate('input[type="checkbox"]')
+    await expect.element(box, { timeout: 2000 }).not.toBeChecked()
     expect(onTaskClick).toHaveBeenCalledTimes(0)
-    await expect.element(box, { timeout: 2000 }).not.toBeChecked()
     await box.click()
-    expect(onTaskClick).toHaveBeenCalledTimes(1)
     await expect.element(box, { timeout: 2000 }).not.toBeChecked()
+    expect(onTaskClick).toHaveBeenCalledTimes(1)
   })
 
   it('keeps checkboxes inert without an onTaskClick handler', async () => {

--- a/packages/react/src/components/markdown-view.test.tsx
+++ b/packages/react/src/components/markdown-view.test.tsx
@@ -104,6 +104,71 @@ describe('MarkdownView', () => {
     await expect.element(view).toHaveTextContent('foo')
   })
 
+  it('renders task checkboxes with their checked state', async () => {
+    await renderView('+ [ ] open\n+ [x] done')
+    const boxes = view.locate('input[type="checkbox"]')
+    await expect.element(boxes.first()).not.toBeChecked()
+    await expect.element(boxes.last()).toBeChecked()
+  })
+
+  it('calls onTaskClick with the document-order index and task facts', async () => {
+    const onTaskClick = vi.fn()
+    await renderView('+ [ ] first\n+ [x] **second** [[Note]]\n- [ ] square', { onTaskClick })
+    await view.locate('input[type="checkbox"]').nth(1).click()
+    expect(onTaskClick).toHaveBeenCalledTimes(1)
+    expect(onTaskClick).toHaveBeenCalledWith(
+      expect.objectContaining({
+        index: 1,
+        checked: true,
+        marker: '+',
+        text: '**second** [[Note]]',
+      }),
+    )
+    await view.locate('input[type="checkbox"]').nth(2).click()
+    expect(onTaskClick).toHaveBeenLastCalledWith(
+      expect.objectContaining({ index: 2, checked: false, marker: '-', text: 'square' }),
+    )
+  })
+
+  it('numbers a nested task after its parent, in document order', async () => {
+    const onTaskClick = vi.fn()
+    await renderView('+ [ ] parent\n  + [ ] child\n+ [ ] after', { onTaskClick })
+    await view.locate('input[type="checkbox"]').nth(1).click()
+    expect(onTaskClick).toHaveBeenCalledWith(expect.objectContaining({ index: 1, text: 'child' }))
+    await view.locate('input[type="checkbox"]').nth(2).click()
+    expect(onTaskClick).toHaveBeenLastCalledWith(
+      expect.objectContaining({ index: 2, text: 'after' }),
+    )
+  })
+
+  it('never flips a clicked checkbox itself', async () => {
+    const onTaskClick = vi.fn()
+    await renderView('+ [ ] open', { onTaskClick })
+    const box = view.locate('input[type="checkbox"]')
+    await box.click()
+    await expect.element(box).not.toBeChecked()
+    expect(onTaskClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps checkboxes inert without an onTaskClick handler', async () => {
+    await renderView('+ [x] done')
+    const box = view.locate('input[type="checkbox"]')
+    await box.click()
+    await expect.element(box).toBeChecked()
+  })
+
+  it('re-seats checkbox state when the markdown prop changes', async () => {
+    const screen = await renderView('+ [ ] task')
+    const box = view.locate('input[type="checkbox"]')
+    await expect.element(box).not.toBeChecked()
+    await screen.rerender(
+      <div data-testid="markdown-view">
+        <MarkdownView markdown="+ [x] task" />
+      </div>,
+    )
+    await expect.element(box).toBeChecked()
+  })
+
   it('updates when the markdown prop changes', async () => {
     const screen = await renderView('first')
     await expect.element(view).toHaveTextContent('first')
@@ -175,6 +240,8 @@ describe('MarkdownView parity with the editor', () => {
     'a #tag here',
     'link [text](https://example.com) end',
     'a [[Note]] and [[target|Alias]] inline',
+    '+ [ ] circle **task**',
+    '- [x] square **done**',
   ])('matches the editor for %s', async (markdown) => {
     await render(
       <div data-testid="parity-editor">

--- a/packages/react/src/components/markdown-view.test.tsx
+++ b/packages/react/src/components/markdown-view.test.tsx
@@ -141,7 +141,7 @@ describe('MarkdownView', () => {
     )
   })
 
-  it.only('never flips a clicked checkbox itself', async () => {
+  it('never flips a clicked checkbox itself', async () => {
     const onTaskClick = vi.fn()
     await renderView('+ [ ] open', { onTaskClick })
     const box = view.locate('input[type="checkbox"]')

--- a/packages/react/src/components/markdown-view.test.tsx
+++ b/packages/react/src/components/markdown-view.test.tsx
@@ -141,13 +141,15 @@ describe('MarkdownView', () => {
     )
   })
 
-  it('never flips a clicked checkbox itself', async () => {
+  it.only('never flips a clicked checkbox itself', async () => {
     const onTaskClick = vi.fn()
     await renderView('+ [ ] open', { onTaskClick })
     const box = view.locate('input[type="checkbox"]')
+    expect(onTaskClick).toHaveBeenCalledTimes(0)
+    await expect.element(box, { timeout: 2000 }).not.toBeChecked()
     await box.click()
-    await expect.element(box).not.toBeChecked()
     expect(onTaskClick).toHaveBeenCalledTimes(1)
+    await expect.element(box, { timeout: 2000 }).not.toBeChecked()
   })
 
   it('keeps checkboxes inert without an onTaskClick handler', async () => {
@@ -184,7 +186,14 @@ describe('MarkdownView', () => {
 // Strip editor-only attributes and sort the rest, so two DOM subtrees compare
 // equal regardless of attribute order or ProseMirror's editing affordances.
 function canonicalize(root: Element): string {
-  const SKIP = new Set(['contenteditable', 'translate', 'draggable', 'spellcheck', 'tabindex'])
+  const SKIP = new Set([
+    'contenteditable',
+    'translate',
+    'draggable',
+    'spellcheck',
+    'tabindex',
+    'readonly',
+  ])
   const walk = (node: ChildNode): string => {
     if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? ''
     if (node.nodeType !== Node.ELEMENT_NODE) return ''

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -39,7 +39,7 @@ import {
 import { useKaTeX } from '../hooks/use-katex.ts'
 
 import styles from './code-block-view.module.css'
-import { outputSpecAttrs, outputSpecToReact, toReactProps } from './dom-output-spec.tsx'
+import { normalizeDOMOutputSpec, outputSpecToReact } from './dom-output-spec.tsx'
 import { MathRender } from './math-render.tsx'
 
 /** Payload for {@link TaskClickHandler}. */
@@ -418,8 +418,16 @@ function TaskItemView(props: {
   const { node, index, onTaskClick, children } = props
   const attrs = node.attrs as MeowdownListAttrs
   const checked = attrs.checked === true
-  const toDOM = node.type.spec.toDOM
-  const outerProps = toReactProps(toDOM ? outputSpecAttrs(toDOM(node)) : undefined)
+  const domSpec = node.type.spec.toDOM?.(node)
+  const domSpec2 = domSpec && normalizeDOMOutputSpec(domSpec)
+  console.log('domSpec', domSpec)
+  console.log('domSpec2', domSpec2)
+
+  const domSpecAttrs = domSpec2?.[1]
+  // const reactProps = toReactProps(domSpecAttrs)
+
+  // const domSpecAttrs = domSpec && outputSpecAttrs(domSpec)
+  // const outerProps = domSpecAttrs && toReactProps(domSpecAttrs)
   const handleClick = (event: MouseEvent) => {
     event.preventDefault()
     const lead = node.firstChild
@@ -433,7 +441,7 @@ function TaskItemView(props: {
     })
   }
   return (
-    <div {...outerProps}>
+    <div {...reactProps}>
       <div className="list-marker list-marker-click-target" contentEditable={false}>
         <label>
           <input
@@ -484,13 +492,13 @@ function renderBlock(node: ProseMirrorNode, key: number, context: RenderContext)
   node.forEach((child, _offset, index) => {
     children.push(renderBlock(child, index, context))
   })
-  if (isTaskItem) {
-    return (
-      <TaskItemView key={key} node={node} index={taskIndex} onTaskClick={context.onTaskClick}>
-        {children}
-      </TaskItemView>
-    )
-  }
+  // if (isTaskItem) {
+  //   return (
+  //     <TaskItemView key={key} node={node} index={taskIndex} onTaskClick={context.onTaskClick}>
+  //       {children}
+  //     </TaskItemView>
+  //   )
+  // }
   return toDOM ? (
     outputSpecToReact(toDOM(node), children, key)
   ) : (

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -29,6 +29,7 @@ import { attributesToProps } from './attributes-to-props.ts'
 import { Mark, type Node as ProseMirrorNode } from '@prosekit/pm/model'
 import { clsx } from 'clsx/lite'
 import {
+  cloneElement,
   createElement,
   Fragment,
   useEffect,
@@ -119,7 +120,7 @@ export function outputSpecToReact(
   spec: DOMOutputSpec | 0 | string,
   content: ReactNode,
   context: RenderContext,
-): ReactNode {
+): ReactElement | string | null {
   const key = context.keyCounter.value++
   if (typeof spec === 'string') return spec
   if (spec === 0) return <Fragment key={key}>{content}</Fragment>
@@ -430,68 +431,30 @@ function renderInline(node: ProseMirrorNode, context: RenderContext): ReactNode 
   return renderRuns(runs, 0, context)
 }
 
-/**
- * A task list item, mirroring `prosemirror-flat-list`'s `listToDOM` DOM shape
- * (which the generic `toDOM` walk would produce) but with a live checkbox: the
- * generic walk hands React `checked: ''` — falsy, so a checked task rendered
- * unchecked — and no way to click. The outer element's attributes still come
- * from the node's real `toDOM`, so extension attributes (`data-list-marker`,
- * `data-list-checked`, …) and their CSS keep working. The input is keyed by its
- * state so a `markdown` change re-seats `defaultChecked`, while `preventDefault`
- * keeps a click from flipping the DOM out from under the source of truth.
- */
-function TaskItemView(props: {
-  node: ProseMirrorNode
-  index: number
-  onTaskClick?: TaskClickHandler
-  children: ReactNode
-}): ReactElement {
-  const { node, index, onTaskClick, children } = props
-  const attrs = node.attrs as MeowdownListAttrs
-  const checked = attrs.checked === true
-  const domSpec = node.type.spec.toDOM?.(node)
-  const domSpec2 = domSpec && normalizeDOMOutputSpec(domSpec)
-  console.log('domSpec', domSpec)
-  console.log('domSpec2', domSpec2)
-
-  const domSpecAttrs = domSpec2?.[1]
-  // const reactProps = toReactProps(domSpecAttrs)
-
-  // const domSpecAttrs = domSpec && outputSpecAttrs(domSpec)
-  // const outerProps = domSpecAttrs && toReactProps(domSpecAttrs)
-  const handleClick = (event: MouseEvent) => {
-    event.preventDefault()
-    const lead = node.firstChild
-    const text = lead?.isTextblock ? (lead.textContent.split('\n', 1)[0] ?? '') : ''
-    onTaskClick?.({
-      index,
-      checked,
-      marker: attrs.marker ?? null,
-      text,
-      event: event.nativeEvent,
-    })
-  }
-  return (
-    <div {...reactProps}>
-      <div className="list-marker list-marker-click-target" contentEditable={false}>
-        <label>
-          <input
-            key={checked ? 'checked' : 'unchecked'}
-            type="checkbox"
-            defaultChecked={checked}
-            onClick={handleClick}
-          />
-        </label>
-      </div>
-      <div className="list-content">{children}</div>
-    </div>
-  )
-}
-
 function renderBlock(node: ProseMirrorNode, context: RenderContext): ReactNode {
   const key = context.keyCounter.value++
+  const typeName = node.type.name as NodeName
 
-  if (node.type.name === ('codeBlock' satisfies NodeName)) {
+  let handleTaskClick: ((event: MouseEvent) => void) | undefined
+
+  if (typeName === 'list') {
+    const attrs = node.attrs as MeowdownListAttrs
+    const { onTaskClick } = context
+    if (attrs.kind === 'task' && onTaskClick) {
+      const index = context.taskCounter.value++
+      const checked = attrs.checked === true
+      const marker = attrs.marker ?? null
+      // TODO: the rule to get the text is a bit weird. Re-visit this later.
+      const text = node.firstChild?.isTextblock
+        ? (node.firstChild.textContent.split('\n', 1)[0] ?? '')
+        : ''
+      handleTaskClick = (event) => {
+        onTaskClick({ index, checked, marker, text, event: event.nativeEvent })
+      }
+    }
+  }
+
+  if (typeName === 'codeBlock') {
     const attrs = node.attrs as CodeBlockAttrs
     const language: string = typeof attrs.language === 'string' ? attrs.language : ''
     if (language === 'math') {
@@ -512,11 +475,23 @@ function renderBlock(node: ProseMirrorNode, context: RenderContext): ReactNode {
 
   const children: ReactNode[] = node.content.content.map((child) => renderBlock(child, context))
 
-  return toDOM ? (
+  const reactNode = toDOM ? (
     outputSpecToReact(toDOM(node), children, context)
   ) : (
     <Fragment key={key}>{children}</Fragment>
   )
+
+  if (
+    typeName === 'list' &&
+    handleTaskClick &&
+    typeof reactNode !== 'string' &&
+    reactNode != null
+  ) {
+    // eslint-disable-next-line @eslint-react/no-clone-element
+    return cloneElement(reactNode, { onClick: handleTaskClick })
+  }
+
+  return reactNode
 }
 
 /**
@@ -550,12 +525,9 @@ export function MarkdownView({
       onImageClick,
       onTaskClick,
       taskCounter: { value: 0 },
+      keyCounter: { value: 0 },
     }
-    const blocks: ReactNode[] = []
-    doc.forEach((node, _offset, index) => {
-      blocks.push(renderBlock(node, index, context))
-    })
-    return blocks
+    return doc.content.content.map((node) => renderBlock(node, context))
   }, [
     markdown,
     frontmatter,

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -121,6 +121,7 @@ export function outputSpecToReact(
   context: RenderContext,
 ): ReactElement | string | null {
   const key = context.keyCounter.value++
+
   if (typeof spec === 'string') return spec
   if (spec === 0) return <Fragment key={key}>{content}</Fragment>
 
@@ -129,7 +130,7 @@ export function outputSpecToReact(
 
   const [tag, attrs, rest] = normalized
   const reactProps = { ...attributesToProps(attrs, tag) }
-  reactProps.key = key
+  reactProps.key = `${key} ${JSON.stringify(attrs)}`
 
   if (tag === 'input' && attrs?.['type'] === 'checkbox') {
     reactProps.readOnly = true

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -24,8 +24,6 @@ import {
   type WikilinkClickHandler,
 } from '@meowdown/core'
 import type { DOMOutputSpec } from '@prosekit/pm/model'
-import { attributesToProps } from './attributes-to-props.ts'
-
 import { Mark, type Node as ProseMirrorNode } from '@prosekit/pm/model'
 import { clsx } from 'clsx/lite'
 import {
@@ -43,6 +41,7 @@ import {
 
 import { useKaTeX } from '../hooks/use-katex.ts'
 
+import { attributesToProps } from './attributes-to-props.ts'
 import styles from './code-block-view.module.css'
 import { normalizeDOMOutputSpec, type TypedDOMOutputSpec } from './dom-output-spec.tsx'
 import { MathRender } from './math-render.tsx'

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -131,6 +131,10 @@ export function outputSpecToReact(
   const reactProps = { ...attributesToProps(attrs, tag) }
   reactProps.key = key
 
+  if (tag === 'input' && attrs?.['type'] === 'checkbox') {
+    reactProps.readOnly = true
+  }
+
   const reactChildren = rest.map((child) => outputSpecToReact(child, content, context))
   return createElement(tag, reactProps, ...reactChildren)
 }

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -11,6 +11,7 @@ import {
   type EmbedDescriptor,
   type ImageClickHandler,
   type LinkClickHandler,
+  type ListMarker,
   type MarkChunk,
   type MarkMode,
   type MarkName,
@@ -18,6 +19,7 @@ import {
   type MdLinkTextAttrs,
   type MdMathAttrs,
   type MdWikilinkAttrs,
+  type MeowdownListAttrs,
   type NodeName,
   type WikilinkClickHandler,
 } from '@meowdown/core'
@@ -37,8 +39,39 @@ import {
 import { useKaTeX } from '../hooks/use-katex.ts'
 
 import styles from './code-block-view.module.css'
-import { outputSpecToReact } from './dom-output-spec.tsx'
+import { outputSpecAttrs, outputSpecToReact, toReactProps } from './dom-output-spec.tsx'
 import { MathRender } from './math-render.tsx'
+
+/** Payload for {@link TaskClickHandler}. */
+export interface TaskClickPayload {
+  /**
+   * Zero-based position of the clicked checkbox among all the checkboxes this
+   * view renders, in document order. Stable for a given `markdown`, so a host
+   * can map it back to the corresponding task item in its own parse of the
+   * same source.
+   */
+  index: number
+  /** The checkbox's rendered state. The view never flips it — see the handler doc. */
+  checked: boolean
+  /** The item's list marker as written (`+` renders a circle checkbox, `-`/`*` a square). */
+  marker: ListMarker
+  /**
+   * First line of the item's own inline content, exactly as it appears in the
+   * source after the `[ ]`/`[x]` marker and one space. A host locating the task
+   * by {@link index} can cross-check this against its own parse and refuse a
+   * mismatch instead of toggling the wrong item.
+   */
+  text: string
+  /** The originating click. Read modifier keys or position a popover from it. */
+  event: globalThis.MouseEvent
+}
+
+/**
+ * Called when a rendered task checkbox is clicked. The view is a pure render
+ * of `markdown` and never flips the box itself: apply the toggle to the
+ * source and re-render, exactly like the other click handlers.
+ */
+export type TaskClickHandler = (payload: TaskClickPayload) => void
 
 export interface MarkdownViewProps {
   /** The Markdown to render. Live: changing it re-renders the content. */
@@ -55,6 +88,8 @@ export interface MarkdownViewProps {
   onLinkClick?: LinkClickHandler
   /** Called when a rendered image is clicked. Pass a stable function. */
   onImageClick?: ImageClickHandler
+  /** Called when a rendered task checkbox is clicked. Pass a stable function. */
+  onTaskClick?: TaskClickHandler
   /** Extra class on the content root (alongside `ProseMirror meowdown-content`). */
   className?: string
 }
@@ -64,6 +99,9 @@ interface RenderContext {
   onWikilinkClick?: WikilinkClickHandler
   onLinkClick?: LinkClickHandler
   onImageClick?: ImageClickHandler
+  onTaskClick?: TaskClickHandler
+  /** Document-order checkbox counter feeding {@link TaskClickPayload.index}. */
+  taskCounter: { value: number }
 }
 
 function WikilinkChip(props: {
@@ -361,6 +399,56 @@ function renderInline(node: ProseMirrorNode, context: RenderContext): ReactNode 
   return renderRuns(runs, 0, context)
 }
 
+/**
+ * A task list item, mirroring `prosemirror-flat-list`'s `listToDOM` DOM shape
+ * (which the generic `toDOM` walk would produce) but with a live checkbox: the
+ * generic walk hands React `checked: ''` — falsy, so a checked task rendered
+ * unchecked — and no way to click. The outer element's attributes still come
+ * from the node's real `toDOM`, so extension attributes (`data-list-marker`,
+ * `data-list-checked`, …) and their CSS keep working. The input is keyed by its
+ * state so a `markdown` change re-seats `defaultChecked`, while `preventDefault`
+ * keeps a click from flipping the DOM out from under the source of truth.
+ */
+function TaskItemView(props: {
+  node: ProseMirrorNode
+  index: number
+  onTaskClick?: TaskClickHandler
+  children: ReactNode
+}): ReactElement {
+  const { node, index, onTaskClick, children } = props
+  const attrs = node.attrs as MeowdownListAttrs
+  const checked = attrs.checked === true
+  const toDOM = node.type.spec.toDOM
+  const outerProps = toReactProps(toDOM ? outputSpecAttrs(toDOM(node)) : undefined)
+  const handleClick = (event: MouseEvent) => {
+    event.preventDefault()
+    const lead = node.firstChild
+    const text = lead?.isTextblock ? (lead.textContent.split('\n', 1)[0] ?? '') : ''
+    onTaskClick?.({
+      index,
+      checked,
+      marker: attrs.marker ?? null,
+      text,
+      event: event.nativeEvent,
+    })
+  }
+  return (
+    <div {...outerProps}>
+      <div className="list-marker list-marker-click-target" contentEditable={false}>
+        <label>
+          <input
+            key={checked ? 'checked' : 'unchecked'}
+            type="checkbox"
+            defaultChecked={checked}
+            onClick={handleClick}
+          />
+        </label>
+      </div>
+      <div className="list-content">{children}</div>
+    </div>
+  )
+}
+
 function renderBlock(node: ProseMirrorNode, key: number, context: RenderContext): ReactNode {
   if (node.type.name === ('codeBlock' satisfies NodeName)) {
     const attrs = node.attrs as CodeBlockAttrs
@@ -381,10 +469,28 @@ function renderBlock(node: ProseMirrorNode, key: number, context: RenderContext)
     )
   }
 
+  // A checkbox task item renders through the interactive special case. Claim
+  // the document-order index before descending so a nested task numbers after
+  // its parent — the order a source-based parse of the same markdown sees.
+  // (When the first child is itself a list the node is a bare wrapper with no
+  // marker of its own, so the generic path applies.)
+  const isTaskItem =
+    node.type.name === ('list' satisfies NodeName) &&
+    (node.attrs as MeowdownListAttrs).kind === 'task' &&
+    node.firstChild?.type !== node.type
+  const taskIndex = isTaskItem ? context.taskCounter.value++ : 0
+
   const children: ReactNode[] = []
   node.forEach((child, _offset, index) => {
     children.push(renderBlock(child, index, context))
   })
+  if (isTaskItem) {
+    return (
+      <TaskItemView key={key} node={node} index={taskIndex} onTaskClick={context.onTaskClick}>
+        {children}
+      </TaskItemView>
+    )
+  }
   return toDOM ? (
     outputSpecToReact(toDOM(node), children, key)
   ) : (
@@ -411,17 +517,33 @@ export function MarkdownView({
   onWikilinkClick,
   onLinkClick,
   onImageClick,
+  onTaskClick,
   className,
 }: MarkdownViewProps): ReactElement {
   const content = useMemo(() => {
     const doc = markdownToDoc(markdown, { frontmatter })
-    const context: RenderContext = { resolveImageUrl, onWikilinkClick, onLinkClick, onImageClick }
+    const context: RenderContext = {
+      resolveImageUrl,
+      onWikilinkClick,
+      onLinkClick,
+      onImageClick,
+      onTaskClick,
+      taskCounter: { value: 0 },
+    }
     const blocks: ReactNode[] = []
     doc.forEach((node, _offset, index) => {
       blocks.push(renderBlock(node, index, context))
     })
     return blocks
-  }, [markdown, frontmatter, resolveImageUrl, onWikilinkClick, onLinkClick, onImageClick])
+  }, [
+    markdown,
+    frontmatter,
+    resolveImageUrl,
+    onWikilinkClick,
+    onLinkClick,
+    onImageClick,
+    onTaskClick,
+  ])
 
   return (
     <div className={clsx('ProseMirror', 'meowdown-content', className)} data-mark-mode={markMode}>

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -452,6 +452,7 @@ function renderBlock(node: ProseMirrorNode, context: RenderContext): ReactNode {
         ? (node.firstChild.textContent.split('\n', 1)[0] ?? '')
         : ''
       handleTaskClick = (event) => {
+        event.preventDefault()
         onTaskClick({ index, checked, marker, text, event: event.nativeEvent })
       }
     }

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -115,7 +115,7 @@ interface RenderContext {
  * walker does not special-case, so blocks and plain marks render off their real
  * `toDOM`, exactly as the editor serializes them.
  */
-export function outputSpecToReact(
+function outputSpecToReact(
   spec: DOMOutputSpec | 0 | string,
   content: ReactNode,
   context: RenderContext,

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -23,9 +23,13 @@ import {
   type NodeName,
   type WikilinkClickHandler,
 } from '@meowdown/core'
+import type { DOMOutputSpec } from '@prosekit/pm/model'
+import { attributesToProps } from './attributes-to-props.ts'
+
 import { Mark, type Node as ProseMirrorNode } from '@prosekit/pm/model'
 import { clsx } from 'clsx/lite'
 import {
+  createElement,
   Fragment,
   useEffect,
   useMemo,
@@ -39,7 +43,7 @@ import {
 import { useKaTeX } from '../hooks/use-katex.ts'
 
 import styles from './code-block-view.module.css'
-import { normalizeDOMOutputSpec, outputSpecToReact } from './dom-output-spec.tsx'
+import { normalizeDOMOutputSpec, type TypedDOMOutputSpec } from './dom-output-spec.tsx'
 import { MathRender } from './math-render.tsx'
 
 /** Payload for {@link TaskClickHandler}. */
@@ -102,6 +106,33 @@ interface RenderContext {
   onTaskClick?: TaskClickHandler
   /** Document-order checkbox counter feeding {@link TaskClickPayload.index}. */
   taskCounter: { value: number }
+  keyCounter: { value: number }
+}
+
+/**
+ * Convert a ProseMirror `DOMOutputSpec` into a React node, substituting `content`
+ * for the spec's content hole (`0`). Reused for every node/mark spec the static
+ * walker does not special-case, so blocks and plain marks render off their real
+ * `toDOM`, exactly as the editor serializes them.
+ */
+export function outputSpecToReact(
+  spec: DOMOutputSpec | 0 | string,
+  content: ReactNode,
+  context: RenderContext,
+): ReactNode {
+  const key = context.keyCounter.value++
+  if (typeof spec === 'string') return spec
+  if (spec === 0) return <Fragment key={key}>{content}</Fragment>
+
+  const normalized = normalizeDOMOutputSpec(spec as TypedDOMOutputSpec)
+  if (!normalized) return null
+
+  const [tag, attrs, rest] = normalized
+  const reactProps = { ...attributesToProps(attrs, tag) }
+  reactProps.key = key
+
+  const reactChildren = rest.map((child) => outputSpecToReact(child, content, context))
+  return createElement(tag, reactProps, ...reactChildren)
 }
 
 function WikilinkChip(props: {
@@ -340,7 +371,7 @@ function wrapMark(mark: Mark, children: ReactNode, context: RenderContext): Reac
     default: {
       const toDOM = mark.type.spec.toDOM
       if (!toDOM) return children
-      return outputSpecToReact(toDOM(mark, true), children)
+      return outputSpecToReact(toDOM(mark, true), children, context)
     }
   }
 }
@@ -457,7 +488,9 @@ function TaskItemView(props: {
   )
 }
 
-function renderBlock(node: ProseMirrorNode, key: number, context: RenderContext): ReactNode {
+function renderBlock(node: ProseMirrorNode, context: RenderContext): ReactNode {
+  const key = context.keyCounter.value++
+
   if (node.type.name === ('codeBlock' satisfies NodeName)) {
     const attrs = node.attrs as CodeBlockAttrs
     const language: string = typeof attrs.language === 'string' ? attrs.language : ''
@@ -471,36 +504,16 @@ function renderBlock(node: ProseMirrorNode, key: number, context: RenderContext)
   if (node.isTextblock) {
     const inline = renderInline(node, context)
     return toDOM ? (
-      outputSpecToReact(toDOM(node), inline, key)
+      outputSpecToReact(toDOM(node), inline, context)
     ) : (
       <Fragment key={key}>{inline}</Fragment>
     )
   }
 
-  // A checkbox task item renders through the interactive special case. Claim
-  // the document-order index before descending so a nested task numbers after
-  // its parent — the order a source-based parse of the same markdown sees.
-  // (When the first child is itself a list the node is a bare wrapper with no
-  // marker of its own, so the generic path applies.)
-  const isTaskItem =
-    node.type.name === ('list' satisfies NodeName) &&
-    (node.attrs as MeowdownListAttrs).kind === 'task' &&
-    node.firstChild?.type !== node.type
-  const taskIndex = isTaskItem ? context.taskCounter.value++ : 0
+  const children: ReactNode[] = node.content.content.map((child) => renderBlock(child, context))
 
-  const children: ReactNode[] = []
-  node.forEach((child, _offset, index) => {
-    children.push(renderBlock(child, index, context))
-  })
-  // if (isTaskItem) {
-  //   return (
-  //     <TaskItemView key={key} node={node} index={taskIndex} onTaskClick={context.onTaskClick}>
-  //       {children}
-  //     </TaskItemView>
-  //   )
-  // }
   return toDOM ? (
-    outputSpecToReact(toDOM(node), children, key)
+    outputSpecToReact(toDOM(node), children, context)
   ) : (
     <Fragment key={key}>{children}</Fragment>
   )

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,5 +1,10 @@
 export { MeowdownEditor, type EditorMode, type EditorProps } from './components/editor.tsx'
-export { MarkdownView, type MarkdownViewProps } from './components/markdown-view.tsx'
+export {
+  MarkdownView,
+  type MarkdownViewProps,
+  type TaskClickHandler,
+  type TaskClickPayload,
+} from './components/markdown-view.tsx'
 export type { TimeFormat } from './utils/date-format.ts'
 export type {
   EditorHandle,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,9 @@ importers:
       lucide-react:
         specifier: ^1.21.0
         version: 1.21.0(react@19.2.7)
+      react-property:
+        specifier: ^2.0.2
+        version: 2.0.2
     devDependencies:
       '@css-modules-kit/codegen':
         specifier: ^1.3.0
@@ -3086,6 +3089,9 @@ packages:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
       react: ^19.2.7
+
+  react-property@2.0.2:
+    resolution: {integrity: sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==}
 
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
@@ -7009,6 +7015,8 @@ snapshots:
     dependencies:
       react: 19.2.7
       scheduler: 0.27.0
+
+  react-property@2.0.2: {}
 
   react@19.2.7: {}
 

--- a/website/src/components/demo-editor.tsx
+++ b/website/src/components/demo-editor.tsx
@@ -3,8 +3,9 @@ import {
   type EditorHandle,
   type EditorMode,
   type EditorProps,
+  type TaskClickHandler,
 } from '@meowdown/react'
-import { useRef, type RefObject } from 'react'
+import { useCallback, useRef, type RefObject } from 'react'
 
 import { CodeMirrorEditor } from './codemirror-editor.tsx'
 import type { MarkdownSource } from './markdown-source.ts'
@@ -46,6 +47,10 @@ export function DemoEditor({
   const seedMarkdown =
     richRef.current?.getMarkdown() ?? plainRef.current?.getMarkdown() ?? initialMarkdown ?? ''
 
+  const taskClickHandler: TaskClickHandler = useCallback((payload) => {
+    console.log('Task clicked:', payload)
+  }, [])
+
   if (mode === 'source') {
     return (
       <div className="meowdown">
@@ -62,6 +67,7 @@ export function DemoEditor({
         onWikilinkClick={richProps.onWikilinkClick}
         onLinkClick={richProps.onLinkClick}
         onImageClick={richProps.onImageClick}
+        onTaskClick={taskClickHandler}
       />
     )
   }


### PR DESCRIPTION
## Problem

`MarkdownView` renders task list items through the generic `toDOM` walk. That has two consequences:

1. **Checked tasks render unchecked.** `listToDOM` emits `checked: ''` for a checked box, which React coerces to `false`, so the `<input>` never shows its state (only the wrapper's `data-list-checked` dimming hinted at it).
2. **Checkboxes are dead.** There is no way for a host rendering markdown statically (e.g. a backlinks panel) to respond to a checkbox click and toggle the task in the underlying source.

## Change

Task list items now render through a dedicated `TaskItemView`:

- The checkbox reflects the node's real `checked` state. It is keyed by that state, so a `markdown` prop change re-seats `defaultChecked` (keeping the `checked` *attribute* in sync too, which the editor-parity tests compare).
- A new optional `onTaskClick` prop reports clicks with `{ index, checked, marker, text, event }`: the checkbox's document-order index, its rendered state, the list marker as written (`+` circle vs `-`/`*` square), and the item's own first-line source text so the host can cross-check its own parse of the same markdown before toggling.
- The view itself never flips the DOM (`preventDefault`): it stays a pure render of `markdown`, exactly like the other click handlers. Without a handler the checkbox is inert.
- The outer element still takes its attributes from the node's real `toDOM`, so extension attributes (`data-list-marker`, `data-list-checked`, …) and their CSS keep working.

Also exports `ListMarker` / `MeowdownListAttrs` from `@meowdown/core` (the payload and the view need them), and `toReactProps` / `outputSpecAttrs` from the react package's spec walker.

## Tests

- Checked/unchecked rendering, payload contents (index/checked/marker/text), document-order numbering of nested tasks, no-self-flip, inert-without-handler, and re-seating on a `markdown` change.
- Editor-parity cases for both checkbox shapes (`+ [ ]` and `- [x]`) — the hand-built DOM canonicalizes identically to the editor's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)