### PR TITLE
fix: anchor the link popover on the link's visible text

### DIFF
--- a/packages/core/src/extensions/get-link-unit-at.test.ts
+++ b/packages/core/src/extensions/get-link-unit-at.test.ts
@@ -16,6 +16,7 @@ describe('getLinkUnitAt', () => {
     expect(fixture.doc.textBetween(link.unit.from, link.unit.to)).toBe('[docs](http://example.com)')
     expect(fixture.doc.textBetween(link.label!.from, link.label!.to)).toBe('docs')
     expect(fixture.doc.textBetween(link.dest!.from, link.dest!.to)).toBe('http://example.com')
+    expect(link.text).toEqual(link.label)
   })
 
   it('parses and unquotes a title', () => {
@@ -53,6 +54,19 @@ describe('getLinkUnitAt', () => {
     expect(link.href).toBe('https://example.com')
     expect(link.label).toBeUndefined()
     expect(link.dest).toBeUndefined()
+    expect(link.text).toEqual(link.unit)
+  })
+
+  it('exposes the visible interior of an angle autolink as text', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('see <https://example.com> here')))
+    const link = getLinkUnitAt(fixture.state, findText(fixture.doc, 'example.com') + 1)!
+    expect(link.href).toBe('https://example.com')
+    expect(link.label).toBeUndefined()
+    expect(link.dest).toBeUndefined()
+    expect(fixture.doc.textBetween(link.unit.from, link.unit.to)).toBe('<https://example.com>')
+    expect(fixture.doc.textBetween(link.text.from, link.text.to)).toBe('https://example.com')
   })
 
   it('handles an empty dest', () => {

--- a/packages/core/src/extensions/get-link-unit-at.ts
+++ b/packages/core/src/extensions/get-link-unit-at.ts
@@ -10,6 +10,14 @@ export interface LinkUnit {
   /** Whole `[text](url "title")` (or autolink) range */
   unit: PositionRange
 
+  /**
+   * The visible text of the link: the `[ ]` interior for a full link, the URL
+   * between `< >` for an angle autolink, the whole unit for a bare autolink.
+   * Popovers anchor on it; the unit's edges can sit inside hidden syntax,
+   * whose collapsed glyphs measure at bogus coordinates.
+   */
+  text: PositionRange
+
   /** Interior of `[ ]`. Absent for an autolink. */
   label?: PositionRange
 
@@ -72,10 +80,22 @@ export function getLinkUnitAt(state: EditorState, pos: number): LinkUnit | undef
   const href = linkTextAttrs?.href ?? ''
 
   // Only a real `[text](dest)` has an editable label/dest.
-  // Autolinks just resolve an href.
+  // Autolinks just resolve an href. A bare autolink is its own visible text;
+  // an angle autolink's visible text is the URL run between the hidden `<`/`>`
+  // (the run lookup misses when `pos` sits on a bracket, so fall back to the
+  // grammar's fixed one-character brackets).
   if (!pack || packAttrs?.key !== 'link') {
+    const unitRange = { from: unit.from, to: unit.to }
+    const text =
+      packAttrs?.key === 'autolink'
+        ? (lastMarkRunIn(state, unitRange, 'mdLinkText') ?? {
+            from: unit.from + 1,
+            to: unit.to - 1,
+          })
+        : unitRange
     return {
-      unit: { from: unit.from, to: unit.to },
+      unit: unitRange,
+      text,
       href,
       title: '',
     }
@@ -87,9 +107,11 @@ export function getLinkUnitAt(state: EditorState, pos: number): LinkUnit | undef
   const closeBracket = uri ? uri.from - 2 : unit.to - 3
   const destFrom = uri ? uri.from : unit.to - 1
 
+  const label = { from: unit.from + 1, to: closeBracket }
   return {
     unit: { from: unit.from, to: unit.to },
-    label: { from: unit.from + 1, to: closeBracket },
+    text: label,
+    label,
     dest: { from: destFrom, to: unit.to - 1 },
     href: packAttrs.data.href,
     title: packAttrs.data.title,

--- a/packages/core/src/utils/caret-coords.ts
+++ b/packages/core/src/utils/caret-coords.ts
@@ -7,15 +7,21 @@ export interface CaretCoords {
   bottom: number
 }
 
-function isZeroRect(rect: CaretCoords): boolean {
-  return rect.left === 0 && rect.top === 0 && rect.right === 0 && rect.bottom === 0
+/**
+ * A dimensionless point: the fallback measurement of a hidden (font-size: 0)
+ * syntax run. A real caret rect always has line height, and a block-context
+ * line always has width. WebKit reports the point at the origin, Blink and
+ * Gecko at the run's baseline.
+ */
+function isPointRect(rect: CaretCoords): boolean {
+  return rect.left === rect.right && rect.top === rect.bottom
 }
 
 /**
  * `view.coordsAtPos` that returns undefined instead of throwing on an
- * out-of-range position or returning a zero rect. A position whose `side`
+ * out-of-range position or returning a point rect. A position whose `side`
  * neighbor is hidden markdown syntax has no visible box on that side and
- * measures as a bogus zero rect.
+ * measures as a bogus dimensionless point.
  */
 export function tryCoordsAtPos(
   view: EditorView,
@@ -29,5 +35,5 @@ export function tryCoordsAtPos(
   } catch {
     return undefined
   }
-  return isZeroRect(coords) ? undefined : coords
+  return isPointRect(coords) ? undefined : coords
 }

--- a/packages/react/src/components/link-menu.test.tsx
+++ b/packages/react/src/components/link-menu.test.tsx
@@ -44,10 +44,51 @@ describe('LinkMenu', () => {
 
     const linkRect = link.element().getBoundingClientRect()
     const popRect = popover.element().getBoundingClientRect()
-    // Just below the link...
-    expect(popRect.top).toBeGreaterThan(linkRect.bottom)
+    // Just below the link: the popover sits `sideOffset` (8px, minus rounding)
+    // under the text box. An anchor measured at the baseline lands closer.
+    expect(popRect.top).toBeGreaterThanOrEqual(linkRect.bottom + 7)
     expect(popRect.top).toBeLessThan(linkRect.bottom + 40)
     // ...and centered on it, not dragged toward the viewport corner.
+    const linkCenter = (linkRect.left + linkRect.right) / 2
+    const popCenter = (popRect.left + popRect.right) / 2
+    expect(Math.abs(popCenter - linkCenter)).toBeLessThan(20)
+  })
+
+  it('anchors the preview to an angle autolink mid-line', async () => {
+    // `<`/`>` are hidden syntax: a whole-unit anchor measures the collapsed
+    // glyphs and sits on the baseline instead of the text box.
+    await render(<MeowdownEditor initialMarkdown="see <https://www.example.com> here" />)
+    const link = pmRoot.getByText('https://www.example.com')
+    await link.hover()
+    await expect.element(popover.getByTestId('link-popover-read')).toBeVisible()
+
+    const linkRect = link.element().getBoundingClientRect()
+    const popRect = popover.element().getBoundingClientRect()
+    expect(popRect.top).toBeGreaterThanOrEqual(linkRect.bottom + 7)
+    expect(popRect.top).toBeLessThan(linkRect.bottom + 40)
+    const linkCenter = (linkRect.left + linkRect.right) / 2
+    const popCenter = (popRect.left + popRect.right) / 2
+    expect(Math.abs(popCenter - linkCenter)).toBeLessThan(20)
+  })
+
+  it('anchors the preview to an angle autolink alone in its block', async () => {
+    // Both unit edges sit at block boundaries next to the hidden `<`/`>`:
+    // WebKit measures zero rects on both sides and used to pin the popover at
+    // the viewport corner. Park the caret in the other paragraph first; the
+    // initial caret at doc start sits inside the autolink and focus mode
+    // reveals the brackets, masking the bug.
+    await render(
+      <MeowdownEditor initialMarkdown={'<https://www.example.com>\n\npark the caret here'} />,
+    )
+    await pmRoot.getByText('park the caret here').click()
+    const link = pmRoot.getByText('https://www.example.com')
+    await link.hover()
+    await expect.element(popover.getByTestId('link-popover-read')).toBeVisible()
+
+    const linkRect = link.element().getBoundingClientRect()
+    const popRect = popover.element().getBoundingClientRect()
+    expect(popRect.top).toBeGreaterThanOrEqual(linkRect.bottom + 7)
+    expect(popRect.top).toBeLessThan(linkRect.bottom + 40)
     const linkCenter = (linkRect.left + linkRect.right) / 2
     const popCenter = (popRect.left + popRect.right) / 2
     expect(Math.abs(popCenter - linkCenter)).toBeLessThan(20)

--- a/packages/react/src/components/link-menu.tsx
+++ b/packages/react/src/components/link-menu.tsx
@@ -231,16 +231,15 @@ export function LinkMenu({ onLinkClick, onLinkCopy }: LinkMenuProps) {
   let rangeFrom: number | undefined
   let rangeTo: number | undefined
 
-  // Anchor on the visible `[ ]` label rather than the whole unit: the unit's
-  // outer edges sit inside the hidden `[`/`](url)` syntax, whose collapsed
-  // glyphs measure at bogus coordinates. Autolinks (no `label`) are fully
-  // visible, so their unit is safe.
+  // Anchor on the link's visible text rather than the whole unit: the unit's
+  // outer edges can sit inside hidden syntax (`[`/`](url)`, an angle
+  // autolink's `<`/`>`), whose collapsed glyphs measure at bogus coordinates.
   if (edit) {
-    const anchorRange = edit.link?.label ?? edit
+    const anchorRange = edit.link?.text ?? edit
     rangeFrom = anchorRange.from
     rangeTo = anchorRange.to
   } else if (hover) {
-    const anchorRange = hover.label ?? hover.unit
+    const anchorRange = hover.text
     rangeFrom = anchorRange.from
     rangeTo = anchorRange.to
   }


### PR DESCRIPTION
Hovering an angle autolink `<https://example.com>` misplaced the link popover: the anchor range included the hidden `<`/`>` glyphs, which measure at bogus coordinates (a baseline point in Blink/Gecko, and in WebKit a zero rect that pins the popover at the viewport corner when the autolink touches a block boundary). `LinkUnit` now exposes the link's visible `text` range, the popover anchors on it, and `tryCoordsAtPos` treats dimensionless point rects as misses so edge measurements fall back to a visible neighbor.


Before:

<img width="578" height="206" alt="Screenshot 2026-07-10 at 08 15 28" src="https://github.com/user-attachments/assets/ca6bcdf3-5e64-489a-aa00-807fe6d396c1" />


After:

<img width="619" height="227" alt="Screenshot 2026-07-10 at 08 17 11" src="https://github.com/user-attachments/assets/c03e9d05-a925-451a-bc2b-4ccb5ecfb219" />
