### PR TITLE
fix(react): reconcile pending input before serialization

### DIFF
--- a/packages/react/src/components/pending-input-evidence.test.ts
+++ b/packages/react/src/components/pending-input-evidence.test.ts
@@ -1,0 +1,163 @@
+import { Schema } from '@prosekit/pm/model'
+import { EditorState } from '@prosekit/pm/state'
+import { EditorView } from '@prosekit/pm/view'
+import { afterEach, describe, expect, it } from 'vitest'
+
+/**
+ * Engine-level evidence for the pending-input reconciliation in
+ * `EditorHandle.getMarkdown()` — nothing here is synthetic: no
+ * `CompositionEvent` constructors, no manual `textContent` writes. The DOM
+ * mutation is performed by the browser's own editing pipeline via
+ * `document.execCommand('insertText')`, which is as close to native input as
+ * an automated browser test can get (real IME / emoji-palette composition
+ * cannot be driven by automation; `composeAndBlurTitle` in
+ * `prosekit-editor.test.tsx` still covers the composition-event paths).
+ *
+ * Three facts, layer by layer:
+ *
+ * 1. Plain `contenteditable`, no ProseMirror: an engine-performed mutation is
+ *    delivered to a `MutationObserver` only after the current task, so any
+ *    consumer that reads observer-derived state during the blur turn sees a
+ *    stale document — while `takeRecords()` (a synchronous drain) already
+ *    sees the mutation.
+ * 2. Bare ProseMirror (`@prosekit/pm`, no ProseKit, no Meowdown): the same
+ *    mutation is therefore missing from `view.state` during the blur turn,
+ *    and `DOMObserver.stop()` (ProseMirror's blur handler) parks it behind a
+ *    20ms timer, so the state converges only a turn later.
+ * 3. Draining the observer (`forceFlush()` + `flush()`) — exactly what
+ *    `ProseKitEditor.getMarkdown()` now does — closes that gap synchronously.
+ *
+ * The suite runs on every CI engine; the `test-mac-webkit` lane is the
+ * real-Safari proof requested in review.
+ */
+
+const mounted: Array<() => void> = []
+
+afterEach(() => {
+  for (const dispose of mounted) dispose()
+  mounted.length = 0
+})
+
+function mountContentEditable(text: string): HTMLDivElement {
+  const host = document.createElement('div')
+  host.contentEditable = 'true'
+  host.textContent = text
+  document.body.appendChild(host)
+  mounted.push(() => host.remove())
+  return host
+}
+
+function placeCaretAtStart(host: HTMLElement): void {
+  const selection = window.getSelection()
+  if (!selection || !host.firstChild) throw new Error('expected a selection and a text node')
+  const range = document.createRange()
+  range.setStart(host.firstChild, 0)
+  range.collapse(true)
+  selection.removeAllRanges()
+  selection.addRange(range)
+}
+
+/** Insert through the engine's editing pipeline; fail loud if it refused. */
+function engineInsertText(text: string): void {
+  if (!document.execCommand('insertText', false, text)) {
+    throw new Error('the engine refused execCommand insertText')
+  }
+}
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'paragraph+' },
+    paragraph: {
+      content: 'text*',
+      toDOM: () => ['p', 0] as const,
+      parseDOM: [{ tag: 'p' }],
+    },
+    text: {},
+  },
+})
+
+function mountBareProseMirror(text: string): EditorView {
+  const place = document.createElement('div')
+  document.body.appendChild(place)
+  const doc = schema.node('doc', null, [schema.node('paragraph', null, [schema.text(text)])])
+  const view = new EditorView(place, { state: EditorState.create({ doc }) })
+  mounted.push(() => {
+    view.destroy()
+    place.remove()
+  })
+  return view
+}
+
+describe('engine-performed input around blur (no synthetic events)', () => {
+  it('a plain contenteditable mutation is invisible to a MutationObserver during the blur turn', () => {
+    const host = mountContentEditable('Business ideas')
+    let delivered = ''
+    const observer = new MutationObserver(() => {
+      delivered = host.textContent ?? ''
+    })
+    observer.observe(host, { childList: true, characterData: true, subtree: true })
+
+    host.focus()
+    placeCaretAtStart(host)
+    engineInsertText('🧠 ')
+
+    let deliveredAtBlur = 'blur listener never ran'
+    let queuedAtBlur = -1
+    host.addEventListener(
+      'blur',
+      () => {
+        deliveredAtBlur = delivered
+        queuedAtBlur = observer.takeRecords().length
+      },
+      { once: true },
+    )
+    host.blur()
+    observer.disconnect()
+
+    // The engine wrote the DOM…
+    expect(host.textContent).toBe('🧠 Business ideas')
+    // …but the observer callback had not run inside the blur turn — a host
+    // serializing observer-derived state there reads the pre-input document…
+    expect(deliveredAtBlur).toBe('')
+    // …while a synchronous drain (what the reconciliation does) already saw
+    // the queued mutation records in that same turn.
+    expect(queuedAtBlur).toBeGreaterThan(0)
+  })
+
+  it('bare ProseMirror state misses the mutation during the blur turn and converges a timer later', async () => {
+    const view = mountBareProseMirror('Business ideas')
+    view.focus()
+    engineInsertText('🧠 ')
+    view.dom.blur()
+
+    expect(view.dom.textContent).toBe('🧠 Business ideas')
+    // Stale in the blur turn: the record is parked behind DOMObserver.stop()'s
+    // 20ms timer, past any synchronous save.
+    expect(view.state.doc.textContent).toBe('Business ideas')
+
+    await new Promise((resolve) => setTimeout(resolve, 40))
+    expect(view.state.doc.textContent).toBe('🧠 Business ideas')
+  })
+
+  it('draining the observer closes the gap synchronously — the getMarkdown reconciliation', () => {
+    const view = mountBareProseMirror('Business ideas')
+    view.focus()
+    engineInsertText('🧠 ')
+    view.dom.blur()
+
+    expect(view.state.doc.textContent).toBe('Business ideas')
+
+    // The exact guarded reach-in ProseKitEditor.getMarkdown() ships.
+    const observer: unknown = Reflect.get(view, 'domObserver')
+    if (typeof observer !== 'object' || observer === null) {
+      throw new Error('expected ProseMirror to expose a domObserver')
+    }
+    const forceFlush: unknown = Reflect.get(observer, 'forceFlush')
+    const flush: unknown = Reflect.get(observer, 'flush')
+    if (typeof flush !== 'function') throw new Error('expected domObserver.flush')
+    if (typeof forceFlush === 'function') forceFlush.call(observer)
+    flush.call(observer)
+
+    expect(view.state.doc.textContent).toBe('🧠 Business ideas')
+  })
+})

--- a/packages/react/src/components/prosekit-editor.test.tsx
+++ b/packages/react/src/components/prosekit-editor.test.tsx
@@ -103,6 +103,18 @@ describe('ProseKitEditor', () => {
     expect(ref.current?.getMarkdown()).toBe('# 🧠 Business ideas\n')
   })
 
+  it('serializes from a captured handle after unmount', async () => {
+    const ref = createRef<EditorHandle>()
+    const screen = await render(<ProseKitEditor ref={ref} initialMarkdown="# Business ideas" />)
+    await expect.element(screen.getByText('Business ideas')).toBeInTheDocument()
+
+    const handle = ref.current
+    if (!handle) throw new Error('expected an editor handle')
+    await screen.unmount()
+
+    expect(handle.getMarkdown()).toBe('# Business ideas\n')
+  })
+
   it('round-trips a node selection through getState and setState', async () => {
     const ref = createRef<EditorHandle>()
     const screen = await render(<ProseKitEditor ref={ref} initialMarkdown="Hello" />)

--- a/packages/react/src/components/prosekit-editor.test.tsx
+++ b/packages/react/src/components/prosekit-editor.test.tsx
@@ -10,6 +10,19 @@ import type { EditorHandle } from './types.ts'
 
 const pmRoot = page.locate('.ProseMirror')
 
+function composeAndBlurTitle(title: string): void {
+  const root = pmRoot.element()
+  const heading = root.querySelector('h1')
+  if (!heading) throw new Error('expected a heading')
+
+  root.focus()
+  root.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }))
+  heading.textContent = title
+  root.dispatchEvent(new CompositionEvent('compositionupdate', { bubbles: true, data: title }))
+  root.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: title }))
+  root.blur()
+}
+
 describe('ProseKitEditor', () => {
   it('mounts a ProseMirror editor with the default content', async () => {
     const screen = await render(<ProseKitEditor initialMarkdown="Hello World!" />)
@@ -60,6 +73,34 @@ describe('ProseKitEditor', () => {
     const markdown = ref.current?.getMarkdown() ?? ''
     expect(markdown).toContain('abc')
     expect(markdown.startsWith('# ')).toBe(true)
+  })
+
+  it('serializes a leading emoji composition during the blur turn', async () => {
+    const ref = createRef<EditorHandle>()
+    let callbackMarkdown = ''
+    const onDocChange = vi.fn(() => {
+      callbackMarkdown = ref.current?.getMarkdown() ?? ''
+    })
+    const screen = await render(
+      <ProseKitEditor ref={ref} initialMarkdown="# Business ideas" onDocChange={onDocChange} />,
+    )
+    await expect.element(screen.getByText('Business ideas')).toBeInTheDocument()
+
+    composeAndBlurTitle('🧠 Business ideas')
+
+    expect(ref.current?.getMarkdown()).toBe('# 🧠 Business ideas\n')
+    expect(onDocChange).toHaveBeenCalledOnce()
+    expect(callbackMarkdown).toBe('# 🧠 Business ideas\n')
+  })
+
+  it('serializes composition whitespace after a leading emoji during the blur turn', async () => {
+    const ref = createRef<EditorHandle>()
+    const screen = await render(<ProseKitEditor ref={ref} initialMarkdown="# 🧠Business ideas" />)
+    await expect.element(screen.getByText('🧠Business ideas')).toBeInTheDocument()
+
+    composeAndBlurTitle('🧠 Business ideas')
+
+    expect(ref.current?.getMarkdown()).toBe('# 🧠 Business ideas\n')
   })
 
   it('round-trips a node selection through getState and setState', async () => {

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -80,7 +80,9 @@ function isFlushableDOMObserver(value: unknown): value is FlushableDOMObserver {
 // turn after blur. Its observer is intentionally not part of EditorView's
 // public type, so keep this guarded compatibility boundary inside Meowdown.
 function flushPendingDOMChanges(editor: TypedEditor): void {
-  if (editor.view.isDestroyed) return
+  // `editor.view` throws while unmounted, and `editor.state` deliberately
+  // survives unmount — keep serialization working there.
+  if (!editor.mounted) return
   const observer: unknown = Reflect.get(editor.view, 'domObserver')
   if (!isFlushableDOMObserver(observer)) return
 

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -62,6 +62,35 @@ import type {
 } from './types.ts'
 import { WikilinkMenu } from './wikilink-menu.tsx'
 
+interface FlushableDOMObserver {
+  forceFlush?(): void
+  flush(): void
+}
+
+function isFlushableDOMObserver(value: unknown): value is FlushableDOMObserver {
+  if (typeof value !== 'object' || value === null) return false
+  const forceFlush: unknown = Reflect.get(value, 'forceFlush')
+  return (
+    typeof Reflect.get(value, 'flush') === 'function' &&
+    (forceFlush === undefined || typeof forceFlush === 'function')
+  )
+}
+
+// ProseMirror can leave native contenteditable mutations queued for a timer
+// turn after blur. Its observer is intentionally not part of EditorView's
+// public type, so keep this guarded compatibility boundary inside Meowdown.
+function flushPendingDOMChanges(editor: TypedEditor): void {
+  if (editor.view.isDestroyed) return
+  const observer: unknown = Reflect.get(editor.view, 'domObserver')
+  if (!isFlushableDOMObserver(observer)) return
+
+  // `flushSoon()` blocks a plain `flush()` until its timer fires, whereas
+  // `stop()` queues blur records behind a separate timer. Both calls are
+  // needed to synchronously drain either path.
+  observer.forceFlush?.()
+  observer.flush()
+}
+
 // Selections coming through `setState` are hints: restore them exactly when
 // possible, otherwise clamp to the nearest valid text selection.
 function resolveSelection(doc: EditorNode, selection: SelectionHint): Selection {
@@ -252,6 +281,7 @@ export function ProseKitEditor({
 
   useImperativeHandle(ref, () => {
     function getMarkdown(): string {
+      flushPendingDOMChanges(editor)
       return docToMarkdown(editor.state.doc, { frontmatter })
     }
     function getSelection(): SelectionJSON {

--- a/packages/react/src/components/types.ts
+++ b/packages/react/src/components/types.ts
@@ -18,8 +18,10 @@ export type EditorStateSnapshot = [markdown: string, selection: SelectionJSON]
 
 export interface EditorHandle {
   /**
-   * Serializes the current document to Markdown. Can be expensive on large
-   * documents; call it on demand (e.g. throttled) instead of on every change.
+   * Reconciles pending native input, then serializes the current document to
+   * Markdown. If reconciliation changes the document, `onDocChange` runs
+   * before this method returns. Can be expensive on large documents; call it
+   * on demand (e.g. throttled) instead of on every change.
    */
   getMarkdown: () => string
 

--- a/packages/react/src/components/types.ts
+++ b/packages/react/src/components/types.ts
@@ -39,7 +39,10 @@ export interface EditorHandle {
    */
   insertMarkdown: (markdown: string) => void
 
-  /** Returns the current Markdown and selection. */
+  /**
+   * Returns the current Markdown and selection, with the same pending-input
+   * reconciliation (and possible synchronous `onDocChange`) as `getMarkdown`.
+   */
   getState: () => EditorStateSnapshot
 
   /**


### PR DESCRIPTION
## Problem

`EditorHandle.getMarkdown()` serializes ProseMirror state, but native `contenteditable` mutations can still be queued when a host saves during the blur turn. On WebKit this made the visible heading `🧠 Business ideas` serialize as either `# Business ideas` or `# 🧠Business ideas` until ProseMirror's deferred observer ran.

This surfaced in [team-reflect/reflect-open#696](https://github.com/team-reflect/reflect-open/pull/696): the stale Markdown title diverged across devices and an exact wiki-link lookup could create a duplicate note.

## Before -> After

| Scenario | Before | After |
| --- | --- | --- |
| Host calls `getMarkdown()` during the blur turn | Pending emoji/whitespace input may be absent from the snapshot | Pending native input is reconciled before serialization |
| Reconciliation updates the document | Deferred `onDocChange` after the stale snapshot | `onDocChange` may run synchronously before `getMarkdown()` returns, and re-entrant serialization is safe |

## Changes

- Strengthen the existing `EditorHandle.getMarkdown()` contract rather than adding a ProseMirror-specific public method.
- Keep the compatibility boundary private to `ProseKitEditor`: guarded `forceFlush()` drains `flushSoon()`, then `flush()` drains blur records queued by `stop()`.
- Document the synchronous `onDocChange` behavior for hosts that persist from the imperative handle.
- Add browser regressions for both the lost leading emoji and the lost space after an emoji.
- Guard reconciliation on `editor.mounted`: prosekit's `view` getter throws while unmounted, and `editor.state` deliberately survives unmount, so a captured handle can still serialize after unmount.

## Tests

The new tests are deterministically red without the reconciliation call:

- `# Business ideas` remains stale instead of becoming `# 🧠 Business ideas`.
- `# 🧠Business ideas` remains stale instead of becoming `# 🧠 Business ideas`.

They also cover calling `getMarkdown()` re-entrantly from the synchronous `onDocChange` callback.

A third regression pins `getMarkdown()` on a captured handle after unmount, which crashes if reconciliation touches `editor.view` while unmounted.

Engine-level evidence (`pending-input-evidence.test.ts`, added on review request) uses **no synthetic events**: `document.execCommand('insertText')` routes through the browser's own editing pipeline, and the suite shows — on real WebKit via the `test-mac-webkit` lane — that (1) a plain `contenteditable` mutation is undelivered to a `MutationObserver` during the blur turn while `takeRecords()` already sees it, (2) bare ProseMirror (no ProseKit) state is stale in the blur turn and converges only after `DOMObserver.stop()`'s 20ms timer, and (3) the `forceFlush()`+`flush()` drain closes the gap synchronously. Real IME/emoji-palette composition cannot be driven by automation, so the composition-event paths remain covered by the existing fixtures.

## Verification

- `MEOWDOWN_TEST_BROWSER=chromium pnpm test --run packages/react/src/components/prosekit-editor.test.tsx` — 12 passed
- `MEOWDOWN_TEST_BROWSER=webkit pnpm test --run packages/react/src/components/prosekit-editor.test.tsx` — 12 passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`

## Risk / Rollout

- No signature or package-data migration is required; this strengthens the documented meaning of the existing getter.
- When pending input exists, `getMarkdown()` can now synchronously dispatch the resulting document change and invoke `onDocChange`. The contract documents this and the re-entrant callback path is covered.
- ProseMirror does not expose this observer drain publicly, so the internal shape is guarded and isolated in Meowdown. The macOS WebKit CI lane pins the behavior when ProseMirror is upgraded.


