### PR TITLE
fix(core): stop `ArrowLeft` getting stuck before a leading atom mark

### DIFF
--- a/packages/core/src/extensions/atom-mark-navigation.test.ts
+++ b/packages/core/src/extensions/atom-mark-navigation.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  formatSelectionSteps,
+  setupFixture,
+  traceKeySelection,
+  traceShiftKeySelection,
+  type Fixture,
+} from '../testing/index.ts'
+
+import { defineImage } from './image.ts'
+import type { MarkMode } from './mark-mode.ts'
+
+const YOUTUBE = '![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)'
+const TWEET = '![](https://twitter.com/jack/status/20)'
+
+function getSVGImageURL(width: number, height: number): string {
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">` +
+    `<rect width="${width}" height="${height}" fill="pink"/>` +
+    `</svg>`
+  return `data:image/svg+xml;base64,${btoa(svg)}`
+}
+
+// An editor with one paragraph per entry in `paragraphs`.
+function setup(mode: MarkMode, paragraphs: string[]): Fixture {
+  const fixture = setupFixture({ extensionOptions: { markMode: mode } })
+  const { editor, n } = fixture
+  editor.use(defineImage({ resolveImageUrl: () => getSVGImageURL(24, 24) }))
+  fixture.set(n.doc(...paragraphs.map((text) => n.paragraph(text))))
+  fixture.view.focus()
+  return fixture
+}
+
+async function walkKey(fixture: Fixture, key: string, times: number): Promise<string> {
+  return formatSelectionSteps(await traceKeySelection(fixture, key, times))
+}
+
+async function walkShiftKey(fixture: Fixture, key: string, times: number): Promise<string> {
+  return formatSelectionSteps(await traceShiftKeySelection(fixture, key, times))
+}
+
+describe('caret navigation across atom-only paragraphs', () => {
+  it('focus: ArrowLeft from after the tweet walks back through both embeds', async () => {
+    using fixture = setup('focus', [YOUTUBE, `${TWEET}<a>`])
+    expect(await walkKey(fixture, 'ArrowLeft', 5)).toMatchInlineSnapshot(`
+      "
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ![](https://twitter.com/jack/status/20)┃
+      ----------
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ❰![](https://twitter.com/jack/status/20)❱
+      ----------
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ┃![](https://twitter.com/jack/status/20)
+      ----------
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)┃
+      ![](https://twitter.com/jack/status/20)
+      ----------
+      ❰![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)❱
+      ![](https://twitter.com/jack/status/20)
+      ----------
+      ┃![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ![](https://twitter.com/jack/status/20)
+      "
+    `)
+  })
+
+  it('focus: ArrowRight from before the youtube walks forward through both embeds', async () => {
+    using fixture = setup('focus', [`<a>${YOUTUBE}`, TWEET])
+    expect(await walkKey(fixture, 'ArrowRight', 5)).toMatchInlineSnapshot(`
+      "
+      ┃![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ![](https://twitter.com/jack/status/20)
+      ----------
+      ❰![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)❱
+      ![](https://twitter.com/jack/status/20)
+      ----------
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)┃
+      ![](https://twitter.com/jack/status/20)
+      ----------
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ┃![](https://twitter.com/jack/status/20)
+      ----------
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ❰![](https://twitter.com/jack/status/20)❱
+      ----------
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ![](https://twitter.com/jack/status/20)┃
+      "
+    `)
+  })
+
+  it('hide: ArrowLeft from after the tweet walks back through both embeds', async () => {
+    using fixture = setup('hide', [YOUTUBE, `${TWEET}<a>`])
+    expect(await walkKey(fixture, 'ArrowLeft', 5)).toMatchInlineSnapshot(`
+      "
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ![](https://twitter.com/jack/status/20)┃
+      ----------
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ❰![](https://twitter.com/jack/status/20)❱
+      ----------
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ┃![](https://twitter.com/jack/status/20)
+      ----------
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)┃
+      ![](https://twitter.com/jack/status/20)
+      ----------
+      ❰![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)❱
+      ![](https://twitter.com/jack/status/20)
+      ----------
+      ┃![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ![](https://twitter.com/jack/status/20)
+      "
+    `)
+  })
+
+  it('show: ArrowLeft from after the tweet walks back through both embeds', async () => {
+    using fixture = setup('show', [YOUTUBE, `${TWEET}<a>`])
+    expect(await walkKey(fixture, 'ArrowLeft', 5)).toMatchInlineSnapshot(`
+      "
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ![](https://twitter.com/jack/status/20)┃
+      ----------
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ❰![](https://twitter.com/jack/status/20)❱
+      ----------
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ┃![](https://twitter.com/jack/status/20)
+      ----------
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)┃
+      ![](https://twitter.com/jack/status/20)
+      ----------
+      ❰![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)❱
+      ![](https://twitter.com/jack/status/20)
+      ----------
+      ┃![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ![](https://twitter.com/jack/status/20)
+      "
+    `)
+  })
+
+  it('focus: ArrowLeft with plain images instead of embeds', async () => {
+    using fixture = setup('focus', ['![a](one.png)', '![b](two.png)<a>'])
+    expect(await walkKey(fixture, 'ArrowLeft', 5)).toMatchInlineSnapshot(`
+      "
+      ![a](one.png)
+      ![b](two.png)┃
+      ----------
+      ![a](one.png)
+      ❰![b](two.png)❱
+      ----------
+      ![a](one.png)
+      ┃![b](two.png)
+      ----------
+      ![a](one.png)┃
+      ![b](two.png)
+      ----------
+      ❰![a](one.png)❱
+      ![b](two.png)
+      ----------
+      ┃![a](one.png)
+      ![b](two.png)
+      "
+    `)
+  })
+
+  it('focus: ArrowLeft from an embed paragraph into a text paragraph', async () => {
+    using fixture = setup('focus', ['hello', `${TWEET}<a>`])
+    expect(await walkKey(fixture, 'ArrowLeft', 4)).toMatchInlineSnapshot(`
+      "
+      hello
+      ![](https://twitter.com/jack/status/20)┃
+      ----------
+      hello
+      ❰![](https://twitter.com/jack/status/20)❱
+      ----------
+      hello
+      ┃![](https://twitter.com/jack/status/20)
+      ----------
+      hello┃
+      ![](https://twitter.com/jack/status/20)
+      ----------
+      hell┃o
+      ![](https://twitter.com/jack/status/20)
+      "
+    `)
+  })
+
+  it('focus: ArrowRight from a text paragraph into an embed paragraph', async () => {
+    using fixture = setup('focus', ['hello<a>', TWEET])
+    expect(await walkKey(fixture, 'ArrowRight', 3)).toMatchInlineSnapshot(`
+      "
+      hello┃
+      ![](https://twitter.com/jack/status/20)
+      ----------
+      hello
+      ┃![](https://twitter.com/jack/status/20)
+      ----------
+      hello
+      ❰![](https://twitter.com/jack/status/20)❱
+      ----------
+      hello
+      ![](https://twitter.com/jack/status/20)┃
+      "
+    `)
+  })
+
+  it('focus: ArrowRight from an embed paragraph into a text paragraph', async () => {
+    using fixture = setup('focus', [`${YOUTUBE}<a>`, 'world'])
+    expect(await walkKey(fixture, 'ArrowRight', 2)).toMatchInlineSnapshot(`
+      "
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)┃
+      world
+      ----------
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ┃world
+      ----------
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      w┃orld
+      "
+    `)
+  })
+
+  it('focus: ArrowLeft from a text paragraph into an embed paragraph', async () => {
+    using fixture = setup('focus', [YOUTUBE, '<a>world'])
+    expect(await walkKey(fixture, 'ArrowLeft', 3)).toMatchInlineSnapshot(`
+      "
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ┃world
+      ----------
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)┃
+      world
+      ----------
+      ❰![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)❱
+      world
+      ----------
+      ┃![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      world
+      "
+    `)
+  })
+})
+
+describe('shift selection across atom-only paragraphs', () => {
+  it('focus: Shift-ArrowLeft from after the tweet extends back through both embeds', async () => {
+    using fixture = setup('focus', [YOUTUBE, `${TWEET}<a>`])
+    expect(await walkShiftKey(fixture, 'ArrowLeft', 3)).toMatchInlineSnapshot(`
+      "
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ![](https://twitter.com/jack/status/20)┃
+      ----------
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ❰![](https://twitter.com/jack/status/20)❱
+      ----------
+      ![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)❰
+      ![](https://twitter.com/jack/status/20)❱
+      ----------
+      ❰![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ![](https://twitter.com/jack/status/20)❱
+      "
+    `)
+  })
+
+  it('focus: Shift-ArrowRight from before the youtube extends through both embeds', async () => {
+    using fixture = setup('focus', [`<a>${YOUTUBE}`, TWEET])
+    expect(await walkShiftKey(fixture, 'ArrowRight', 3)).toMatchInlineSnapshot(`
+      "
+      ┃![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ![](https://twitter.com/jack/status/20)
+      ----------
+      ❰![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)❱
+      ![](https://twitter.com/jack/status/20)
+      ----------
+      ❰![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ❱![](https://twitter.com/jack/status/20)
+      ----------
+      ❰![](https://www.youtube.com/watch?v=aqz-KE-bpKQ)
+      ![](https://twitter.com/jack/status/20)❱
+      "
+    `)
+  })
+
+  it('focus: Shift-ArrowLeft in one paragraph swallows the image as a unit', async () => {
+    using fixture = setup('focus', ['ABC![img](url)D<a>EF'])
+    expect(await walkShiftKey(fixture, 'ArrowLeft', 3)).toMatchInlineSnapshot(`
+      "
+      ABC![img](url)D┃EF
+      ----------
+      ABC![img](url)❰D❱EF
+      ----------
+      ABC❰![img](url)D❱EF
+      ----------
+      AB❰C![img](url)D❱EF
+      "
+    `)
+  })
+
+  it('focus: Shift-ArrowLeft from an embed paragraph into a text paragraph', async () => {
+    using fixture = setup('focus', ['hello', `${TWEET}<a>`])
+    expect(await walkShiftKey(fixture, 'ArrowLeft', 3)).toMatchInlineSnapshot(`
+      "
+      hello
+      ![](https://twitter.com/jack/status/20)┃
+      ----------
+      hello
+      ❰![](https://twitter.com/jack/status/20)❱
+      ----------
+      hello❰
+      ![](https://twitter.com/jack/status/20)❱
+      ----------
+      hell❰o
+      ![](https://twitter.com/jack/status/20)❱
+      "
+    `)
+  })
+})

--- a/packages/core/src/extensions/atom-mark-navigation.ts
+++ b/packages/core/src/extensions/atom-mark-navigation.ts
@@ -10,7 +10,7 @@ import {
   type PlainExtension,
 } from '@prosekit/core'
 import type { Command, EditorState } from '@prosekit/pm/state'
-import { Plugin, PluginKey, TextSelection } from '@prosekit/pm/state'
+import { Plugin, PluginKey, Selection, TextSelection } from '@prosekit/pm/state'
 import { Decoration, DecorationSet } from '@prosekit/pm/view'
 
 import { getMarkRangeAt } from './get-mark-range-at.ts'
@@ -78,8 +78,47 @@ function selectRange(state: EditorState, range: MarkRange): TextSelection {
   return TextSelection.create(state.doc, range.from, range.to)
 }
 
+// The blockwise step out of `pos`'s textblock in `direction`, or undefined when
+// the step is not this keymap's to take. Chromium and WebKit cannot move the
+// native caret across the contenteditable=false preview at a textblock edge,
+// and prosemirror-view's own blockwise handling only covers vertical arrows.
+function findSelectionAcrossBlockBoundary(
+  state: EditorState,
+  pos: number,
+  markNames: MarkName[],
+  direction: -1 | 1,
+): Selection | undefined {
+  const $pos = state.doc.resolve(pos)
+  // Only a caret sitting exactly on the textblock edge can leave the block.
+  const atEdge =
+    direction === -1 ? $pos.parentOffset === 0 : $pos.parentOffset === $pos.parent.content.size
+  if (!atEdge || $pos.depth === 0) return undefined
+  // The unit being left behind: one starting (going left) or ending (going
+  // right) exactly at the caret. Chromium/WebKit cannot walk out past it.
+  const nearUnit =
+    direction === -1 ? getRangeAfter(state, pos, markNames) : getRangeBefore(state, pos, markNames)
+  // The nearest selection past the boundary: the adjacent textblock's near
+  // edge, or a NodeSelection for a selectable block such as a horizontal rule
+  // (the same landing prosemirror-view's moveSelectionBlock would pick).
+  const boundary = direction === -1 ? $pos.before() : $pos.after()
+  const target = Selection.findFrom(state.doc.resolve(boundary), direction)
+  if (!target) return undefined
+  // The unit being entered: one touching the landing position from the far
+  // side. WebKit skips caret stops when walking into such a block.
+  const farUnit = isTextSelection(target)
+    ? direction === -1
+      ? getRangeBefore(state, target.head, markNames)
+      : getRangeAfter(state, target.head, markNames)
+    : undefined
+  // No unit on either side of the boundary: stay out of the browser's way
+  // (native handles bidi/RTL horizontal motion better than we can).
+  if (nearUnit == null && farUnit == null) return undefined
+  return target
+}
+
 // ArrowRight: select the unit to the right, collapse a selected unit to its far
-// edge, or step past a unit to the left (which the browser cannot do).
+// edge, step past a unit to the left (which the browser cannot do), or step
+// blockwise at the textblock end.
 function createArrowRight(marks: AtomMarks): Command {
   return (state, dispatch) => {
     const markNames = activeMarkNames(marks, state)
@@ -92,13 +131,16 @@ function createArrowRight(marks: AtomMarks): Command {
         return true
       }
       const before = getRangeBefore(state, selection.from, markNames)
-      if (before) {
-        const $from = state.doc.resolve(selection.from)
-        if (selection.from >= $from.end()) return false
+      if (before && selection.from < state.doc.resolve(selection.from).end()) {
         dispatch?.(state.tr.setSelection(TextSelection.create(state.doc, selection.from + 1)))
         return true
       }
-      return false
+      // The mirror of ArrowLeft. Not observed broken on desktop, but owning the
+      // step keeps the walk deterministic instead of depending on the browser.
+      const target = findSelectionAcrossBlockBoundary(state, selection.from, markNames, 1)
+      if (!target) return false
+      dispatch?.(state.tr.setSelection(target).scrollIntoView())
+      return true
     }
     const range = getSelectedRange(state, markNames)
     if (!range) return false
@@ -107,8 +149,8 @@ function createArrowRight(marks: AtomMarks): Command {
   }
 }
 
-// ArrowLeft: select the unit to the left, or collapse a selected unit to its
-// near edge.
+// ArrowLeft: select the unit to the left, collapse a selected unit to its near
+// edge, or step blockwise at the textblock start.
 function createArrowLeft(marks: AtomMarks): Command {
   return (state, dispatch) => {
     const markNames = activeMarkNames(marks, state)
@@ -116,13 +158,53 @@ function createArrowLeft(marks: AtomMarks): Command {
     const selection = state.selection
     if (selection.empty) {
       const before = getRangeBefore(state, selection.from, markNames)
-      if (!before) return false
-      dispatch?.(state.tr.setSelection(selectRange(state, before)))
+      if (before) {
+        dispatch?.(state.tr.setSelection(selectRange(state, before)))
+        return true
+      }
+      // At the textblock start, take the blockwise step: Chromium/WebKit's
+      // native caret cannot leave a block that starts with a unit.
+      const target = findSelectionAcrossBlockBoundary(state, selection.from, markNames, -1)
+      if (!target) return false
+      dispatch?.(state.tr.setSelection(target).scrollIntoView())
       return true
     }
     const range = getSelectedRange(state, markNames)
     if (!range) return false
     dispatch?.(state.tr.setSelection(TextSelection.create(state.doc, range.from)))
+    return true
+  }
+}
+
+// Shift-Arrow: the selection head swallows an adjacent unit whole, or takes the
+// blockwise step at a textblock edge. Without this, native extension creeps
+// through the hidden source one invisible character per press.
+function createShiftArrow(marks: AtomMarks, direction: -1 | 1): Command {
+  return (state, dispatch) => {
+    const markNames = activeMarkNames(marks, state)
+    if (markNames.length === 0 || !isTextSelection(state.selection)) return false
+    const { anchor, head } = state.selection
+    // A unit whose edge sits exactly at the head enters (or leaves) the
+    // selection whole; a head inside a revealed source keeps native per-char
+    // behavior (the text is visible there).
+    const unit =
+      direction === -1
+        ? getRangeBefore(state, head, markNames)
+        : getRangeAfter(state, head, markNames)
+    if (unit) {
+      const nextHead = direction === -1 ? unit.from : unit.to
+      dispatch?.(
+        state.tr.setSelection(TextSelection.create(state.doc, anchor, nextHead)).scrollIntoView(),
+      )
+      return true
+    }
+    // At the textblock edge, move the head blockwise; only a textblock landing
+    // can extend a text selection, so a NodeSelection target declines.
+    const target = findSelectionAcrossBlockBoundary(state, head, markNames, direction)
+    if (!target || !isTextSelection(target)) return false
+    dispatch?.(
+      state.tr.setSelection(TextSelection.create(state.doc, anchor, target.head)).scrollIntoView(),
+    )
     return true
   }
 }
@@ -203,8 +285,9 @@ function createSelectionPlugin(marks: AtomMarks): Plugin {
 
 /**
  * Make a text-backed source unit a single caret stop in the listed mark modes:
- * arrowing onto it selects the whole source, and Backspace/Delete remove it as a
- * unit.
+ * arrowing onto it selects the whole source, Shift-arrowing extends over it
+ * whole, arrows cross textblock boundaries it touches (which the browser's
+ * native caret cannot), and Backspace/Delete remove it as a unit.
  */
 export function defineAtomMarkNavigation({ marks }: AtomMarkNavigationOptions): PlainExtension {
   return union(
@@ -212,6 +295,8 @@ export function defineAtomMarkNavigation({ marks }: AtomMarkNavigationOptions): 
       defineKeymap({
         ArrowRight: createArrowRight(marks),
         ArrowLeft: createArrowLeft(marks),
+        'Shift-ArrowRight': createShiftArrow(marks, 1),
+        'Shift-ArrowLeft': createShiftArrow(marks, -1),
         Backspace: createBackspace(marks),
         Delete: createForwardDelete(marks),
       }),

--- a/packages/core/src/extensions/wikilink.test.ts
+++ b/packages/core/src/extensions/wikilink.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 
 import {
+  formatSelectionSteps,
   getSelectionSnapshot,
   setupFixture,
   traceKeyAt,
@@ -158,8 +159,7 @@ describe('wikilink vertical caret navigation', () => {
       ),
     )
     fixture.view.focus()
-    const steps = await traceKeySelection(fixture, 'ArrowDown', 7)
-    return steps.map((step) => '\n' + step + '\n').join('-'.repeat(10))
+    return formatSelectionSteps(await traceKeySelection(fixture, 'ArrowDown', 7))
   }
 
   it('can ArrowDown from the first paragraph to the last paragraph in hide mode', async () => {

--- a/packages/core/src/testing/caret.ts
+++ b/packages/core/src/testing/caret.ts
@@ -4,6 +4,23 @@ import { getSelectionSnapshot } from './selection-snapshot.ts'
 
 import type { Fixture } from './index.ts'
 
+async function traceSelection(
+  fixture: Fixture,
+  press: () => Promise<void>,
+  times: number,
+): Promise<string[]> {
+  const steps = new Set([getSelectionSnapshot(fixture.state)])
+  const extraTimes = 2 // We press the key more times than requested to address flaky tests.
+  for (let index = 0; index < times + extraTimes; index++) {
+    await press()
+    steps.add(getSelectionSnapshot(fixture.state))
+    if (steps.size > times) {
+      break
+    }
+  }
+  return Array.from(steps)
+}
+
 /**
  * Press `key` `times` times, capturing the selection snapshot before the first
  * press and after each one. The returned array has `times + 1` entries.
@@ -13,16 +30,26 @@ export async function traceKeySelection(
   key: string,
   times: number,
 ): Promise<string[]> {
-  const steps = new Set([getSelectionSnapshot(fixture.state)])
-  const extraTimes = 2 // We press the key more times than requested to address flaky tests.
-  for (let index = 0; index < times + extraTimes; index++) {
-    await userEvent.keyboard(`{${key}}`)
-    steps.add(getSelectionSnapshot(fixture.state))
-    if (steps.size > times) {
-      break
-    }
-  }
-  return Array.from(steps)
+  return await traceSelection(fixture, () => userEvent.keyboard(`{${key}}`), times)
+}
+
+/**
+ * Like {@link traceKeySelection}, but holds Shift through each press.
+ */
+export async function traceShiftKeySelection(
+  fixture: Fixture,
+  key: string,
+  times: number,
+): Promise<string[]> {
+  return await traceSelection(fixture, () => userEvent.keyboard(`{Shift>}{${key}}{/Shift}`), times)
+}
+
+/**
+ * Render trace steps as one readable snapshot: each document state on its own
+ * lines, separated by a dashed rule.
+ */
+export function formatSelectionSteps(steps: string[]): string {
+  return steps.map((step) => '\n' + step + '\n').join('-'.repeat(10))
 }
 
 /**

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -11,7 +11,12 @@ import { defineEditorExtension, type EditorExtensionOptions } from '../extension
 import { getSelectionSnapshot } from './selection-snapshot.ts'
 
 export { getSelectionSnapshot } from './selection-snapshot.ts'
-export { traceKeySelection, traceKeyAt } from './caret.ts'
+export {
+  formatSelectionSteps,
+  traceKeyAt,
+  traceKeySelection,
+  traceShiftKeySelection,
+} from './caret.ts'
 
 export interface SetupFixtureOptions {
   /** Whether to mount the editor onto a real DOM container. Defaults to `true`. */


### PR DESCRIPTION
In Chromium and WebKit, arrow keys get stuck at a textblock boundary that touches an atom mark (image, embed, wikilink, file pill), because the native caret cannot cross the contenteditable=false preview; shift selection also creeps through the hidden source one invisible character per press in every browser. The atom mark keymap now owns the blockwise arrow step at such boundaries and makes Shift-Arrow swallow a unit whole.


Closes https://github.com/prosekit/meowdown/issues/267 