### PR TITLE
fix(react): construct autocomplete trigger regexes with `new RegExp`

### DIFF
--- a/packages/react/src/components/slash-menu.tsx
+++ b/packages/react/src/components/slash-menu.tsx
@@ -23,7 +23,10 @@ import styles from './autocomplete-menu.module.css'
 import type { SlashMenuItem, SlashMenuSearchHandler } from './types.ts'
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
-const regex = canUseRegexLookbehind() ? /(?<!\S)\/(\S.*)?$/u : /\/(\S.*)?$/u
+const regex = new RegExp(
+  canUseRegexLookbehind() ? String.raw`(?<!\S)\/(\S.*)?$` : String.raw`\/(\S.*)?$`,
+  'u',
+)
 
 const defaultOnFileSaveError: FileSaveErrorHandler = (error) => {
   console.error('[meowdown] failed to save attached file:', error)

--- a/packages/react/src/components/slash-menu.tsx
+++ b/packages/react/src/components/slash-menu.tsx
@@ -24,7 +24,7 @@ import type { SlashMenuItem, SlashMenuSearchHandler } from './types.ts'
 
 // Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
 const regex = new RegExp(
-  canUseRegexLookbehind() ? String.raw`(?<!\S)\/(\S.*)?$` : String.raw`\/(\S.*)?$`,
+  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`\/(\S.*)?$`,
   'u',
 )
 

--- a/packages/react/src/components/tag-menu.tsx
+++ b/packages/react/src/components/tag-menu.tsx
@@ -17,7 +17,10 @@ import type { TagItem, TagSearchHandler } from './types.ts'
 
 // Match "#tag" with at least one character, so typing a heading ("# ") never
 // opens the menu. Do not match "abc#def".
-const regex = canUseRegexLookbehind() ? /(?<!\S)#[\da-z]+$/iu : /#[\da-z]+$/iu
+const regex = new RegExp(
+  canUseRegexLookbehind() ? String.raw`(?<!\S)#[\da-z]+$` : String.raw`#[\da-z]+$`,
+  'iu',
+)
 
 interface TagMenuProps {
   onTagSearch: TagSearchHandler

--- a/packages/react/src/components/tag-menu.tsx
+++ b/packages/react/src/components/tag-menu.tsx
@@ -18,7 +18,7 @@ import type { TagItem, TagSearchHandler } from './types.ts'
 // Match "#tag" with at least one character, so typing a heading ("# ") never
 // opens the menu. Do not match "abc#def".
 const regex = new RegExp(
-  canUseRegexLookbehind() ? String.raw`(?<!\S)#[\da-z]+$` : String.raw`#[\da-z]+$`,
+  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`#[\da-z]+$`,
   'iu',
 )
 

--- a/packages/react/src/components/wikilink-menu.tsx
+++ b/packages/react/src/components/wikilink-menu.tsx
@@ -24,9 +24,9 @@ import type { WikilinkItem, WikilinkSearchHandler } from './types.ts'
 //   menu. The lookbehind also keeps "@" inside a word (e.g. emails) from
 //   triggering; the fallback drops only that boundary guard.
 const regex = new RegExp(
-  canUseRegexLookbehind()
-    ? String.raw`(?:\[\[[^[\]]*|(?<!\S)@(?:[^[\]\s][^[\]]*)?)$`
-    : String.raw`(?:\[\[[^[\]]*|@(?:[^[\]\s][^[\]]*)?)$`,
+  String.raw`(?:\[\[[^[\]]*|` +
+    (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') +
+    String.raw`@(?:[^[\]\s][^[\]]*)?)$`,
   'u',
 )
 

--- a/packages/react/src/components/wikilink-menu.tsx
+++ b/packages/react/src/components/wikilink-menu.tsx
@@ -23,9 +23,12 @@ import type { WikilinkItem, WikilinkSearchHandler } from './types.ts'
 //   right after "@" cancels it, so prose like "meet @ 5pm" never opens the
 //   menu. The lookbehind also keeps "@" inside a word (e.g. emails) from
 //   triggering; the fallback drops only that boundary guard.
-const regex = canUseRegexLookbehind()
-  ? /(?:\[\[[^[\]]*|(?<!\S)@(?:[^[\]\s][^[\]]*)?)$/u
-  : /(?:\[\[[^[\]]*|@(?:[^[\]\s][^[\]]*)?)$/u
+const regex = new RegExp(
+  canUseRegexLookbehind()
+    ? String.raw`(?:\[\[[^[\]]*|(?<!\S)@(?:[^[\]\s][^[\]]*)?)$`
+    : String.raw`(?:\[\[[^[\]]*|@(?:[^[\]\s][^[\]]*)?)$`,
+  'u',
+)
 
 function queryFromRegexMatch(match: RegExpExecArray): string {
   return match[0].replace(/^(?:\[\[|@)/, '').trim()


### PR DESCRIPTION
Regex literals containing lookbehind syntax fail at module parse time on engines without lookbehind support, before `canUseRegexLookbehind()` can select the fallback, so the slash, tag, and wikilink menus now build the selected pattern with `new RegExp` from string sources, with no change to the matched expressions.