### PR TITLE
fix(core): strip formatting from selected wikilink queries

### DIFF
--- a/packages/core/src/extensions/mark-mode.ts
+++ b/packages/core/src/extensions/mark-mode.ts
@@ -1,8 +1,9 @@
 import { defineCommands, definePlugin, getMarkRange, getMarkType, union } from '@prosekit/core'
-import type { Slice } from '@prosekit/pm/model'
 import type { Command, EditorState } from '@prosekit/pm/state'
 import { Plugin, PluginKey } from '@prosekit/pm/state'
 import { Decoration, DecorationSet } from '@prosekit/pm/view'
+
+import { cleanTextFromSlice } from '../utils/clean-text.ts'
 
 import type { MarkName } from './mark-names.ts'
 
@@ -15,20 +16,6 @@ import type { MarkName } from './mark-names.ts'
  * - 'show':  syntax chars always visible (dim grey); copy keeps them.
  */
 export type MarkMode = 'hide' | 'focus' | 'show'
-
-// Marks whose text is dropped from a clean clipboard copy, so copied markdown
-// omits the rendered syntax. The image/wikilink sources carry only their own
-// mark, so they are kept verbatim (`![alt](url)`, `[[target]]`).
-const CLIPBOARD_STRIP_MARK_NAMES: ReadonlySet<MarkName> = new Set<MarkName>([
-  'mdMark',
-  'mdLinkUri',
-  'mdLinkTitle',
-])
-
-// Marks whose text survives a clean copy even when a strip mark also covers
-// it. A math dollar carries `mdMark` for hiding, but stripping it would paste
-// bare TeX; `$E=mc^2$` should copy whole, like an image source.
-const CLIPBOARD_KEEP_MARK_NAMES: ReadonlySet<MarkName> = new Set<MarkName>(['mdMath'])
 
 const markModeKey = new PluginKey<MarkMode>('mark-mode')
 
@@ -59,7 +46,9 @@ function createMarkModePlugin(initialMode: MarkMode): Plugin<MarkMode> {
       // the next serializer (`defineMarkdownCopy` in the full editor) and the
       // copied text keeps the syntax.
       clipboardTextSerializer: (slice, view) => {
-        return getCurrentMarkMode(view.state) === 'show' ? '' : cleanCopySerializer(slice)
+        return getCurrentMarkMode(view.state) === 'show'
+          ? ''
+          : cleanTextFromSlice(slice, { preserveMathSource: true })
       },
     },
   })
@@ -84,26 +73,6 @@ export function defineMarkMode(mode: MarkMode) {
  */
 export function getMarkMode(state: EditorState): MarkMode | undefined {
   return markModeKey.getState(state)
-}
-
-function cleanCopySerializer(slice: Slice): string {
-  const blocks: string[] = []
-  slice.content.forEach((blockNode) => {
-    const parts: string[] = []
-    blockNode.descendants((textNode) => {
-      if (!textNode.isText || !textNode.text) return true
-      const textNodeMarks = textNode.marks.map((mark) => mark.type.name as MarkName)
-      const stripped =
-        textNodeMarks.some((markName) => CLIPBOARD_STRIP_MARK_NAMES.has(markName)) &&
-        !textNodeMarks.some((markName) => CLIPBOARD_KEEP_MARK_NAMES.has(markName))
-      if (!stripped) parts.push(textNode.text)
-      return false
-    })
-    blocks.push(parts.join(''))
-  })
-  // Single '\n' between blocks (not '\n\n'): output mirrors "what the user
-  // sees on screen", not the markdown paragraph convention.
-  return blocks.join('\n')
 }
 
 /**

--- a/packages/core/src/extensions/wikilink-trigger.test.ts
+++ b/packages/core/src/extensions/wikilink-trigger.test.ts
@@ -107,6 +107,28 @@ describe('defineWikilinkTrigger', () => {
     expect(fixture.selectionSnapshot).toBe('Cat [[naps┃')
   })
 
+  it('uses visible text from a formatted selection as the query', async () => {
+    using fixture = setup()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>**Klara and the Sun**<b>')))
+    fixture.view.focus()
+
+    await pressModShiftK()
+
+    expect(fixture.selectionSnapshot).toBe('[[Klara and the Sun┃')
+  })
+
+  it('drops math delimiters from a formatted selection query', async () => {
+    using fixture = setup()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>$E=mc^2$<b>')))
+    fixture.view.focus()
+
+    await pressModShiftK()
+
+    expect(fixture.selectionSnapshot).toBe('[[E=mc^2┃')
+  })
+
   it('keeps autocomplete matched while ArrowRight includes existing text', async () => {
     using fixture = setup()
     const matches = trackWikilinkMatches(fixture)

--- a/packages/core/src/extensions/wikilink-trigger.ts
+++ b/packages/core/src/extensions/wikilink-trigger.ts
@@ -2,6 +2,8 @@ import { defineKeymap, isTextSelection, type PlainExtension } from '@prosekit/co
 import { triggerAutocomplete } from '@prosekit/extensions/autocomplete'
 import { TextSelection, type Command } from '@prosekit/pm/state'
 
+import { cleanTextFromSlice } from '../utils/clean-text.ts'
+
 const WIKILINK_OPEN = '[['
 
 interface OpenWikilinkMenuOptions {
@@ -13,10 +15,11 @@ interface OpenWikilinkMenuOptions {
 
 /**
  * Inserts the `[[` wikilink trigger at the cursor and opens the wikilink menu.
- * Any selected text becomes the initial query, so selecting "Cat naps" and
- * running this yields `[[Cat naps` with the menu searching it. A leading `[` in
- * the selection is dropped; a selection that already starts with `[[`, that
- * spans more than one block, or that sits in a code block is left untouched.
+ * Any selected visible text becomes the initial query, so selecting bold
+ * "Cat naps" and running this yields `[[Cat naps` without the hidden `**`
+ * markers. A leading `[` in the selection is dropped; a selection that already
+ * starts with `[[`, that spans more than one block, or that sits in a code block
+ * is left untouched.
  */
 function openWikilinkMenu({ allowEmpty }: OpenWikilinkMenuOptions): Command {
   return (state, dispatch) => {
@@ -35,7 +38,7 @@ function openWikilinkMenu({ allowEmpty }: OpenWikilinkMenuOptions): Command {
       return false
     }
 
-    let query = state.doc.textBetween(selection.from, selection.to)
+    let query = cleanTextFromSlice(selection.content())
     if (query.startsWith(WIKILINK_OPEN)) {
       return false
     }

--- a/packages/core/src/utils/clean-text.ts
+++ b/packages/core/src/utils/clean-text.ts
@@ -1,0 +1,37 @@
+import type { Slice } from '@prosekit/pm/model'
+
+import type { MarkName } from '../extensions/mark-names.ts'
+
+const CLEAN_TEXT_STRIP_MARK_NAMES: ReadonlySet<MarkName> = new Set<MarkName>([
+  'mdMark',
+  'mdLinkUri',
+  'mdLinkTitle',
+])
+
+interface CleanTextOptions {
+  /** Keep math delimiters so the projected text remains valid Markdown. */
+  preserveMathSource?: boolean
+}
+
+/**
+ * Projects a document slice to syntax-clean text, omitting inline markers and
+ * hidden link destinations. Set `preserveMathSource` when the result must keep
+ * complete `$...$` expressions rather than only their formula text.
+ */
+export function cleanTextFromSlice(slice: Slice, options: CleanTextOptions = {}): string {
+  const blocks: string[] = []
+  slice.content.forEach((blockNode) => {
+    const parts: string[] = []
+    blockNode.descendants((textNode) => {
+      if (!textNode.isText || !textNode.text) return true
+      const textNodeMarks = textNode.marks.map((mark) => mark.type.name as MarkName)
+      const stripped =
+        textNodeMarks.some((markName) => CLEAN_TEXT_STRIP_MARK_NAMES.has(markName)) &&
+        !(options.preserveMathSource && textNodeMarks.includes('mdMath'))
+      if (!stripped) parts.push(textNode.text)
+      return false
+    })
+    blocks.push(parts.join(''))
+  })
+  return blocks.join('\n')
+}

--- a/packages/react/src/components/wikilink-menu.test.tsx
+++ b/packages/react/src/components/wikilink-menu.test.tsx
@@ -404,6 +404,28 @@ describe('Mod-Shift-K shortcut', () => {
     await expect.element(menu.getByText('Reading list')).not.toBeInTheDocument()
   })
 
+  it('seeds the query from the visible text of a formatted selection', async () => {
+    const ref = createRef<EditorHandle>()
+    const onWikilinkSearch = vi.fn(searchNotes)
+    await render(
+      <ProseKitEditor
+        ref={ref}
+        initialMarkdown="**Cat naps**"
+        onWikilinkSearch={onWikilinkSearch}
+      />,
+    )
+    ref.current?.setSelection({ type: 'text', anchor: 1, head: 13 })
+    ref.current?.focus()
+
+    await pressInsertShortcut()
+
+    await vi.waitFor(() => {
+      expect(onWikilinkSearch).toHaveBeenLastCalledWith('Cat naps')
+    })
+    await menu.getByText('Cat naps').click()
+    expect(ref.current?.getMarkdown()).toBe('[[Cat naps]]\n')
+  })
+
   it('inserts the selected note as [[Name]] and removes the query', async () => {
     const ref = createRef<EditorHandle>()
     await render(<ProseKitEditor ref={ref} onWikilinkSearch={searchNotes} />)


### PR DESCRIPTION
## Problem

Wrapping a fully formatted selection as a wikilink used its Markdown source as the autocomplete query. For example, selecting bold `Klara and the Sun` searched for `**Klara and the Sun**`, so hosts could not resolve the existing `Klara and the Sun` target and instead offered to create a duplicate note.

Typed punctuation is valid in note titles, so this has to be fixed while the editor still has mark metadata rather than by stripping punctuation in the host search handler.

## Before -> After

| Selection | Before | After |
| --- | --- | --- |
| Bold `Klara and the Sun` | `[[**Klara and the Sun**` | `[[Klara and the Sun` |
| Math `$E=mc^2$` | `[[$E=mc^2$` | `[[E=mc^2` |

## Changes

1. Extract the syntax-clean slice projection used by hide/focus-mode clipboard serialization, with an explicit option for preserving complete math source when copying.
2. Seed the wikilink command from the clean selected text, removing hidden formatting markers and link destinations before autocomplete runs.
3. Cover the command behavior and the React menu flow, including resolving and inserting an existing note from a bold selection.

## Verification

- `pnpm test --run packages/core/src/extensions/wikilink-trigger.test.ts packages/core/src/extensions/mark-mode.test.ts packages/react/src/components/wikilink-menu.test.tsx` — 89 tests passed.
- `pnpm typecheck` — passed.
- `pnpm lint` — passed.
- `pnpm build` — passed.

## Risk / Rollout

The change is limited to programmatically seeding a wikilink from an existing selection. Normal typed queries keep their punctuation, and clipboard behavior remains unchanged, including preservation of complete math source.
