### PR TITLE
feat(core): restore automatic typography replacements

### DIFF
--- a/packages/core/src/extensions/extension.ts
+++ b/packages/core/src/extensions/extension.ts
@@ -35,6 +35,7 @@ import { defineMeowdownParagraph } from './paragraph.ts'
 import { definePendingReplacement } from './pending-replacement.ts'
 import { defineSelectDocBoundary } from './select-doc-boundary.ts'
 import { defineTable } from './table.ts'
+import { defineTypography } from './typography.ts'
 import { defineVirtualCaret } from './virtual-caret.ts'
 import { defineWikilink } from './wikilink.ts'
 
@@ -66,6 +67,7 @@ function defineEditorExtensionImpl(options: EditorExtensionOptions) {
     defineLinkCommands(),
     defineWikilink(),
     defineMath(),
+    defineTypography(),
     defineMarkMode(options.markMode ?? 'focus'),
     defineVirtualCaret(),
     defineHiddenRunCaret(),

--- a/packages/core/src/extensions/typography.test.ts
+++ b/packages/core/src/extensions/typography.test.ts
@@ -3,44 +3,66 @@ import { userEvent } from 'vitest/browser'
 
 import { setupFixture } from '../testing/index.ts'
 
-describe('left arrow typography', () => {
-  it('replaces a trailing `<-` only after a space is typed', async () => {
-    using fixture = setupFixture()
-    const { n } = fixture
-    fixture.set(n.doc(n.paragraph('before <a>after')))
-    fixture.view.focus()
+const REPLACEMENTS = [
+  { input: '<-', output: '←' },
+  { input: '->', output: '→' },
+  { input: '(c)', output: '©' },
+  { input: '(r)', output: '®' },
+  { input: '1/2', output: '½' },
+  { input: '+/-', output: '±' },
+  { input: '!=', output: '≠' },
+  { input: '<<', output: '«' },
+  { input: '>>', output: '»' },
+  { input: '--', output: '—' },
+] as const
 
-    await userEvent.keyboard('<-')
-    expect(fixture.doc.textContent).toBe('before <-after')
+describe('typography replacements', () => {
+  it.each(REPLACEMENTS)(
+    'replaces `$input` only after Space is typed',
+    async ({ input, output }) => {
+      using fixture = setupFixture()
+      const { n } = fixture
+      fixture.set(n.doc(n.paragraph('before <a>after')))
+      fixture.view.focus()
 
-    await userEvent.keyboard(' ')
-    expect(fixture.doc.textContent).toBe('before ← after')
-  })
+      await userEvent.keyboard(input)
+      expect(fixture.doc.textContent).toBe(`before ${input}after`)
 
-  it('replaces a trailing `<-` before Enter splits the paragraph', async () => {
-    using fixture = setupFixture()
-    const { n } = fixture
-    fixture.set(n.doc(n.paragraph('before <a>after')))
-    fixture.view.focus()
+      await userEvent.keyboard(' ')
+      expect(fixture.doc.textContent).toBe(`before ${output} after`)
+    },
+  )
 
-    await userEvent.keyboard('<-{Enter}')
+  it.each(REPLACEMENTS)(
+    'replaces `$input` before Enter splits the paragraph',
+    async ({ input, output }) => {
+      using fixture = setupFixture()
+      const { n } = fixture
+      fixture.set(n.doc(n.paragraph('before <a>after')))
+      fixture.view.focus()
 
-    const expected = n.doc(n.paragraph('before ←'), n.paragraph('after'))
-    expect(fixture.doc.eq(expected)).toBe(true)
-  })
+      await userEvent.keyboard(`${input}{Enter}`)
 
-  it('restores the literal input on an immediate Backspace', async () => {
-    using fixture = setupFixture()
-    const { n } = fixture
-    fixture.set(n.doc(n.paragraph('<a>')))
-    fixture.view.focus()
+      const expected = n.doc(n.paragraph(`before ${output}`), n.paragraph('after'))
+      expect(fixture.doc.eq(expected)).toBe(true)
+    },
+  )
 
-    await userEvent.keyboard('<- ')
-    expect(fixture.doc.textContent).toBe('← ')
+  it.each(REPLACEMENTS)(
+    'restores `$input` on an immediate Backspace',
+    async ({ input, output }) => {
+      using fixture = setupFixture()
+      const { n } = fixture
+      fixture.set(n.doc(n.paragraph('before <a>after')))
+      fixture.view.focus()
 
-    await userEvent.keyboard('{Backspace}')
-    expect(fixture.doc.textContent).toBe('<- ')
-  })
+      await userEvent.keyboard(`${input} `)
+      expect(fixture.doc.textContent).toBe(`before ${output} after`)
+
+      await userEvent.keyboard('{Backspace}')
+      expect(fixture.doc.textContent).toBe(`before ${input} after`)
+    },
+  )
 
   it('uses normal Backspace behavior after more text is typed', async () => {
     using fixture = setupFixture()
@@ -48,14 +70,14 @@ describe('left arrow typography', () => {
     fixture.set(n.doc(n.paragraph('<a>')))
     fixture.view.focus()
 
-    await userEvent.keyboard('<- x{Backspace}')
-    expect(fixture.doc.textContent).toBe('← ')
+    await userEvent.keyboard('(c) x{Backspace}')
+    expect(fixture.doc.textContent).toBe('© ')
   })
 
   it.each([
-    { trigger: 'Space', keys: '<- ', expected: '<- ' },
-    { trigger: 'Enter', keys: '<-{Enter}', expected: '<-\n' },
-  ])('does not replace `<-` before $trigger inside a code block', async ({ keys, expected }) => {
+    { trigger: 'Space', keys: '(c) ', expected: '(c) ' },
+    { trigger: 'Enter', keys: '(c){Enter}', expected: '(c)\n' },
+  ])('does not replace `(c)` before $trigger inside a code block', async ({ keys, expected }) => {
     using fixture = setupFixture()
     const { n } = fixture
     fixture.set(n.doc(n.codeBlock({ language: '' }, '<a>')))
@@ -68,24 +90,50 @@ describe('left arrow typography', () => {
   it.each([
     { trigger: 'Space', keys: ' ' },
     { trigger: 'Enter', keys: '{Enter}' },
-  ])('does not replace `<-` before $trigger inside inline code', async ({ keys }) => {
+  ])('does not replace `(c)` before $trigger inside inline code', async ({ keys }) => {
     using fixture = setupFixture()
     const { n } = fixture
-    fixture.set(n.doc(n.paragraph('`<-<a>`')))
+    fixture.set(n.doc(n.paragraph('`(c)<a>`')))
     fixture.view.focus()
 
     await userEvent.keyboard(keys)
-    expect(fixture.doc.textContent).toContain('<-')
-    expect(fixture.doc.textContent).not.toContain('←')
+    expect(fixture.doc.textContent).toContain('(c)')
+    expect(fixture.doc.textContent).not.toContain('©')
   })
 
-  it("does not enable the legacy extension's other typography replacements", async () => {
+  it.each([
+    { input: '--> ', output: '-→ ' },
+    { input: '->> ', output: '-» ' },
+  ])('uses the matching suffix in `$input`', async ({ input, output }) => {
     using fixture = setupFixture()
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('<a>')))
     fixture.view.focus()
 
-    await userEvent.keyboard('-> -- (c) ')
-    expect(fixture.doc.textContent).toBe('-> -- (c) ')
+    await userEvent.keyboard(input)
+    expect(fixture.doc.textContent).toBe(output)
+  })
+
+  it('replaces the final dash pair after nonempty text', async () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('x<a>')))
+    fixture.view.focus()
+
+    await userEvent.keyboard('--- ')
+    expect(fixture.doc.textContent).toBe('x-— ')
+  })
+
+  it('undoes only the latest replacement', async () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>')))
+    fixture.view.focus()
+
+    await userEvent.keyboard('<- -> ')
+    expect(fixture.doc.textContent).toBe('← → ')
+
+    await userEvent.keyboard('{Backspace}')
+    expect(fixture.doc.textContent).toBe('← -> ')
   })
 })

--- a/packages/core/src/extensions/typography.test.ts
+++ b/packages/core/src/extensions/typography.test.ts
@@ -101,17 +101,68 @@ describe('typography replacements', () => {
     expect(fixture.doc.textContent).not.toContain('©')
   })
 
-  it.each([
-    { input: '--> ', output: '-→ ' },
-    { input: '->> ', output: '-» ' },
-  ])('uses the matching suffix in `$input`', async ({ input, output }) => {
+  it('uses the matching suffix in `->>`', async () => {
     using fixture = setupFixture()
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('<a>')))
     fixture.view.focus()
 
-    await userEvent.keyboard(input)
-    expect(fixture.doc.textContent).toBe(output)
+    await userEvent.keyboard('->> ')
+    expect(fixture.doc.textContent).toBe('-» ')
+  })
+
+  it.each([
+    {
+      trigger: 'Space',
+      keys: '<!-- x --> ',
+      expected: (n: ReturnType<typeof setupFixture>['n']) => n.doc(n.paragraph('<!-- x --> ')),
+    },
+    {
+      trigger: 'Enter',
+      keys: '<!-- x -->{Enter}',
+      expected: (n: ReturnType<typeof setupFixture>['n']) =>
+        n.doc(n.paragraph('<!-- x -->'), n.paragraph()),
+    },
+  ])('preserves HTML comment delimiters before $trigger', async ({ keys, expected }) => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>')))
+    fixture.view.focus()
+
+    await userEvent.keyboard(keys)
+    expect(fixture.doc.eq(expected(n))).toBe(true)
+  })
+
+  it.each([
+    {
+      trigger: 'Space',
+      keys: ' ',
+      expected: (n: ReturnType<typeof setupFixture>['n']) => n.doc(n.paragraph('--- ')),
+    },
+    {
+      trigger: 'Enter',
+      keys: '{Enter}',
+      expected: (n: ReturnType<typeof setupFixture>['n']) =>
+        n.doc(n.paragraph('---'), n.paragraph()),
+    },
+  ])('preserves a thematic-break marker before $trigger', async ({ keys, expected }) => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('---<a>')))
+    fixture.view.focus()
+
+    await userEvent.keyboard(keys)
+    expect(fixture.doc.eq(expected(n))).toBe(true)
+  })
+
+  it('keeps the horizontal-rule input rule working', async () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>')))
+    fixture.view.focus()
+
+    await userEvent.keyboard('---')
+    expect(fixture.doc.eq(n.doc(n.horizontalRule(), n.paragraph()))).toBe(true)
   })
 
   it('replaces the final dash pair after nonempty text', async () => {

--- a/packages/core/src/extensions/typography.test.ts
+++ b/packages/core/src/extensions/typography.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { userEvent } from 'vitest/browser'
+
+import { setupFixture } from '../testing/index.ts'
+
+describe('left arrow typography', () => {
+  it('replaces a trailing `<-` only after a space is typed', async () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('before <a>after')))
+    fixture.view.focus()
+
+    await userEvent.keyboard('<-')
+    expect(fixture.doc.textContent).toBe('before <-after')
+
+    await userEvent.keyboard(' ')
+    expect(fixture.doc.textContent).toBe('before ← after')
+  })
+
+  it('replaces a trailing `<-` before Enter splits the paragraph', async () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('before <a>after')))
+    fixture.view.focus()
+
+    await userEvent.keyboard('<-{Enter}')
+
+    const expected = n.doc(n.paragraph('before ←'), n.paragraph('after'))
+    expect(fixture.doc.eq(expected)).toBe(true)
+  })
+
+  it('restores the literal input on an immediate Backspace', async () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>')))
+    fixture.view.focus()
+
+    await userEvent.keyboard('<- ')
+    expect(fixture.doc.textContent).toBe('← ')
+
+    await userEvent.keyboard('{Backspace}')
+    expect(fixture.doc.textContent).toBe('<- ')
+  })
+
+  it('uses normal Backspace behavior after more text is typed', async () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>')))
+    fixture.view.focus()
+
+    await userEvent.keyboard('<- x{Backspace}')
+    expect(fixture.doc.textContent).toBe('← ')
+  })
+
+  it.each([
+    { trigger: 'Space', keys: '<- ', expected: '<- ' },
+    { trigger: 'Enter', keys: '<-{Enter}', expected: '<-\n' },
+  ])('does not replace `<-` before $trigger inside a code block', async ({ keys, expected }) => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.codeBlock({ language: '' }, '<a>')))
+    fixture.view.focus()
+
+    await userEvent.keyboard(keys)
+    expect(fixture.doc.textContent).toBe(expected)
+  })
+
+  it.each([
+    { trigger: 'Space', keys: ' ' },
+    { trigger: 'Enter', keys: '{Enter}' },
+  ])('does not replace `<-` before $trigger inside inline code', async ({ keys }) => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('`<-<a>`')))
+    fixture.view.focus()
+
+    await userEvent.keyboard(keys)
+    expect(fixture.doc.textContent).toContain('<-')
+    expect(fixture.doc.textContent).not.toContain('←')
+  })
+
+  it("does not enable the legacy extension's other typography replacements", async () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>')))
+    fixture.view.focus()
+
+    await userEvent.keyboard('-> -- (c) ')
+    expect(fixture.doc.textContent).toBe('-> -- (c) ')
+  })
+})

--- a/packages/core/src/extensions/typography.ts
+++ b/packages/core/src/extensions/typography.ts
@@ -1,0 +1,102 @@
+import {
+  defineKeymap,
+  definePlugin,
+  Priority,
+  union,
+  withPriority,
+  type PlainExtension,
+} from '@prosekit/core'
+import { defineEnterRule } from '@prosekit/extensions/enter-rule'
+import { defineInputRule } from '@prosekit/extensions/input-rule'
+import { InputRule } from '@prosekit/pm/inputrules'
+import { Plugin, PluginKey, type EditorState, type Transaction } from '@prosekit/pm/state'
+
+const LEFT_ARROW_INPUT_PATTERN = /(<-)\s$/
+
+interface LeftArrowUndoState {
+  from: number
+  to: number
+}
+
+const leftArrowUndoKey = new PluginKey<LeftArrowUndoState | null>('meowdown-left-arrow-undo')
+
+function isInlineCode(state: EditorState, from: number, to: number): boolean {
+  const type = state.schema.marks.mdCode
+  return !!type && state.doc.rangeHasMark(from, to, type)
+}
+
+function replaceLeftArrow(
+  state: EditorState,
+  from: number,
+  to: number,
+  trailingSpace: boolean,
+): Transaction | null {
+  if (isInlineCode(state, from, to)) return null
+  const text = trailingSpace ? '← ' : '←'
+  const tr = state.tr.replaceWith(from, to, state.schema.text(text))
+  if (trailingSpace) {
+    tr.setMeta(leftArrowUndoKey, { from, to: from + text.length } satisfies LeftArrowUndoState)
+  }
+  return tr
+}
+
+function defineLeftArrowInputRule(): PlainExtension {
+  return defineInputRule(
+    new InputRule(LEFT_ARROW_INPUT_PATTERN, (state, _match, start, end) => {
+      return replaceLeftArrow(state, start, end, true)
+    }),
+  )
+}
+
+function defineLeftArrowUndo(): PlainExtension {
+  return union(
+    definePlugin(
+      new Plugin<LeftArrowUndoState | null>({
+        key: leftArrowUndoKey,
+        state: {
+          init: () => null,
+          apply: (tr, previous) => {
+            const meta = tr.getMeta(leftArrowUndoKey) as LeftArrowUndoState | null | undefined
+            if (meta !== undefined) return meta
+            if (!previous) return null
+
+            const from = tr.mapping.map(previous.from)
+            const to = tr.mapping.map(previous.to)
+            const stillImmediatelyAfterArrow =
+              tr.selection.empty &&
+              tr.selection.from === to &&
+              tr.doc.textBetween(from, to) === '← '
+            return stillImmediatelyAfterArrow ? { from, to } : null
+          },
+        },
+      }),
+    ),
+    withPriority(
+      defineKeymap({
+        Backspace: (state, dispatch) => {
+          const undo = leftArrowUndoKey.getState(state)
+          if (!undo) return false
+          dispatch?.(
+            state.tr
+              .replaceWith(undo.from, undo.to, state.schema.text('<- '))
+              .setMeta(leftArrowUndoKey, null),
+          )
+          return true
+        },
+      }),
+      Priority.highest,
+    ),
+  )
+}
+
+function defineLeftArrowEnterRule(): PlainExtension {
+  return defineEnterRule({
+    regex: /<-$/,
+    handler: ({ state, from, to }) => replaceLeftArrow(state, from, to, false),
+  })
+}
+
+/** Apply the editor's automatic plain-text typography replacements. */
+export function defineTypography(): PlainExtension {
+  return union(defineLeftArrowInputRule(), defineLeftArrowUndo(), defineLeftArrowEnterRule())
+}

--- a/packages/core/src/extensions/typography.ts
+++ b/packages/core/src/extensions/typography.ts
@@ -11,62 +11,96 @@ import { defineInputRule } from '@prosekit/extensions/input-rule'
 import { InputRule } from '@prosekit/pm/inputrules'
 import { Plugin, PluginKey, type EditorState, type Transaction } from '@prosekit/pm/state'
 
-const LEFT_ARROW_INPUT_PATTERN = /(<-)\s$/
-
-interface LeftArrowUndoState {
-  from: number
-  to: number
+interface TypographyReplacement {
+  input: string
+  replacement: string
 }
 
-const leftArrowUndoKey = new PluginKey<LeftArrowUndoState | null>('meowdown-left-arrow-undo')
+const TYPOGRAPHY_REPLACEMENTS: TypographyReplacement[] = [
+  { input: '<-', replacement: '←' },
+  { input: '->', replacement: '→' },
+  { input: '(c)', replacement: '©' },
+  { input: '(r)', replacement: '®' },
+  { input: '1/2', replacement: '½' },
+  // Reflect included an inner `$` here, making its whitespace-wrapped rule impossible to match.
+  { input: '+/-', replacement: '±' },
+  { input: '!=', replacement: '≠' },
+  { input: '<<', replacement: '«' },
+  { input: '>>', replacement: '»' },
+  { input: '--', replacement: '—' },
+]
+
+function escapeRegexp(input: string): string {
+  return input.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
+}
+
+interface TypographyUndoState {
+  from: number
+  to: number
+  before: string
+  after: string
+}
+
+const typographyUndoKey = new PluginKey<TypographyUndoState | null>('meowdown-typography-undo')
 
 function isInlineCode(state: EditorState, from: number, to: number): boolean {
   const type = state.schema.marks.mdCode
   return !!type && state.doc.rangeHasMark(from, to, type)
 }
 
-function replaceLeftArrow(
+function replaceTypography(
   state: EditorState,
   from: number,
   to: number,
-  trailingSpace: boolean,
+  replacement: string,
+  undoText?: string,
 ): Transaction | null {
   if (isInlineCode(state, from, to)) return null
-  const text = trailingSpace ? '← ' : '←'
+  const text = undoText == null ? replacement : `${replacement} `
   const tr = state.tr.replaceWith(from, to, state.schema.text(text))
-  if (trailingSpace) {
-    tr.setMeta(leftArrowUndoKey, { from, to: from + text.length } satisfies LeftArrowUndoState)
+  if (undoText != null) {
+    tr.setMeta(typographyUndoKey, {
+      from,
+      to: from + text.length,
+      before: undoText,
+      after: text,
+    } satisfies TypographyUndoState)
   }
   return tr
 }
 
-function defineLeftArrowInputRule(): PlainExtension {
-  return defineInputRule(
-    new InputRule(LEFT_ARROW_INPUT_PATTERN, (state, _match, start, end) => {
-      return replaceLeftArrow(state, start, end, true)
+function defineTypographyInputRules(): PlainExtension {
+  return union(
+    TYPOGRAPHY_REPLACEMENTS.map(({ input, replacement }) => {
+      const inputRegexp = new RegExp(String.raw`(${escapeRegexp(input)})\s$`)
+      return defineInputRule(
+        new InputRule(inputRegexp, (state, match, start, end) => {
+          return replaceTypography(state, start, end, replacement, match[0])
+        }),
+      )
     }),
   )
 }
 
-function defineLeftArrowUndo(): PlainExtension {
+function defineTypographyUndo(): PlainExtension {
   return union(
     definePlugin(
-      new Plugin<LeftArrowUndoState | null>({
-        key: leftArrowUndoKey,
+      new Plugin<TypographyUndoState | null>({
+        key: typographyUndoKey,
         state: {
           init: () => null,
           apply: (tr, previous) => {
-            const meta = tr.getMeta(leftArrowUndoKey) as LeftArrowUndoState | null | undefined
+            const meta = tr.getMeta(typographyUndoKey) as TypographyUndoState | null | undefined
             if (meta !== undefined) return meta
             if (!previous) return null
 
             const from = tr.mapping.map(previous.from)
             const to = tr.mapping.map(previous.to)
-            const stillImmediatelyAfterArrow =
+            const stillImmediatelyAfterReplacement =
               tr.selection.empty &&
               tr.selection.from === to &&
-              tr.doc.textBetween(from, to) === '← '
-            return stillImmediatelyAfterArrow ? { from, to } : null
+              tr.doc.textBetween(from, to) === previous.after
+            return stillImmediatelyAfterReplacement ? { ...previous, from, to } : null
           },
         },
       }),
@@ -74,12 +108,12 @@ function defineLeftArrowUndo(): PlainExtension {
     withPriority(
       defineKeymap({
         Backspace: (state, dispatch) => {
-          const undo = leftArrowUndoKey.getState(state)
+          const undo = typographyUndoKey.getState(state)
           if (!undo) return false
           dispatch?.(
             state.tr
-              .replaceWith(undo.from, undo.to, state.schema.text('<- '))
-              .setMeta(leftArrowUndoKey, null),
+              .replaceWith(undo.from, undo.to, state.schema.text(undo.before))
+              .setMeta(typographyUndoKey, null),
           )
           return true
         },
@@ -89,14 +123,18 @@ function defineLeftArrowUndo(): PlainExtension {
   )
 }
 
-function defineLeftArrowEnterRule(): PlainExtension {
-  return defineEnterRule({
-    regex: /<-$/,
-    handler: ({ state, from, to }) => replaceLeftArrow(state, from, to, false),
-  })
+function defineTypographyEnterRules(): PlainExtension {
+  return union(
+    TYPOGRAPHY_REPLACEMENTS.map(({ input, replacement }) => {
+      return defineEnterRule({
+        regex: new RegExp(`${escapeRegexp(input)}$`),
+        handler: ({ state, from, to }) => replaceTypography(state, from, to, replacement),
+      })
+    }),
+  )
 }
 
 /** Apply the editor's automatic plain-text typography replacements. */
 export function defineTypography(): PlainExtension {
-  return union(defineLeftArrowInputRule(), defineLeftArrowUndo(), defineLeftArrowEnterRule())
+  return union(defineTypographyInputRules(), defineTypographyUndo(), defineTypographyEnterRules())
 }

--- a/packages/core/src/extensions/typography.ts
+++ b/packages/core/src/extensions/typography.ts
@@ -12,27 +12,35 @@ import { InputRule } from '@prosekit/pm/inputrules'
 import { Plugin, PluginKey, type EditorState, type Transaction } from '@prosekit/pm/state'
 
 interface TypographyReplacement {
-  input: string
+  regexp: RegExp
   replacement: string
+  shouldSkip?: (textBefore: string) => boolean
 }
 
 const TYPOGRAPHY_REPLACEMENTS: TypographyReplacement[] = [
-  { input: '<-', replacement: '←' },
-  { input: '->', replacement: '→' },
-  { input: '(c)', replacement: '©' },
-  { input: '(r)', replacement: '®' },
-  { input: '1/2', replacement: '½' },
+  { regexp: /<-/, replacement: '←' },
+  {
+    regexp: /->/,
+    replacement: '→',
+    // `-->` is Markdown's HTML comment closing delimiter.
+    shouldSkip: (textBefore) => textBefore.endsWith('-->'),
+  },
+  { regexp: /\(c\)/, replacement: '©' },
+  { regexp: /\(r\)/, replacement: '®' },
+  { regexp: /1\/2/, replacement: '½' },
   // Reflect included an inner `$` here, making its whitespace-wrapped rule impossible to match.
-  { input: '+/-', replacement: '±' },
-  { input: '!=', replacement: '≠' },
-  { input: '<<', replacement: '«' },
-  { input: '>>', replacement: '»' },
-  { input: '--', replacement: '—' },
+  { regexp: /\+\/-/, replacement: '±' },
+  { regexp: /!=/, replacement: '≠' },
+  { regexp: /<</, replacement: '«' },
+  { regexp: />>/, replacement: '»' },
+  {
+    regexp: /--/,
+    replacement: '—',
+    // Keep HTML comment openers and thematic-break markers literal.
+    shouldSkip: (textBefore) =>
+      textBefore.endsWith('<!--') || /^ {0,3}(?:-[ \t]*){3,}$/.test(textBefore),
+  },
 ]
-
-function escapeRegexp(input: string): string {
-  return input.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
-}
 
 interface TypographyUndoState {
   from: number
@@ -48,14 +56,22 @@ function isInlineCode(state: EditorState, from: number, to: number): boolean {
   return !!type && state.doc.rangeHasMark(from, to, type)
 }
 
+function getTextBefore(state: EditorState, position: number): string {
+  const $position = state.doc.resolve(position)
+  return $position.parent.textBetween(0, $position.parentOffset, null, '\u{FFFC}')
+}
+
 function replaceTypography(
   state: EditorState,
   from: number,
   to: number,
-  replacement: string,
+  rule: TypographyReplacement,
   undoText?: string,
 ): Transaction | null {
   if (isInlineCode(state, from, to)) return null
+  if (rule.shouldSkip?.(getTextBefore(state, to))) return null
+
+  const { replacement } = rule
   const text = undoText == null ? replacement : `${replacement} `
   const tr = state.tr.replaceWith(from, to, state.schema.text(text))
   if (undoText != null) {
@@ -71,11 +87,11 @@ function replaceTypography(
 
 function defineTypographyInputRules(): PlainExtension {
   return union(
-    TYPOGRAPHY_REPLACEMENTS.map(({ input, replacement }) => {
-      const inputRegexp = new RegExp(String.raw`(${escapeRegexp(input)})\s$`)
+    TYPOGRAPHY_REPLACEMENTS.map((rule) => {
+      const inputRegexp = new RegExp(String.raw`(?:${rule.regexp.source})\s$`)
       return defineInputRule(
         new InputRule(inputRegexp, (state, match, start, end) => {
-          return replaceTypography(state, start, end, replacement, match[0])
+          return replaceTypography(state, start, end, rule, match[0])
         }),
       )
     }),
@@ -125,10 +141,10 @@ function defineTypographyUndo(): PlainExtension {
 
 function defineTypographyEnterRules(): PlainExtension {
   return union(
-    TYPOGRAPHY_REPLACEMENTS.map(({ input, replacement }) => {
+    TYPOGRAPHY_REPLACEMENTS.map((rule) => {
       return defineEnterRule({
-        regex: new RegExp(`${escapeRegexp(input)}$`),
-        handler: ({ state, from, to }) => replaceTypography(state, from, to, replacement),
+        regex: new RegExp(`(?:${rule.regexp.source})$`),
+        handler: ({ state, from, to }) => replaceTypography(state, from, to, rule),
       })
     }),
   )


### PR DESCRIPTION
## Problem

Reflect supported a compact typography table that converted ten typed ASCII sequences into their Unicode equivalents after Space or before Enter. Meowdown did not carry that feature forward, so every sequence stayed literal.

This PR restores the complete surviving Reflect table, not just the left-arrow example.

## Before -> After

| Typed sequence | Inserted glyph |
| --- | --- |
| `<-` | `←` |
| `->` | `→` |
| `(c)` | `©` |
| `(r)` | `®` |
| `1/2` | `½` |
| `+/-` | `±` |
| `!=` | `≠` |
| `<<` | `«` |
| `>>` | `»` |
| `--` | `—` |

The source remains literal until Space or plain Enter commits it. Inline code and code blocks remain literal. Markdown HTML-comment delimiters and valid dash thematic-break markers are also preserved. Immediate Backspace after a Space-triggered replacement restores the original sequence and space.

## Changes

1. Add a Reflect-style `RegExp` typography table and derive both ProseMirror input rules and ProseKit enter rules from it.
2. Generalize typography-only undo state so Backspace restores the latest source sequence without changing list, heading, fence, or other editor input-rule behavior.
3. Apply the shared inline-code exclusion to Space and Enter while retaining the standard code-block guards.
4. Repair the intended Reflect `+/- → ±` mapping. The legacy regex embedded an end anchor before its required whitespace, making that one table entry impossible to trigger.
5. Preserve `<!--` / `-->` HTML-comment delimiters and dash-only Markdown thematic-break markers instead of applying typography inside them.
6. Cover the full mapping table plus delimiter timing, paragraph splitting, undo lifetime, code exclusions, suffix conflicts, and Markdown syntax interactions.

## Tests

`typography.test.ts` contains 43 browser cases:

- all ten mappings after Space;
- all ten mappings before Enter;
- immediate Backspace restoration for all ten mappings;
- undo expiry and latest-only undo;
- inline-code and code-block exclusions for both triggers;
- HTML-comment and thematic-break preservation before Space and Enter;
- the live `---` horizontal-rule input rule;
- suffix ordering such as `->>` and a nonempty `x---` run.

## Verification

- `pnpm test --run` — 86 files passed; 1,679 tests passed and 13 expected failures remained expected.
- `pnpm vitest packages/core/src/extensions/typography.test.ts --run` — 43 passed in Chromium.
- `pnpm lint` — passed.
- `pnpm typecheck` — passed.
- GitHub CI build and snapshot checks — passed for the latest commit.

## Risk / Rollout

This is a default typing-behavior change with no schema, converter, data, or public API changes. Replacements occur only when typed text ends in one of the listed sequences and is committed with Space or plain Enter. Code and Markdown syntax contexts are excluded, and immediate Backspace provides a literal-text escape hatch.
