### PR TITLE
feat(core): extend wikilink queries with arrow keys

### DIFF
--- a/packages/core/src/extensions/wikilink-trigger.test.ts
+++ b/packages/core/src/extensions/wikilink-trigger.test.ts
@@ -1,3 +1,4 @@
+import { AutocompleteRule, defineAutocomplete } from '@prosekit/extensions/autocomplete'
 import { describe, expect, it } from 'vitest'
 import { userEvent } from 'vitest/browser'
 
@@ -7,12 +8,28 @@ import { defineWikilinkTrigger } from './wikilink-trigger.ts'
 
 // In `userEvent.keyboard` a literal `[` must be escaped by doubling it.
 const pressBracket = () => userEvent.keyboard('[[')
+const pressWikilinkOpen = () => userEvent.keyboard('[[[[')
 const pressModShiftK = () => userEvent.keyboard('{ControlOrMeta>}{Shift>}k{/Shift}{/ControlOrMeta}')
 
 function setup(): Fixture {
   const fixture = setupFixture()
   fixture.editor.use(defineWikilinkTrigger())
   return fixture
+}
+
+function trackWikilinkMatches(fixture: Fixture): string[] {
+  const matches: string[] = []
+  fixture.editor.use(
+    defineAutocomplete(
+      new AutocompleteRule({
+        regex: /\[\[[^[\]]*$/u,
+        onEnter: ({ match }) => {
+          matches.push(match[0])
+        },
+      }),
+    ),
+  )
+  return matches
 }
 
 describe('defineWikilinkTrigger', () => {
@@ -87,5 +104,37 @@ describe('defineWikilinkTrigger', () => {
     fixture.view.focus()
     await pressModShiftK()
     expect(fixture.selectionSnapshot).toBe('Cat [[naps┃')
+  })
+
+  it('keeps autocomplete matched while ArrowRight includes existing text', async () => {
+    using fixture = setup()
+    const matches = trackWikilinkMatches(fixture)
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>Cat')))
+    fixture.view.focus()
+
+    await pressWikilinkOpen()
+    expect(fixture.selectionSnapshot).toBe('[[┃Cat')
+
+    await userEvent.keyboard('{ArrowRight}')
+    expect(fixture.selectionSnapshot).toBe('[[C┃at')
+    expect(matches.at(-1)).toBe('[[C')
+
+    await userEvent.keyboard('{ArrowLeft}')
+    expect(fixture.selectionSnapshot).toBe('[[┃Cat')
+    expect(matches.at(-1)).toBe('[[')
+  })
+
+  it('does not activate autocomplete while ArrowRight crosses a loaded incomplete wikilink', async () => {
+    using fixture = setup()
+    const matches = trackWikilinkMatches(fixture)
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('[[<a>Cat')))
+    fixture.view.focus()
+
+    await userEvent.keyboard('{ArrowRight}')
+
+    expect(fixture.selectionSnapshot).toBe('[[C┃at')
+    expect(matches).toEqual([])
   })
 })

--- a/packages/core/src/extensions/wikilink-trigger.ts
+++ b/packages/core/src/extensions/wikilink-trigger.ts
@@ -1,8 +1,25 @@
-import { defineKeymap, isTextSelection, type PlainExtension } from '@prosekit/core'
+import {
+  defineKeymap,
+  definePlugin,
+  isTextSelection,
+  OBJECT_REPLACEMENT_CHARACTER,
+  union,
+  type PlainExtension,
+} from '@prosekit/core'
 import { triggerAutocomplete } from '@prosekit/extensions/autocomplete'
-import { TextSelection, type Command } from '@prosekit/pm/state'
+import {
+  Plugin,
+  PluginKey,
+  TextSelection,
+  type Command,
+  type EditorState,
+} from '@prosekit/pm/state'
+import type { EditorView } from '@prosekit/pm/view'
 
 const WIKILINK_OPEN = '[['
+const WIKILINK_QUERY = /\[\[[^[\]]*$/u
+const MAX_AUTOCOMPLETE_MATCH = 200
+const wikilinkCursorTrackingKey = new PluginKey('meowdown-wikilink-cursor-tracking')
 
 interface OpenWikilinkMenuOptions {
   /**
@@ -56,13 +73,106 @@ function openWikilinkMenu({ allowEmpty }: OpenWikilinkMenuOptions): Command {
   }
 }
 
+function hasOpenWikilinkQueryBeforeCursor(state: EditorState): boolean {
+  const { selection } = state
+  if (!isTextSelection(selection) || !selection.empty) return false
+  const { parent, parentOffset } = selection.$head
+  const from = Math.max(0, parentOffset - MAX_AUTOCOMPLETE_MATCH)
+  const text = parent.textBetween(from, parentOffset, '\n', OBJECT_REPLACEMENT_CHARACTER)
+  return WIKILINK_QUERY.test(text)
+}
+
+function hasActiveWikilinkAutocomplete(view: EditorView): boolean {
+  const match = view.dom.querySelector<HTMLElement>('.prosekit-autocomplete-match')
+  return match?.dataset.autocompleteMatchText?.startsWith(WIKILINK_OPEN) ?? false
+}
+
+// ProseKit normally closes autocomplete as soon as a selection-only transaction
+// moves the caret beyond the current match. Remember horizontal arrow presses
+// while a wikilink match is active, then tag the resulting native cursor
+// transaction so the match is re-scanned before it can be ignored. Leaving
+// cursor motion to the browser preserves its grapheme and bidi handling.
+function createWikilinkCursorTrackingPlugin(): Plugin {
+  let cursorMoveFrom: number | undefined
+
+  const clearCursorMove = () => {
+    cursorMoveFrom = undefined
+  }
+
+  return new Plugin({
+    key: wikilinkCursorTrackingKey,
+    filterTransaction: (tr, state) => {
+      const before = state.selection
+      const after = tr.selection
+      if (cursorMoveFrom !== before.head) return true
+      if (
+        !tr.docChanged &&
+        isTextSelection(before) &&
+        before.empty &&
+        isTextSelection(after) &&
+        after.empty &&
+        before.head !== after.head &&
+        before.$head.sameParent(after.$head) &&
+        hasOpenWikilinkQueryBeforeCursor(state)
+      ) {
+        triggerAutocomplete(tr)
+      }
+      if (tr.docChanged || !before.eq(after)) clearCursorMove()
+      return true
+    },
+    props: {
+      handleKeyDown: (view, event) => {
+        clearCursorMove()
+        if (
+          (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') ||
+          view.composing ||
+          !hasOpenWikilinkQueryBeforeCursor(view.state) ||
+          !hasActiveWikilinkAutocomplete(view)
+        ) {
+          return false
+        }
+
+        cursorMoveFrom = view.state.selection.head
+        return false
+      },
+      handleDOMEvents: {
+        blur: () => {
+          clearCursorMove()
+          return false
+        },
+        keyup: (view) => {
+          if (cursorMoveFrom == null) return false
+          // At a textblock boundary there is no selection transaction to clear
+          // the remembered keydown, so compare against the browser's DOM caret.
+          const selection = view.dom.ownerDocument.getSelection()
+          const focusNode = selection?.focusNode
+          if (!focusNode || !view.dom.contains(focusNode)) {
+            clearCursorMove()
+            return false
+          }
+          const domHead = view.posAtDOM(focusNode, selection.focusOffset, 1)
+          if (domHead === cursorMoveFrom) clearCursorMove()
+          return false
+        },
+        pointerdown: () => {
+          clearCursorMove()
+          return false
+        },
+      },
+    },
+  })
+}
+
 /**
  * Binds `Mod-Shift-k` to open the wikilink menu, and `[` to wrap a selected
  * phrase into an open wikilink (`[[phrase`) with the menu searching it.
  */
 export function defineWikilinkTrigger(): PlainExtension {
-  return defineKeymap({
-    'Mod-Shift-k': openWikilinkMenu({ allowEmpty: true }),
-    '[': openWikilinkMenu({ allowEmpty: false }),
-  })
+  return union(
+    defineKeymap({
+      'Mod-Shift-k': openWikilinkMenu({ allowEmpty: true }),
+      '[': openWikilinkMenu({ allowEmpty: false }),
+    }),
+    definePlugin(createWikilinkCursorTrackingPlugin()),
+  )
 }

--- a/packages/react/src/components/wikilink-menu.test.tsx
+++ b/packages/react/src/components/wikilink-menu.test.tsx
@@ -234,6 +234,90 @@ describe('WikilinkMenu', () => {
     expect(ref.current?.getMarkdown()).not.toContain('[[re')
   })
 
+  it('extends the query over existing text with ArrowRight', async () => {
+    const ref = createRef<EditorHandle>()
+    const onWikilinkSearch = vi.fn(searchNotes)
+    await render(
+      <ProseKitEditor
+        ref={ref}
+        initialMarkdown="See Reading list today"
+        onWikilinkSearch={onWikilinkSearch}
+      />,
+    )
+    ref.current?.setSelection({ type: 'text', anchor: 5, head: 5 })
+    ref.current?.focus()
+
+    await userEvent.keyboard(TWO_BRACKETS)
+    await userEvent.keyboard('{ArrowRight}'.repeat('Reading list'.length))
+
+    await vi.waitFor(() => {
+      expect(onWikilinkSearch).toHaveBeenLastCalledWith('Reading list')
+    })
+    await expect.element(menu.getByText('Reading list')).toBeVisible()
+
+    await menu.getByText('Reading list').click()
+    expect(ref.current?.getMarkdown()).toBe('See [[Reading list]] today\n')
+  })
+
+  it('can create a wikilink from existing text included with ArrowRight', async () => {
+    const ref = createRef<EditorHandle>()
+    const onSelect = vi.fn()
+    const onWikilinkSearch = vi.fn((query: string): WikilinkItem[] => {
+      return query ? [{ target: query, label: `Create "${query}"`, onSelect }] : []
+    })
+    await render(
+      <ProseKitEditor
+        ref={ref}
+        initialMarkdown="See New project later"
+        onWikilinkSearch={onWikilinkSearch}
+      />,
+    )
+    ref.current?.setSelection({ type: 'text', anchor: 5, head: 5 })
+    ref.current?.focus()
+
+    await userEvent.keyboard(TWO_BRACKETS)
+    await userEvent.keyboard('{ArrowRight}'.repeat('New project'.length))
+
+    const createItem = menu.getByText('Create "New project"')
+    await expect.element(createItem).toBeVisible()
+    await createItem.click()
+
+    expect(ref.current?.getMarkdown()).toBe('See [[New project]] later\n')
+    expect(onSelect).toHaveBeenCalledOnce()
+  })
+
+  it('does not reopen a dismissed query when ArrowRight crosses existing text', async () => {
+    const ref = createRef<EditorHandle>()
+    await render(
+      <ProseKitEditor ref={ref} initialMarkdown="See Cat" onWikilinkSearch={searchNotes} />,
+    )
+    ref.current?.setSelection({ type: 'text', anchor: 5, head: 5 })
+    ref.current?.focus()
+
+    await userEvent.keyboard(TWO_BRACKETS)
+    await expect.element(menu).toBeVisible()
+    await userEvent.keyboard('{Escape}')
+    await userEvent.keyboard('{ArrowRight}')
+
+    await expect.element(menu).not.toBeVisible()
+    expect(ref.current?.getSelection()).toMatchObject({ anchor: 8, head: 8 })
+  })
+
+  it('closes instead of extending when the cursor moves programmatically', async () => {
+    const ref = createRef<EditorHandle>()
+    await render(
+      <ProseKitEditor ref={ref} initialMarkdown="See Cat" onWikilinkSearch={searchNotes} />,
+    )
+    ref.current?.setSelection({ type: 'text', anchor: 5, head: 5 })
+    ref.current?.focus()
+
+    await userEvent.keyboard(TWO_BRACKETS)
+    await expect.element(menu).toBeVisible()
+    ref.current?.setSelection({ type: 'text', anchor: 10, head: 10 })
+
+    await expect.element(menu).not.toBeVisible()
+  })
+
   it('renders no wikilink menu when onWikilinkSearch is not given', async () => {
     await render(<ProseKitEditor />)
     await pmRoot.click()


### PR DESCRIPTION
## Problem

Typing `[[` immediately before existing prose opens the wikilink search, but the first Right Arrow used to close it. ProseKit treated the caret as having left the original zero-length query because the autocomplete match ended where `[[` was typed.

That prevented users from progressively including existing text in the query, choosing an existing note, or returning a host-provided create-note result for that text.

## Before → After

| Interaction | Before | After |
| --- | --- | --- |
| Type `[[` before `Reading list`, then press Right Arrow | Menu closes on the first keypress | Query grows one native caret step at a time |
| Press Left Arrow after advancing | Query stays at its furthest extent | Query shrinks with the caret |
| Pick an existing or create-note result | Traversed prose cannot be used | Traversed prose is replaced by the selected `[[target]]` |

## Changes

1. Add wikilink cursor tracking to `defineWikilinkTrigger`.
   - Re-scan autocomplete in the same native selection transaction, before ProseKit can dismiss and ignore the match.
   - Let the browser own caret movement so grapheme and bidirectional-text behavior remains native.
2. Scope tracking to Left/Right Arrow presses while an actual `[[…` autocomplete match is active.
   - Escape dismissal remains sticky.
   - Pointer, programmatic, Home/End, vertical, and loaded-incomplete-text selection moves do not activate or extend a query.
3. Add core and React browser regressions for growth, shrinkage, exact replacement, host-side creation, dismissal, and inactive selection movement.

## Verification

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm exec vitest run` — 85 files passed; 1,642 tests passed and 13 expected failures
- Focused wikilink suites in Chromium, Firefox, and WebKit — 43 tests passed in each browser

## Risk / Rollout

The behavior is limited to editors with the wikilink trigger/menu enabled and only changes active horizontal-arrow autocomplete navigation. There are no migrations or rollout steps.
