### PR TITLE
feat(core): add `scrollIntoView` command

### DIFF
--- a/packages/core/src/extensions/commands.ts
+++ b/packages/core/src/extensions/commands.ts
@@ -81,10 +81,20 @@ function insertTrigger(text: string): Command {
   }
 }
 
+function scrollIntoView(): Command {
+  return (state, dispatch) => {
+    if (dispatch) {
+      dispatch(state.tr.scrollIntoView())
+    }
+    return true
+  }
+}
+
 export function defineEditorCommands() {
   return defineCommands({
     insertMarkdown,
     insertTrigger,
+    scrollIntoView,
     selectText,
     selectTextBetween,
   })

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -290,7 +290,7 @@ export function ProseKitEditor({
       editor.focus()
     }
     function scrollIntoView(): void {
-      editor.view.dispatch(editor.state.tr.scrollIntoView())
+      editor.commands.scrollIntoView()
     }
     function getSelectedTextFromState(): string {
       return getSelectedText(editor.state)


### PR DESCRIPTION
Add a `scrollIntoView` command to the core package and use it in the React editor handle.