### PR TITLE
fix: prevent image preview focus on touch pointerdown

### DIFF
--- a/packages/core/src/extensions/image-click.ts
+++ b/packages/core/src/extensions/image-click.ts
@@ -13,6 +13,14 @@ interface ImageHit {
   alt: string
 }
 
+function closestImagePreview(target: EventTarget | null): HTMLElement | null {
+  return target instanceof HTMLElement ? target.closest('.md-image-view-preview') : null
+}
+
+function isMousePointerEvent(event: Event): boolean {
+  return 'pointerType' in event && event.pointerType === 'mouse'
+}
+
 function findImageAt(state: EditorState, pos: number): ImageHit | undefined {
   const range = getMarkRangeAt(state, pos, 'mdImage')
   if (!range) return
@@ -41,9 +49,16 @@ export function defineImageClickHandler(onClick: ImageClickHandler): PlainExtens
     new Plugin({
       key: imageClickKey,
       props: {
+        handleDOMEvents: {
+          pointerdown: (_view, event) => {
+            if (closestImagePreview(event.target) && !isMousePointerEvent(event)) {
+              event.preventDefault()
+            }
+            return false
+          },
+        },
         handleClick: (view, _pos, event) => {
-          const target = event.target as HTMLElement | null
-          const preview = target?.closest?.('.md-image-view-preview')
+          const preview = closestImagePreview(event.target)
           if (!preview) return false
           // Resolve the position from the preview's own content holder, not the
           // click's `pos`: a click on the non-editable preview lands on the run

--- a/packages/core/src/extensions/image-click.ts
+++ b/packages/core/src/extensions/image-click.ts
@@ -13,12 +13,8 @@ interface ImageHit {
   alt: string
 }
 
-function closestImagePreview(target: EventTarget | null): HTMLElement | null {
-  return target instanceof HTMLElement ? target.closest('.md-image-view-preview') : null
-}
-
-function isMousePointerEvent(event: Event): boolean {
-  return 'pointerType' in event && event.pointerType === 'mouse'
+function getClosestImagePreview(target: EventTarget | null): HTMLElement | false | null {
+  return target instanceof HTMLElement && target.closest('.md-image-view-preview')
 }
 
 function findImageAt(state: EditorState, pos: number): ImageHit | undefined {
@@ -50,15 +46,19 @@ export function defineImageClickHandler(onClick: ImageClickHandler): PlainExtens
       key: imageClickKey,
       props: {
         handleDOMEvents: {
-          pointerdown: (_view, event) => {
-            if (closestImagePreview(event.target) && !isMousePointerEvent(event)) {
+          pointerdown: (view, event) => {
+            if (getClosestImagePreview(event.target) && event.pointerType !== 'mouse') {
+              // Clickable image previews live inside the editor contenteditable. On touch surfaces,
+              // tapping a rendered image can let the browser focus the editor on pointerdown before
+              // the image click handler opens an external surface such as a lightbox. In mobile
+              // WebKit this can briefly raise the software keyboard.
               event.preventDefault()
             }
             return false
           },
         },
         handleClick: (view, _pos, event) => {
-          const preview = closestImagePreview(event.target)
+          const preview = getClosestImagePreview(event.target)
           if (!preview) return false
           // Resolve the position from the preview's own content holder, not the
           // click's `pos`: a click on the non-editable preview lands on the run

--- a/packages/core/src/extensions/image.test.ts
+++ b/packages/core/src/extensions/image.test.ts
@@ -151,6 +151,39 @@ describe('image click callback', () => {
     expect(onImageClick.mock.calls[0][0].event).toBeInstanceOf(MouseEvent)
   })
 
+  it('prevents non-mouse pointerdown on clickable previews without swallowing click', async () => {
+    const onImageClick = vi.fn<ImageClickHandler>()
+    using fixture = setupClickable('![cat](https://example.com/cat.png)', onImageClick)
+    void fixture
+    await expect.element(preview).toBeInTheDocument()
+
+    const pointerDown = new PointerEvent('pointerdown', {
+      bubbles: true,
+      cancelable: true,
+      pointerType: 'touch',
+    })
+    expect(preview.element().dispatchEvent(pointerDown)).toBe(false)
+    expect(pointerDown.defaultPrevented).toBe(true)
+
+    await userEvent.click(preview)
+    await vi.waitFor(() => expect(onImageClick).toHaveBeenCalledTimes(1))
+  })
+
+  it('leaves mouse pointerdown on clickable previews alone', async () => {
+    const onImageClick = vi.fn<ImageClickHandler>()
+    using fixture = setupClickable('![cat](https://example.com/cat.png)', onImageClick)
+    void fixture
+    await expect.element(preview).toBeInTheDocument()
+
+    const pointerDown = new PointerEvent('pointerdown', {
+      bubbles: true,
+      cancelable: true,
+      pointerType: 'mouse',
+    })
+    expect(preview.element().dispatchEvent(pointerDown)).toBe(true)
+    expect(pointerDown.defaultPrevented).toBe(false)
+  })
+
   it('does not fire when plain text is clicked', async () => {
     const onImageClick = vi.fn<ImageClickHandler>()
     using fixture = setupClickable('hello ![cat](https://example.com/cat.png)', onImageClick)


### PR DESCRIPTION
## Problem

Clickable image previews live inside the editor contenteditable. On touch surfaces, tapping a rendered image can let the browser focus the editor on pointerdown before the image click handler opens an external surface such as a lightbox. In mobile WebKit this can briefly raise the software keyboard.

## Changes

- Reuse the image preview lookup in `defineImageClickHandler`.
- Add a `pointerdown` DOM event handler for clickable image previews that calls `preventDefault()` for non-mouse pointers.
- Return `false` from the DOM handler so the event is not swallowed and the existing click handler still receives the click.
- Keep mouse pointerdown unchanged for desktop behavior.

## Verification

- `pnpm exec vitest run packages/core/src/extensions/image.test.ts` passed: 24 tests.
- `pnpm typecheck` passed.
- `pnpm lint` passed.
