### PR TITLE
docs(website): add a `Readonly` mode that renders `MarkdownView`

### DIFF
--- a/website/src/components/codemirror-editor.tsx
+++ b/website/src/components/codemirror-editor.tsx
@@ -1,25 +1,11 @@
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown'
 import { defaultHighlightStyle, syntaxHighlighting } from '@codemirror/language'
-import { Compartment, EditorSelection, EditorState } from '@codemirror/state'
+import { EditorState } from '@codemirror/state'
 import { EditorView, keymap } from '@codemirror/view'
-import type {
-  EditorHandle,
-  EditorStateSnapshot,
-  SelectionHint,
-  SelectionJSON,
-} from '@meowdown/react'
-import { clamp } from '@ocavue/utils'
 import { useImperativeHandle, useLayoutEffect, useRef, type Ref } from 'react'
 
-function resolveSelection(selection: SelectionHint, docLength: number): EditorSelection {
-  if (selection === 'start') return EditorSelection.single(0)
-  if (selection === 'end') return EditorSelection.single(docLength)
-  return EditorSelection.single(
-    clamp(selection.anchor, 0, docLength),
-    clamp(selection.head, 0, docLength),
-  )
-}
+import type { MarkdownSource } from './markdown-source.ts'
 
 export interface CodeMirrorEditorProps {
   /**
@@ -28,113 +14,24 @@ export interface CodeMirrorEditorProps {
    */
   initialMarkdown?: string
 
-  /** Called on every user-driven document change, not on programmatic setState. */
-  onDocChange?: VoidFunction
-
-  /** Makes the editor read-only. */
-  readOnly?: boolean
-
-  /** Imperative handle for the editor. */
-  ref?: Ref<EditorHandle>
+  /** Reports the current Markdown text back to the mode-flip seeding. */
+  ref?: Ref<MarkdownSource>
 }
 
-export function CodeMirrorEditor({
-  initialMarkdown,
-  onDocChange,
-  readOnly,
-  ref,
-}: CodeMirrorEditorProps) {
+export function CodeMirrorEditor({ initialMarkdown, ref }: CodeMirrorEditorProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const viewRef = useRef<EditorView | null>(null)
-  const readOnlyCompartmentRef = useRef(new Compartment())
 
-  // Set while a programmatic setState/setMarkdown dispatch runs, so the update
-  // listener can ignore it: a host replacing content already knows.
-  const suppressDocChangeRef = useRef(false)
-
-  // Keep the latest callback in a ref so the view is never recreated when
-  // the parent passes a new function identity.
-  const onDocChangeRef = useRef(onDocChange)
-  useLayoutEffect(() => {
-    onDocChangeRef.current = onDocChange
-  }, [onDocChange])
-
-  // Capture the first-render values so the create effect lists no deps.
+  // Capture the first-render value so the create effect lists no deps.
   const initialMarkdownRef = useRef(initialMarkdown ?? '')
-  const initialReadOnlyRef = useRef(readOnly ?? false)
 
-  useImperativeHandle(ref, () => {
-    function getMarkdown(): string {
-      return viewRef.current?.state.doc.toString() ?? initialMarkdownRef.current
-    }
-    function getSelection(): SelectionJSON {
-      const main = viewRef.current?.state.selection.main
-      return { type: 'text', anchor: main?.anchor ?? 0, head: main?.head ?? 0 }
-    }
-    function getState(): EditorStateSnapshot {
-      return [getMarkdown(), getSelection()]
-    }
-    function setState(markdown?: string, selection?: SelectionHint): void {
-      const view = viewRef.current
-      if (!view) {
-        if (markdown != null) initialMarkdownRef.current = markdown
-        return
-      }
-      if (markdown == null && !selection) return
-      const docLength = markdown == null ? view.state.doc.length : markdown.length
-      suppressDocChangeRef.current = true
-      try {
-        view.dispatch({
-          changes:
-            markdown == null ? undefined : { from: 0, to: view.state.doc.length, insert: markdown },
-          selection: selection ? resolveSelection(selection, docLength) : undefined,
-          scrollIntoView: true,
-        })
-      } finally {
-        suppressDocChangeRef.current = false
-      }
-    }
-    function setMarkdown(markdown: string): void {
-      setState(markdown)
-    }
-    function insertMarkdown(_markdown: string): void {
-      throw new Error('CodeMirrorEditor.insertMarkdown is not implemented')
-    }
-    function setSelection(selection: SelectionHint): void {
-      setState(undefined, selection)
-    }
-    function focus(): void {
-      viewRef.current?.focus()
-    }
-    function scrollIntoView(): void {
-      viewRef.current?.dispatch({ scrollIntoView: true })
-    }
-    function getSelectedText(): string {
-      const view = viewRef.current
-      if (!view) return ''
-      const main = view.state.selection.main
-      return view.state.sliceDoc(main.from, main.to)
-    }
-    return {
-      getMarkdown,
-      setMarkdown,
-      insertMarkdown,
-      getState,
-      setState,
-      getSelection,
-      setSelection,
-      focus,
-      scrollIntoView,
-      getSelectedText,
-      // The raw-Markdown editor has no selection menu or staged replacements.
-      openSelectionMenu: () => {},
-      startPendingReplacement: () => false,
-      appendPendingReplacementText: () => {},
-      acceptPendingReplacement: () => {},
-      discardPendingReplacement: () => {},
-      editor: undefined,
-    }
-  }, [])
+  useImperativeHandle(
+    ref,
+    () => ({
+      getMarkdown: () => viewRef.current?.state.doc.toString() ?? initialMarkdownRef.current,
+    }),
+    [],
+  )
 
   useLayoutEffect(() => {
     const container = containerRef.current
@@ -149,11 +46,6 @@ export function CodeMirrorEditor({
           markdown({ base: markdownLanguage }),
           syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
           EditorView.lineWrapping,
-          readOnlyCompartmentRef.current.of(EditorState.readOnly.of(initialReadOnlyRef.current)),
-          EditorView.updateListener.of((update) => {
-            if (!update.docChanged || suppressDocChangeRef.current) return
-            onDocChangeRef.current?.()
-          }),
         ],
       }),
     })
@@ -163,14 +55,6 @@ export function CodeMirrorEditor({
       viewRef.current = null
     }
   }, [])
-
-  useLayoutEffect(() => {
-    viewRef.current?.dispatch({
-      effects: readOnlyCompartmentRef.current.reconfigure(
-        EditorState.readOnly.of(readOnly ?? false),
-      ),
-    })
-  }, [readOnly])
 
   return <div ref={containerRef} data-editor="codemirror" />
 }

--- a/website/src/components/demo-editor.tsx
+++ b/website/src/components/demo-editor.tsx
@@ -7,21 +7,26 @@ import {
 import { useRef, type RefObject } from 'react'
 
 import { CodeMirrorEditor } from './codemirror-editor.tsx'
+import type { MarkdownSource } from './markdown-source.ts'
+import { ReadonlyView } from './readonly-view.tsx'
 
-/** The four demo modes: the three rich modes plus the CodeMirror source mode. */
-export type DemoMode = EditorMode | 'source'
+/**
+ * The five demo modes: the three rich modes, the CodeMirror source mode, and
+ * the read-only `MarkdownView` mode.
+ */
+export type DemoMode = EditorMode | 'source' | 'readonly'
 
 export interface DemoEditorProps extends Omit<EditorProps, 'mode' | 'handleRef'> {
   /**
    * The editor mode. 'source' renders a CodeMirror editor showing the raw
-   * Markdown text; the three rich modes render the Meowdown editor. Defaults to
-   * 'focus'.
+   * Markdown text, 'readonly' renders the document with `MarkdownView`; the
+   * three rich modes render the Meowdown editor. Defaults to 'focus'.
    */
   mode?: DemoMode
 
   /**
-   * Handle of whichever editor is currently mounted. In source mode the
-   * selection and pending-replacement methods are no-ops.
+   * Handle of the rich editor. Detached (null) in the source and readonly
+   * modes, which support none of its methods.
    */
   handleRef?: RefObject<EditorHandle | null>
 }
@@ -29,41 +34,40 @@ export interface DemoEditorProps extends Omit<EditorProps, 'mode' | 'handleRef'>
 export function DemoEditor({
   mode = 'focus',
   initialMarkdown,
-  onDocChange,
-  readOnly,
   children,
   handleRef,
   ...richProps
 }: DemoEditorProps) {
-  // Handle of whichever editor is currently mounted. Reading it during render
-  // seeds the next editor with the previous one's content when the mode flips
-  // between the rich and source families.
+  // Handles of whichever pane is currently mounted. Reading them during render
+  // seeds the next pane with the previous one's content when the mode flips.
   const fallbackRef = useRef<EditorHandle>(null)
-  const childRef = handleRef ?? fallbackRef
-  const seedMarkdown = childRef.current?.getMarkdown() ?? initialMarkdown ?? ''
+  const richRef = handleRef ?? fallbackRef
+  const plainRef = useRef<MarkdownSource>(null)
+  const seedMarkdown =
+    richRef.current?.getMarkdown() ?? plainRef.current?.getMarkdown() ?? initialMarkdown ?? ''
 
   if (mode === 'source') {
     return (
       <div className="meowdown">
-        <CodeMirrorEditor
-          ref={childRef}
-          initialMarkdown={seedMarkdown}
-          onDocChange={onDocChange}
-          readOnly={readOnly}
-        />
+        <CodeMirrorEditor ref={plainRef} initialMarkdown={seedMarkdown} />
       </div>
     )
   }
 
+  if (mode === 'readonly') {
+    return (
+      <ReadonlyView
+        ref={plainRef}
+        markdown={seedMarkdown}
+        onWikilinkClick={richProps.onWikilinkClick}
+        onLinkClick={richProps.onLinkClick}
+        onImageClick={richProps.onImageClick}
+      />
+    )
+  }
+
   return (
-    <MeowdownEditor
-      handleRef={childRef}
-      mode={mode}
-      initialMarkdown={seedMarkdown}
-      onDocChange={onDocChange}
-      readOnly={readOnly}
-      {...richProps}
-    >
+    <MeowdownEditor handleRef={richRef} mode={mode} initialMarkdown={seedMarkdown} {...richProps}>
       {children}
     </MeowdownEditor>
   )

--- a/website/src/components/markdown-source.ts
+++ b/website/src/components/markdown-source.ts
@@ -1,0 +1,7 @@
+/**
+ * The one thing `DemoEditor` asks of a mounted pane: its current Markdown,
+ * read when the mode flips to seed the next pane.
+ */
+export interface MarkdownSource {
+  getMarkdown: () => string
+}

--- a/website/src/components/readonly-view.tsx
+++ b/website/src/components/readonly-view.tsx
@@ -1,0 +1,18 @@
+import { MarkdownView, type MarkdownViewProps } from '@meowdown/react'
+import { useImperativeHandle, type Ref } from 'react'
+
+import type { MarkdownSource } from './markdown-source.ts'
+
+export interface ReadonlyViewProps extends MarkdownViewProps {
+  /** Reports the rendered Markdown text back to the mode-flip seeding. */
+  ref?: Ref<MarkdownSource>
+}
+
+export function ReadonlyView({ markdown, ref, ...viewProps }: ReadonlyViewProps) {
+  useImperativeHandle(ref, () => ({ getMarkdown: () => markdown }), [markdown])
+  return (
+    <div className="meowdown">
+      <MarkdownView markdown={markdown} {...viewProps} />
+    </div>
+  )
+}

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -133,6 +133,31 @@ html {
   transition: color 0.2s ease;
 }
 
+/* Compact segments so all five fit a phone-width toolbar (down to 320px).
+ * Equal `1fr` columns cannot fit there at a readable font size, and a
+ * space-constrained grid resolves them unequally anyway, which breaks the
+ * thumb's `translateX` math. So on phones the columns are content-sized and
+ * the checked label carries the pill itself; the slide stays desktop-only. */
+@media (width < 40rem) {
+  .segmented {
+    grid-auto-columns: auto;
+  }
+
+  .segmented::before {
+    display: none;
+  }
+
+  .segmented label {
+    padding: 0.375rem 0.3125rem;
+    font-size: 0.75rem;
+  }
+
+  .segmented label:has(input:checked) {
+    background: light-dark(var(--color-white), var(--color-stone-950));
+    box-shadow: 0 1px 2px 0 color-mix(in oklab, var(--color-black) 5%, transparent);
+  }
+}
+
 .segmented label:hover {
   color: light-dark(var(--color-stone-800), var(--color-stone-200));
 }

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -105,7 +105,7 @@ html {
   pointer-events: none;
 }
 
-/* Slide the thumb onto the checked option (supports up to 4 segments). */
+/* Slide the thumb onto the checked option (supports up to 5 segments). */
 .segmented:has(> label:nth-child(2) input:checked)::before {
   transform: translateX(100%);
 }
@@ -114,6 +114,9 @@ html {
 }
 .segmented:has(> label:nth-child(4) input:checked)::before {
   transform: translateX(300%);
+}
+.segmented:has(> label:nth-child(5) input:checked)::before {
+  transform: translateX(400%);
 }
 
 .segmented label {

--- a/website/src/use-editor-mode.ts
+++ b/website/src/use-editor-mode.ts
@@ -29,6 +29,11 @@ export const MODES: ModeOption[] = [
     label: 'Source',
     description: 'Raw Markdown text.',
   },
+  {
+    value: 'readonly',
+    label: 'Readonly',
+    description: 'A read-only render of the document, with no editor behind it.',
+  },
 ]
 
 const MODE_STORAGE_KEY = 'meowdown:mode'


### PR DESCRIPTION
Adds a fifth "Readonly" segment to the demo site that renders the current document with `MarkdownView`, so the read-only renderer can be tested against the same content as the editor. Content still carries over when switching between the rich, source, and readonly panes. Also slims `CodeMirrorEditor` down to a minimal `getMarkdown` handle, since the website never used the rest of its `EditorHandle` implementation.