### PR TITLE
feat: simplify wikilink styles

### DIFF
--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -84,7 +84,7 @@
       oklch(0.693 0.194 46 / 0.1),
       oklch(0.741 0.165 52 / 0.12)
     );
-    --meowdown-selection: light-dark(oklch(0.693 0.194 46 / 0.22), oklch(0.741 0.165 52 / 0.3));
+    --meowdown-selection: yellow;
 
     /* The resting bullet dot color (a collapsed bullet's dot uses the themed
      * `--meowdown-bullet-collapsed` instead). */
@@ -717,10 +717,11 @@
 
     .md-atom-view:has(.md-atom-selected) {
       .md-atom-view-preview {
-        outline: 2px solid var(--meowdown-node-outline);
+        outline-width: 2px;
+        outline-color: var(--meowdown-node-outline);
+        outline-style: solid;
         outline-offset: 2px;
         background: transparent;
-        position: relative;
       }
 
       & ::selection {
@@ -928,17 +929,12 @@
 
     .md-wikilink-view.md-atom-view:has(.md-atom-selected) {
       .md-atom-view-preview {
-        outline-offset: 1px;
+        padding: 1px;
+        margin: -1px;
+        outline-offset: 0px;
         cursor: pointer;
         border-radius: 4px;
-
-        &::after {
-          border-radius: 4px;
-          background: var(--meowdown-selection);
-          content: '';
-          position: absolute;
-          inset: -1px;
-        }
+        background: var(--meowdown-selection);
       }
     }
   }

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -84,7 +84,7 @@
       oklch(0.693 0.194 46 / 0.1),
       oklch(0.741 0.165 52 / 0.12)
     );
-    --meowdown-selection: yellow;
+    --meowdown-selection: light-dark(oklch(0.693 0.194 46 / 0.22), oklch(0.741 0.165 52 / 0.3));
 
     /* The resting bullet dot color (a collapsed bullet's dot uses the themed
      * `--meowdown-bullet-collapsed` instead). */
@@ -717,11 +717,8 @@
 
     .md-atom-view:has(.md-atom-selected) {
       .md-atom-view-preview {
-        outline-width: 2px;
-        outline-color: var(--meowdown-node-outline);
-        outline-style: solid;
+        outline: 2px solid var(--meowdown-node-outline);
         outline-offset: 2px;
-        background: transparent;
       }
 
       & ::selection {

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -918,7 +918,6 @@
       color: var(--meowdown-accent);
       overflow: hidden;
       padding: 2px 0px;
-      border-radius: 0px;
       /* Give each wrapped line fragment its own full padding and rounded
        * background, so a wikilink broken across lines reads as a chip on
        * every line. */

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -932,7 +932,7 @@
         cursor: pointer;
         border-radius: 4px;
 
-        &::before {
+        &::after {
           border-radius: 4px;
           background: var(--meowdown-selection);
           content: '';

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -912,7 +912,6 @@
     /* A plain inline, not the shared inline-block in .md-atom-view-preview */
     .md-wikilink-view-preview.md-atom-view-preview {
       display: inline;
-      border-radius: 4px;
     }
 
     .md-wikilink-view-label {
@@ -931,16 +930,15 @@
     .md-wikilink-view.md-atom-view:has(.md-atom-selected) {
       .md-atom-view-preview {
         outline-offset: 1px;
+        cursor: pointer;
         border-radius: 4px;
-        content: '';
-        pointer-events: none;
 
         &::before {
-          background: var(--meowdown-selection);
           border-radius: 4px;
+          background: var(--meowdown-selection);
           content: '';
           position: absolute;
-          inset: -2px;
+          inset: -1px;
         }
       }
     }

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -718,7 +718,9 @@
     .md-atom-view:has(.md-atom-selected) {
       .md-atom-view-preview {
         outline: 2px solid var(--meowdown-node-outline);
-        background: var(--meowdown-selection);
+        outline-offset: 2px;
+        background: transparent;
+        position: relative;
       }
 
       & ::selection {
@@ -910,31 +912,37 @@
     /* A plain inline, not the shared inline-block in .md-atom-view-preview */
     .md-wikilink-view-preview.md-atom-view-preview {
       display: inline;
+      border-radius: 4px;
     }
 
     .md-wikilink-view-label {
+      color: var(--meowdown-accent);
       overflow: hidden;
-      padding: 2px 5px;
-      border-radius: 6px;
+      padding: 2px 0px;
+      border-radius: 0px;
       /* Give each wrapped line fragment its own full padding and rounded
        * background, so a wikilink broken across lines reads as a chip on
        * every line. */
       -webkit-box-decoration-break: clone;
       box-decoration-break: clone;
-
-      background: color-mix(in oklab, var(--meowdown-accent) 10%, transparent);
-      color: color-mix(in oklab, var(--meowdown-accent) 80%, var(--meowdown-heading));
-
-      text-decoration-line: underline;
-      text-decoration-style: dashed;
-      text-decoration-thickness: 1px;
-      text-underline-offset: 2px;
       cursor: pointer;
     }
 
-    .md-wikilink-view:has(.md-atom-selected) .md-wikilink-view-label {
-      background-color: transparent;
-      outline-color: transparent;
+    .md-wikilink-view.md-atom-view:has(.md-atom-selected) {
+      .md-atom-view-preview {
+        outline-offset: 1px;
+        border-radius: 4px;
+        content: '';
+        pointer-events: none;
+
+        &::before {
+          background: var(--meowdown-selection);
+          border-radius: 4px;
+          content: '';
+          position: absolute;
+          inset: -2px;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Before:

<img width="317" height="76" alt="image" src="https://github.com/user-attachments/assets/9c944951-c717-4fea-8ad9-03621759d3e7" />
<br>
<img width="318" height="73" alt="image" src="https://github.com/user-attachments/assets/a29f622c-127c-49ae-852e-4bedcea29f85" />


After:


 
<img width="279" height="43" alt="image" src="https://github.com/user-attachments/assets/03d390d2-da4a-4cbf-a532-9368cd0ac1ea" />
<br>
<img width="269" height="51" alt="image" src="https://github.com/user-attachments/assets/df5280f6-8d9f-48a3-89ea-9316c13dcb1d" />
