### PR TITLE
fix(react): preserve double-slash text in the slash menu

### DIFF
--- a/packages/react/src/components/slash-menu.test.tsx
+++ b/packages/react/src/components/slash-menu.test.tsx
@@ -49,6 +49,53 @@ describe('SlashMenu', () => {
     await expect.element(menu.getByText('Heading 1')).not.toBeVisible()
   })
 
+  it('inserts a table when Enter selects a normal single-slash command', async () => {
+    const ref = createRef<EditorHandle>()
+    await render(<ProseKitEditor ref={ref} />)
+    await pmRoot.click()
+    await userEvent.keyboard('/table')
+    await expect.element(menu.getByText('Table')).toBeVisible()
+    await userEvent.keyboard('{Enter}')
+
+    await expect.element(menu).not.toBeVisible()
+    await expect.element(page.locate('.ProseMirror table')).toBeInTheDocument()
+    expect(ref.current?.getMarkdown()).not.toContain('/table')
+  })
+
+  it('closes immediately on a double slash and preserves following text on Enter', async () => {
+    const ref = createRef<EditorHandle>()
+    await render(<ProseKitEditor ref={ref} />)
+    await pmRoot.click()
+    await userEvent.keyboard('Name /')
+    await expect.element(menu).toBeVisible()
+    await userEvent.keyboard('/')
+    await expect.element(menu).not.toBeVisible()
+    await userEvent.keyboard(' Table')
+    await expect.element(menu).not.toBeVisible()
+    await userEvent.keyboard('{Enter}')
+
+    await expect.element(page.locate('.ProseMirror table')).not.toBeInTheDocument()
+    expect(ref.current?.getMarkdown()).toBe('Name // Table\n')
+  })
+
+  it('does not select a matching host template from double-slash text', async () => {
+    const ref = createRef<EditorHandle>()
+    const onSelect = vi.fn()
+    const onSlashMenuSearch = (): SlashMenuItem[] => [{ label: 'Meeting note', onSelect }]
+    await render(<ProseKitEditor ref={ref} onSlashMenuSearch={onSlashMenuSearch} />)
+    await pmRoot.click()
+    await userEvent.keyboard('Name /')
+    await expect.element(menu).toBeVisible()
+    await userEvent.keyboard('/')
+    await expect.element(menu).not.toBeVisible()
+    await userEvent.keyboard(' Meeting note')
+    await expect.element(menu).not.toBeVisible()
+    await userEvent.keyboard('{Enter}')
+
+    expect(onSelect).not.toHaveBeenCalled()
+    expect(ref.current?.getMarkdown()).toBe('Name // Meeting note\n')
+  })
+
   it('applies the selected block type and removes the query text', async () => {
     const ref = createRef<EditorHandle>()
     await render(<ProseKitEditor ref={ref} />)

--- a/packages/react/src/components/slash-menu.tsx
+++ b/packages/react/src/components/slash-menu.tsx
@@ -22,9 +22,10 @@ import { formatNowTime, type TimeFormat } from '../utils/date-format.ts'
 import styles from './autocomplete-menu.module.css'
 import type { SlashMenuItem, SlashMenuSearchHandler } from './types.ts'
 
-// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading".
+// Match inputs like "/", "/table", "/heading 1" etc. Do not match "/ heading"
+// or "//", so double-slash text like "Name // Table" never runs a command.
 const regex = new RegExp(
-  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`\/(\S.*)?$`,
+  (canUseRegexLookbehind() ? String.raw`(?<!\S)` : '') + String.raw`\/(?!\/)(\S.*)?$`,
   'u',
 )
 


### PR DESCRIPTION
Typing a second slash now closes the slash menu immediately, so Enter preserves text like `Name // Table` instead of inserting a table or running a matching host item; the regression tests are copied from #276, which #284 and this PR together replace.