### PR TITLE
feat: wrap the selection as a markdown link when pasting a URL

### DIFF
--- a/packages/core/src/extensions/embed-paste.ts
+++ b/packages/core/src/extensions/embed-paste.ts
@@ -1,10 +1,10 @@
 import { definePlugin, type PlainExtension } from '@prosekit/core'
 import { closeHistory } from '@prosekit/pm/history'
-import type { Slice } from '@prosekit/pm/model'
 import { Plugin, PluginKey } from '@prosekit/pm/state'
 import type { EditorView } from '@prosekit/pm/view'
 
 import { matchEmbed } from './embed/index.ts'
+import { getPastedText } from './paste.ts'
 
 const embedPasteKey = new PluginKey('meowdown-embed-paste')
 
@@ -12,17 +12,6 @@ export function detectEmbedUrl(text: string): string | undefined {
   const trimmed = text.trim()
   if (!trimmed || /\s/.test(trimmed)) return undefined
   return matchEmbed(trimmed) ? trimmed : undefined
-}
-
-export function getPastedText(event: ClipboardEvent, slice: Slice): string {
-  const fromClipboard = event.clipboardData?.getData('text/plain')
-  if (fromClipboard) return fromClipboard
-  // Firefox ignores the standard `clipboardData` init member of the ClipboardEvent
-  // constructor (Gecko reads non-standard `data`/`dataType` strings instead), so a
-  // synthetic paste carries no text there; Chrome and WebKit honor it. Fall back to
-  // the slice ProseMirror parsed from the paste, which holds the text on every engine.
-  // See https://github.com/w3c/clipboard-apis/issues/33
-  return slice.content.textBetween(0, slice.content.size, '\n')
 }
 
 function insertEmbedFromPaste(view: EditorView, url: string): void {

--- a/packages/core/src/extensions/embed-paste.ts
+++ b/packages/core/src/extensions/embed-paste.ts
@@ -14,7 +14,7 @@ export function detectEmbedUrl(text: string): string | undefined {
   return matchEmbed(trimmed) ? trimmed : undefined
 }
 
-function getPastedText(event: ClipboardEvent, slice: Slice): string {
+export function getPastedText(event: ClipboardEvent, slice: Slice): string {
   const fromClipboard = event.clipboardData?.getData('text/plain')
   if (fromClipboard) return fromClipboard
   // Firefox ignores the standard `clipboardData` init member of the ClipboardEvent

--- a/packages/core/src/extensions/hidden-run-caret.ts
+++ b/packages/core/src/extensions/hidden-run-caret.ts
@@ -10,6 +10,8 @@ import {
 import type { Command } from '@prosekit/pm/state'
 import { Plugin, PluginKey, TextSelection } from '@prosekit/pm/state'
 
+import { executeCommand } from '../utils/execute-command.ts'
+
 import {
   getHiddenRunAfter,
   getHiddenRunAround,
@@ -132,7 +134,7 @@ function createBeforeInputPlugin(): Plugin {
                 ? deleteUnformat
                 : undefined
           if (command == null) return false
-          if (!command(view.state, view.dispatch)) return false
+          if (!executeCommand(view, command)) return false
           event.preventDefault()
           return true
         },

--- a/packages/core/src/extensions/link-commands.ts
+++ b/packages/core/src/extensions/link-commands.ts
@@ -25,7 +25,12 @@ function destText(href: string, title: string): string {
   return href + quoted
 }
 
-function getWrapRange(state: EditorState): undefined | PositionRange {
+/**
+ * The range a new link would wrap: the current selection when it is a
+ * non-empty text selection inside a single non-code textblock, trimmed of
+ * surrounding whitespace. `undefined` when there is nothing to wrap.
+ */
+export function getWrapRange(state: EditorState): undefined | PositionRange {
   const { selection } = state
   const { $from, $to, empty } = selection
   if (empty || !$from.sameParent($to) || !isTextSelection(selection)) {

--- a/packages/core/src/extensions/link-commands.ts
+++ b/packages/core/src/extensions/link-commands.ts
@@ -53,18 +53,31 @@ function getWrapRange(state: EditorState): undefined | PositionRange {
   }
 }
 
-export function insertLink(attrs: LinkAttrs = {}): Command {
+export function insertLink({
+  href,
+  title,
+  wrapText = true,
+}: {
+  href?: string
+  title?: string
+  wrapText?: boolean
+} = {}): Command {
   return (state, dispatch) => {
     const range = getWrapRange(state)
     if (!range) return false
     if (dispatch) {
       const { from, to } = range
       const tr = state.tr
-      const dest = destText(normalizeHref(attrs.href ?? ''), attrs.title ?? '')
+      const dest = destText(normalizeHref(href ?? ''), title ?? '')
       const close = `](${dest})`
       tr.insertText(close, to).insertText('[', from)
-      // Park the caret after the closing `)` so typing continues outside the link.
-      tr.setSelection(TextSelection.create(tr.doc, from, to + 1 + close.length))
+      // The position after the closing `)`
+      const linkTo = to + 1 + close.length
+      tr.setSelection(
+        wrapText
+          ? TextSelection.create(tr.doc, from, linkTo)
+          : TextSelection.create(tr.doc, linkTo),
+      )
       tr.scrollIntoView()
       dispatch(tr)
     }

--- a/packages/core/src/extensions/link-commands.ts
+++ b/packages/core/src/extensions/link-commands.ts
@@ -30,7 +30,7 @@ function destText(href: string, title: string): string {
  * non-empty text selection inside a single non-code textblock, trimmed of
  * surrounding whitespace. `undefined` when there is nothing to wrap.
  */
-export function getWrapRange(state: EditorState): undefined | PositionRange {
+function getWrapRange(state: EditorState): undefined | PositionRange {
   const { selection } = state
   const { $from, $to, empty } = selection
   if (empty || !$from.sameParent($to) || !isTextSelection(selection)) {
@@ -55,17 +55,18 @@ export function getWrapRange(state: EditorState): undefined | PositionRange {
 
 export function insertLink(attrs: LinkAttrs = {}): Command {
   return (state, dispatch) => {
-    const dest = destText(normalizeHref(attrs.href ?? ''), attrs.title ?? '')
     const range = getWrapRange(state)
     if (!range) return false
     if (dispatch) {
       const { from, to } = range
       const tr = state.tr
+      const dest = destText(normalizeHref(attrs.href ?? ''), attrs.title ?? '')
       const close = `](${dest})`
       tr.insertText(close, to).insertText('[', from)
-      dispatch(
-        tr.setSelection(TextSelection.create(tr.doc, from, to + 1 + close.length)).scrollIntoView(),
-      )
+      // Park the caret after the closing `)` so typing continues outside the link.
+      tr.setSelection(TextSelection.create(tr.doc, from, to + 1 + close.length))
+      tr.scrollIntoView()
+      dispatch(tr)
     }
     return true
   }

--- a/packages/core/src/extensions/link-paste.test.ts
+++ b/packages/core/src/extensions/link-paste.test.ts
@@ -1,0 +1,176 @@
+import { pasteText } from '@prosekit/core/test'
+import { describe, expect, it } from 'vitest'
+import { page } from 'vitest/browser'
+
+import { setupFixture, type Fixture } from '../testing/index.ts'
+
+import { defineEmbedPaste } from './embed-paste.ts'
+import { defineImage } from './image.ts'
+import { defineLinkPaste, detectLinkUrl } from './link-paste.ts'
+
+const pmRoot = page.locate('.ProseMirror')
+const youtubeEmbed = pmRoot.getByTestId('youtube-embed')
+
+const LINK = 'https://example.com/page'
+const YT = 'https://youtu.be/aqz-KE-bpKQ'
+
+function useLinkPaste(fixture: Fixture): void {
+  fixture.editor.use(defineLinkPaste())
+}
+
+describe('detectLinkUrl', () => {
+  it.each([
+    ['https://example.com/page?q=1', 'https://example.com/page?q=1'],
+    ['x-devonthink-item://40C8E9F8-DEAD-BEEF', 'x-devonthink-item://40C8E9F8-DEAD-BEEF'],
+    ['obsidian://open?vault=notes', 'obsidian://open?vault=notes'],
+    ['www.example.com', 'https://www.example.com'],
+    ['google.com/path', 'https://google.com/path'],
+    ['someone@example.com', 'mailto:someone@example.com'],
+  ])('accepts a lone URL: %s', (text, href) => {
+    expect(detectLinkUrl(text)).toBe(href)
+  })
+
+  it('trims surrounding whitespace and newlines', () => {
+    expect(detectLinkUrl('  https://example.com\n')).toBe('https://example.com')
+  })
+
+  it.each([
+    'read https://example.com', // text + url
+    'https://a.com https://b.com', // two urls
+    'node.js', // not a linkable bare domain
+    'plain words',
+    '',
+    '   ',
+  ])('declines %s', (text) => {
+    expect(detectLinkUrl(text)).toBeUndefined()
+  })
+})
+
+describe('paste a URL over a selection', () => {
+  it('wraps the selected text as a markdown link', () => {
+    using fixture = setupFixture()
+    const { editor, n, view } = fixture
+    useLinkPaste(fixture)
+    fixture.set(n.doc(n.paragraph('pick <a>this phrase<b> please')))
+    pasteText(view, LINK)
+    expect(editor.state.doc.textContent).toBe(`pick [this phrase](${LINK}) please`)
+  })
+
+  it('leaves the caret after the closing paren', () => {
+    using fixture = setupFixture()
+    const { n, view } = fixture
+    useLinkPaste(fixture)
+    fixture.set(n.doc(n.paragraph('<a>label<b>')))
+    pasteText(view, LINK)
+    const { selection } = fixture.state
+    expect(selection.empty).toBe(true)
+    expect(selection.from).toBe(1 + `[label](${LINK})`.length)
+  })
+
+  it('normalizes a www URL to an https href', () => {
+    using fixture = setupFixture()
+    const { editor, n, view } = fixture
+    useLinkPaste(fixture)
+    fixture.set(n.doc(n.paragraph('<a>site<b>')))
+    pasteText(view, 'www.example.com')
+    expect(editor.state.doc.textContent).toBe('[site](https://www.example.com)')
+  })
+
+  it('links a custom scheme URI', () => {
+    using fixture = setupFixture()
+    const { editor, n, view } = fixture
+    useLinkPaste(fixture)
+    fixture.set(n.doc(n.paragraph('<a>my note<b>')))
+    pasteText(view, 'x-devonthink-item://40C8E9F8')
+    expect(editor.state.doc.textContent).toBe('[my note](x-devonthink-item://40C8E9F8)')
+  })
+
+  it('wraps only the trimmed selection, keeping edge whitespace as text', () => {
+    using fixture = setupFixture()
+    const { editor, n, view } = fixture
+    useLinkPaste(fixture)
+    fixture.set(n.doc(n.paragraph('a<a> mid <b>b')))
+    pasteText(view, LINK)
+    expect(editor.state.doc.textContent).toBe(`a [mid](${LINK}) b`)
+  })
+
+  it('one undo restores the plain selected text', () => {
+    using fixture = setupFixture()
+    const { editor, n, view } = fixture
+    useLinkPaste(fixture)
+    fixture.set(n.doc(n.paragraph('pick <a>this<b> please')))
+    pasteText(view, LINK)
+    expect(editor.state.doc.textContent).toBe(`pick [this](${LINK}) please`)
+    editor.commands.undo()
+    expect(editor.state.doc.textContent).toBe('pick this please')
+  })
+})
+
+describe('falls through to a plain paste', () => {
+  it('with an empty selection', () => {
+    using fixture = setupFixture()
+    const { editor, n, view } = fixture
+    useLinkPaste(fixture)
+    fixture.set(n.doc(n.paragraph('before <a>')))
+    pasteText(view, LINK)
+    expect(editor.state.doc.textContent).toBe(`before ${LINK}`)
+  })
+
+  it('when the selection spans two blocks', () => {
+    using fixture = setupFixture()
+    const { editor, n, view } = fixture
+    useLinkPaste(fixture)
+    fixture.set(n.doc(n.paragraph('one <a>two'), n.paragraph('three<b> four')))
+    pasteText(view, LINK)
+    expect(editor.state.doc.textContent).toBe(`one ${LINK} four`)
+  })
+
+  it('inside a code block', () => {
+    using fixture = setupFixture()
+    const { editor, n, view } = fixture
+    useLinkPaste(fixture)
+    fixture.set(n.doc(n.codeBlock({ language: 'js' }, 'const <a>x<b> = 1')))
+    pasteText(view, LINK)
+    expect(editor.state.doc.textContent).toBe(`const ${LINK} = 1`)
+  })
+
+  it('when the clipboard is not a lone URL', () => {
+    using fixture = setupFixture()
+    const { editor, n, view } = fixture
+    useLinkPaste(fixture)
+    fixture.set(n.doc(n.paragraph('<a>gone<b>')))
+    pasteText(view, `read ${LINK}`)
+    expect(editor.state.doc.textContent).toBe(`read ${LINK}`)
+  })
+})
+
+describe('ordering against embed paste', () => {
+  function useEmbedThenLinkPaste(fixture: Fixture): void {
+    const { editor } = fixture
+    editor.use(defineImage({ resolveImageUrl: (src) => src }))
+    // Embed paste registered first: without `Priority.high` on link paste,
+    // its `handlePaste` would win and the selection would be discarded.
+    editor.use(defineEmbedPaste())
+    editor.use(defineLinkPaste())
+  }
+
+  it('an embeddable URL pasted over a selection becomes a link, not an embed', async () => {
+    using fixture = setupFixture()
+    const { editor, n, view } = fixture
+    useEmbedThenLinkPaste(fixture)
+    fixture.set(n.doc(n.paragraph('<a>talk<b>')))
+    pasteText(view, YT)
+    expect(editor.state.doc.textContent).toBe(`[talk](${YT})`)
+    await expect.element(youtubeEmbed).not.toBeInTheDocument()
+  })
+
+  it('an embeddable URL pasted at a caret still embeds', async () => {
+    using fixture = setupFixture()
+    const { editor, n, view } = fixture
+    useEmbedThenLinkPaste(fixture)
+    fixture.set(n.doc(n.paragraph('<a>')))
+    pasteText(view, YT)
+    expect(editor.state.doc.textContent).toBe(`![](${YT})`)
+    await expect.element(youtubeEmbed).toBeInTheDocument()
+  })
+})

--- a/packages/core/src/extensions/link-paste.ts
+++ b/packages/core/src/extensions/link-paste.ts
@@ -1,0 +1,68 @@
+import { definePlugin, Priority, withPriority, type PlainExtension } from '@prosekit/core'
+import { closeHistory } from '@prosekit/pm/history'
+import { Plugin, PluginKey, TextSelection } from '@prosekit/pm/state'
+import type { EditorView } from '@prosekit/pm/view'
+
+import { getAutolinkHref } from '../lezer/autolink-tld.ts'
+import type { PositionRange } from '../utils/range.ts'
+
+import { getPastedText } from './embed-paste.ts'
+import { getWrapRange } from './link-commands.ts'
+
+const linkPasteKey = new PluginKey('meowdown-link-paste')
+
+/**
+ * The pasted text as a link `href` when the clipboard holds exactly one URL:
+ * a `scheme:` URI, a `www.`/bare-domain URL (implied `https://`), or an email
+ * (implied `mailto:`) — the same shapes autolinking recognizes.
+ */
+export function detectLinkUrl(text: string): string | undefined {
+  const trimmed = text.trim()
+  if (!trimmed || /\s/.test(trimmed)) return undefined
+  return getAutolinkHref(trimmed)
+}
+
+function wrapSelectionWithLink(view: EditorView, range: PositionRange, href: string): void {
+  const { from, to } = range
+  const close = `](${href})`
+  const tr = view.state.tr.insertText(close, to).insertText('[', from)
+  // Park the caret after the closing `)` so typing continues outside the link.
+  tr.setSelection(TextSelection.create(tr.doc, to + 1 + close.length))
+  view.dispatch(closeHistory(tr).scrollIntoView())
+}
+
+/**
+ * Paste a URL over selected text to wrap the selection as a Markdown link
+ * `[selected text](url)`. Only fires when the clipboard holds exactly one URL
+ * and the selection is a non-empty text selection inside a single non-code
+ * textblock; otherwise the paste falls through to the other handlers
+ * (embed paste, plain paste). One undo restores the plain selected text.
+ *
+ * Registered with `Priority.high` so its `handlePaste` runs before
+ * `defineEmbedPaste`'s: pasting an embeddable URL (tweet/YouTube) over a
+ * selection keeps the selected text as a link instead of discarding it for an
+ * embed. Not part of `defineEditorExtension`; the React package applies it via
+ * the `linkPaste` prop (on by default).
+ */
+export function defineLinkPaste(): PlainExtension {
+  return withPriority(
+    definePlugin(
+      new Plugin({
+        key: linkPasteKey,
+        props: {
+          handlePaste: (view, event, slice) => {
+            const range = getWrapRange(view.state)
+            if (!range) return false
+            const text = getPastedText(event, slice)
+            if (!text) return false
+            const href = detectLinkUrl(text)
+            if (!href) return false
+            wrapSelectionWithLink(view, range, href)
+            return true
+          },
+        },
+      }),
+    ),
+    Priority.high,
+  )
+}

--- a/packages/core/src/extensions/link-paste.ts
+++ b/packages/core/src/extensions/link-paste.ts
@@ -1,13 +1,11 @@
 import { definePlugin, Priority, withPriority, type PlainExtension } from '@prosekit/core'
-import { closeHistory } from '@prosekit/pm/history'
-import { Plugin, PluginKey, TextSelection } from '@prosekit/pm/state'
-import type { EditorView } from '@prosekit/pm/view'
+import { Plugin, PluginKey } from '@prosekit/pm/state'
 
 import { getAutolinkHref } from '../lezer/autolink-tld.ts'
-import type { PositionRange } from '../utils/range.ts'
+import { executeCommand } from '../utils/execute-command.ts'
 
-import { getPastedText } from './embed-paste.ts'
-import { getWrapRange } from './link-commands.ts'
+import { insertLink } from './link-commands.ts'
+import { getPastedText } from './paste.ts'
 
 const linkPasteKey = new PluginKey('meowdown-link-paste')
 
@@ -20,15 +18,6 @@ export function detectLinkUrl(text: string): string | undefined {
   const trimmed = text.trim()
   if (!trimmed || /\s/.test(trimmed)) return undefined
   return getAutolinkHref(trimmed)
-}
-
-function wrapSelectionWithLink(view: EditorView, range: PositionRange, href: string): void {
-  const { from, to } = range
-  const close = `](${href})`
-  const tr = view.state.tr.insertText(close, to).insertText('[', from)
-  // Park the caret after the closing `)` so typing continues outside the link.
-  tr.setSelection(TextSelection.create(tr.doc, to + 1 + close.length))
-  view.dispatch(closeHistory(tr).scrollIntoView())
 }
 
 /**
@@ -51,14 +40,11 @@ export function defineLinkPaste(): PlainExtension {
         key: linkPasteKey,
         props: {
           handlePaste: (view, event, slice) => {
-            const range = getWrapRange(view.state)
-            if (!range) return false
             const text = getPastedText(event, slice)
             if (!text) return false
             const href = detectLinkUrl(text)
             if (!href) return false
-            wrapSelectionWithLink(view, range, href)
-            return true
+            return executeCommand(view, insertLink({ href }))
           },
         },
       }),

--- a/packages/core/src/extensions/link-paste.ts
+++ b/packages/core/src/extensions/link-paste.ts
@@ -44,7 +44,14 @@ export function defineLinkPaste(): PlainExtension {
             if (!text) return false
             const href = detectLinkUrl(text)
             if (!href) return false
-            return executeCommand(view, insertLink({ href }))
+            return executeCommand(
+              view,
+              insertLink({
+                href,
+                // Put the caret after the link so the user can continue typing without having to move it.
+                wrapText: false,
+              }),
+            )
           },
         },
       }),

--- a/packages/core/src/extensions/paste.ts
+++ b/packages/core/src/extensions/paste.ts
@@ -1,0 +1,12 @@
+import type { Slice } from '@prosekit/pm/model'
+
+export function getPastedText(event: ClipboardEvent, slice: Slice): string {
+  const fromClipboard = event.clipboardData?.getData('text/plain')
+  if (fromClipboard) return fromClipboard
+  // Firefox ignores the standard `clipboardData` init member of the ClipboardEvent
+  // constructor (Gecko reads non-standard `data`/`dataType` strings instead), so a
+  // synthetic paste carries no text there; Chrome and WebKit honor it. Fall back to
+  // the slice ProseMirror parsed from the paste, which holds the text on every engine.
+  // See https://github.com/w3c/clipboard-apis/issues/33
+  return slice.content.textBetween(0, slice.content.size, '\n')
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -95,6 +95,7 @@ export {
 } from './extensions/link-commands.ts'
 export type { LinkEditHandler, LinkEditOptions } from './extensions/link-commands.ts'
 export { defineLinkHoverHandler, type LinkHoverHandler } from './extensions/link-hover.ts'
+export { defineLinkPaste } from './extensions/link-paste.ts'
 export type { MarkChunk } from './extensions/mark-chunk.ts'
 export type { MarkMode } from './extensions/mark-mode.ts'
 export type { MarkName } from './extensions/mark-names.ts'

--- a/packages/core/src/utils/execute-command.ts
+++ b/packages/core/src/utils/execute-command.ts
@@ -1,0 +1,6 @@
+import type { Command } from '@prosekit/pm/state'
+import type { EditorView } from '@prosekit/pm/view'
+
+export function executeCommand(view: EditorView, command: Command): boolean {
+  return command(view.state, view.dispatch, view)
+}

--- a/packages/react/src/components/editor-extensions.tsx
+++ b/packages/react/src/components/editor-extensions.tsx
@@ -10,6 +10,7 @@ import {
   defineImage,
   defineImageClickHandler,
   defineLinkClickHandler,
+  defineLinkPaste,
   defineMarkdownCopy,
   definePlaceholder,
   defineReadonly,
@@ -48,6 +49,7 @@ export interface EditorExtensionsProps {
   onFileSaveError?: FilePasteOptions['onFileSaveError']
   onImageClick?: ImageClickHandler
   embedPaste?: boolean
+  linkPaste?: boolean
   bulletAfterHeading?: boolean
   placeholder?: PlaceholderOptions['placeholder']
   readOnly?: boolean
@@ -72,6 +74,7 @@ export function EditorExtensions({
   onFileSaveError,
   onImageClick,
   embedPaste,
+  linkPaste,
   bulletAfterHeading,
   placeholder,
   readOnly,
@@ -166,6 +169,12 @@ export function EditorExtensions({
     useMemo(() => {
       return embedPaste ? defineEmbedPaste() : null
     }, [embedPaste]),
+  )
+
+  useExtension(
+    useMemo(() => {
+      return linkPaste ? defineLinkPaste() : null
+    }, [linkPaste]),
   )
 
   useExtension(

--- a/packages/react/src/components/editor.tsx
+++ b/packages/react/src/components/editor.tsx
@@ -210,6 +210,12 @@ export interface EditorProps {
   embedPaste?: boolean
 
   /**
+   * Pasting a URL over selected text wraps the selection as a Markdown link
+   * `[selected text](url)`; one undo restores the plain text. On by default.
+   */
+  linkPaste?: boolean
+
+  /**
    * Pressing Enter at the end of the document's first heading (the title line)
    * starts a fresh empty bullet on the next line instead of a plain paragraph.
    * Off by default.
@@ -286,6 +292,7 @@ export function MeowdownEditor({
   onFileSaveError,
   onImageClick,
   embedPaste = true,
+  linkPaste = true,
   bulletAfterHeading = false,
   frontmatter = false,
   blockHandle = true,
@@ -396,6 +403,7 @@ export function MeowdownEditor({
         onFileSaveError={onFileSaveError}
         onImageClick={onImageClick}
         embedPaste={embedPaste}
+        linkPaste={linkPaste}
         bulletAfterHeading={bulletAfterHeading}
         frontmatter={frontmatter}
         blockHandle={blockHandle}

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -150,6 +150,9 @@ export interface ProseKitEditorProps {
   /** Auto-embeds a pasted tweet/YouTube link. See `EditorProps.embedPaste`. */
   embedPaste?: boolean
 
+  /** Wraps the selection as a link on URL paste. See `EditorProps.linkPaste`. */
+  linkPaste?: boolean
+
   /** Starts a bullet on Enter after a heading. See `EditorProps.bulletAfterHeading`. */
   bulletAfterHeading?: boolean
 
@@ -205,6 +208,7 @@ export function ProseKitEditor({
   onFileSaveError,
   onImageClick,
   embedPaste,
+  linkPaste,
   bulletAfterHeading,
   frontmatter = false,
   blockHandle = true,
@@ -354,6 +358,7 @@ export function ProseKitEditor({
         onFileSaveError={onFileSaveError}
         onImageClick={onImageClick}
         embedPaste={embedPaste}
+        linkPaste={linkPaste}
         bulletAfterHeading={bulletAfterHeading}
         placeholder={placeholder}
         readOnly={readOnly}


### PR DESCRIPTION
Pasting a URL over selected text now rewrites the selection to `[selected text](url)` instead of replacing it. The new `defineLinkPaste` extension fires only when the clipboard holds exactly one URL (the same shapes autolinking recognizes, via `getAutolinkHref`) and the selection is a non-empty text selection inside a single non-code textblock; anything else falls through to the embed/plain paste behavior. It registers with `Priority.high` so a tweet/YouTube URL pasted over a selection becomes a link (selection wins) rather than an embed. Applied via a new `linkPaste` prop on the React editor, on by default.