### PR TITLE
feat(core): add checkable list cycle command

### DIFF
--- a/packages/core/src/extensions/list.test.ts
+++ b/packages/core/src/extensions/list.test.ts
@@ -56,6 +56,70 @@ describe('commands', () => {
     fixture.editor.commands.wrapInSquareTask()
     expect(docToMarkdown(fixture.doc)).toBe('- [x] done\n')
   })
+
+  it('cycleCheckableList cycles plain content through square and circle tasks', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('todo<a>')))
+
+    fixture.editor.commands.cycleCheckableList()
+    expect(docToMarkdown(fixture.doc)).toBe('- [ ] todo\n')
+    fixture.editor.commands.cycleCheckableList()
+    expect(docToMarkdown(fixture.doc)).toBe('+ [ ] todo\n')
+    fixture.editor.commands.cycleCheckableList()
+    expect(docToMarkdown(fixture.doc)).toBe('- [ ] todo\n')
+  })
+
+  it('cycleCheckableList preserves checked state and task-marker casing', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(
+      n.doc(
+        n.list(
+          { kind: 'task', marker: '*', checked: true, taskMarker: 'X' },
+          n.paragraph('done<a>'),
+        ),
+      ),
+    )
+
+    fixture.editor.commands.cycleCheckableList()
+    expect(docToMarkdown(fixture.doc)).toBe('+ [X] done\n')
+    fixture.editor.commands.cycleCheckableList()
+    expect(docToMarkdown(fixture.doc)).toBe('- [X] done\n')
+  })
+
+  it('cycleCheckableList clears latent checked state from non-task lists', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.list({ kind: 'bullet', checked: true }, n.paragraph('todo<a>'))))
+
+    fixture.editor.commands.cycleCheckableList()
+    expect(fixture.doc.child(0).attrs).toMatchObject({
+      kind: 'task',
+      marker: null,
+      checked: false,
+    })
+    expect(docToMarkdown(fixture.doc)).toBe('- [ ] todo\n')
+  })
+
+  it('cycleCheckableList changes only the closest nested list', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(
+      n.doc(
+        n.list(
+          { kind: 'task', marker: '+', checked: false },
+          n.paragraph('outer'),
+          n.list({ kind: 'task', checked: false }, n.paragraph('inner<a>')),
+        ),
+      ),
+    )
+
+    fixture.editor.commands.cycleCheckableList()
+    expect(docToMarkdown(fixture.doc)).toBe('+ [ ] outer\n  + [ ] inner\n')
+    fixture.editor.commands.cycleCheckableList()
+    expect(docToMarkdown(fixture.doc)).toBe('+ [ ] outer\n  - [ ] inner\n')
+  })
 })
 
 describe('keymap', () => {

--- a/packages/core/src/extensions/list.ts
+++ b/packages/core/src/extensions/list.ts
@@ -287,13 +287,6 @@ function wrapInSquareTask(): Command {
   return wrapInList<MeowdownListAttrs>({ kind: 'task', marker: null })
 }
 
-function defineTaskCommands() {
-  return defineCommands({
-    wrapInCircleTask,
-    wrapInSquareTask,
-  })
-}
-
 /** The attributes of the closest list node enclosing the selection, if any. */
 function getListAttrsAtSelection(state: EditorState): MeowdownListAttrs | null {
   const { $from } = state.selection
@@ -304,6 +297,31 @@ function getListAttrsAtSelection(state: EditorState): MeowdownListAttrs | null {
     }
   }
   return null
+}
+
+/**
+ * Cycle the selected block between square and circle checkbox tasks. Non-task
+ * content becomes an unchecked square task; shape changes preserve checked state.
+ */
+function cycleCheckableList(): Command {
+  return (state, dispatch, view) => {
+    const attrs = getListAttrsAtSelection(state)
+    const command =
+      attrs?.kind !== 'task'
+        ? wrapInList<MeowdownListAttrs>({ kind: 'task', marker: null, checked: false })
+        : attrs.marker === '+'
+          ? wrapInSquareTask()
+          : wrapInCircleTask()
+    return command(state, dispatch, view)
+  }
+}
+
+function defineTaskCommands() {
+  return defineCommands({
+    cycleCheckableList,
+    wrapInCircleTask,
+    wrapInSquareTask,
+  })
 }
 
 /**

--- a/packages/core/src/extensions/table.test.ts
+++ b/packages/core/src/extensions/table.test.ts
@@ -104,6 +104,7 @@ describe('table cell is inline-only', () => {
     commands.wrapInList({ kind: 'ordered' })
     commands.wrapInCircleTask()
     commands.wrapInSquareTask()
+    commands.cycleCheckableList()
     commands.setBlockquote()
     commands.setHeading({ level: 1 })
     commands.setCodeBlock()


### PR DESCRIPTION
## Problem

Hosts that offer one control for square checklists and circle tasks currently have to inspect ProseMirror selection state and interpret Meowdown list markers themselves. [Reflect PR #730](https://github.com/team-reflect/reflect-open/pull/730) had to duplicate the closest-list traversal and the `+` marker contract to restore its mobile toolbar behavior.

Meowdown already owns those semantics and exposes the lower-level `wrapInSquareTask` and `wrapInCircleTask` commands, so the combined cycle belongs alongside them.

## Before -> After

| Selection | Before | `cycleCheckableList()` |
| --- | --- | --- |
| Plain, bullet, or ordered content | Host chooses and initializes a task shape | Unchecked square task |
| Square checkbox task | Host inspects `kind` and `marker` | Circle task, preserving completion state |
| Circle task | Host inspects `kind` and `marker` | Square task, preserving completion state |

## Changes

1. Add `editor.commands.cycleCheckableList()` to the core task-command extension, using Meowdown own closest-list lookup and marker model.
2. Explicitly clear latent `checked` state when non-task content first becomes a square task; shape-to-shape conversions preserve `checked` and task-marker casing.
3. Cover the full three-state cycle, checked `*`-marker conversion, latent checked-state reset, closest nested-list behavior, and table-cell no-op safety.

## Verification

- `MEOWDOWN_TEST_BROWSER=chromium pnpm test --run packages/core/src/extensions/list.test.ts packages/core/src/extensions/table.test.ts` — 37 passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed
- `pnpm build` — passed
- Full Chromium run: 1,659 passed and 13 expected failures; one unrelated `pending-input-evidence.test.ts` failure from the ProseMirror missing-CSS console warning. The same failure reproduces on a clean detached `origin/master` checkout.

## Risk / Rollout

Low risk and additive. Existing commands and keybindings are unchanged. Release Please can publish the new core command through the normal linked package release; consumers can remove their local marker inspection after upgrading.