### PR TITLE
fix(core): keep the virtual caret one line tall beside a wrapped wikilink

### DIFF
--- a/packages/core/src/extensions/caret-rect.ts
+++ b/packages/core/src/extensions/caret-rect.ts
@@ -57,7 +57,9 @@ export function findCoordsCaretRect(view: EditorView): CaretRect | undefined {
 // An atom mark view collapses its source text to a zero-size box
 // (font-size: 0), so no position beside it has a box the other measurements
 // can see. The preview element standing in for the source is the visible
-// geometry; the caret sits flush against its outer edge.
+// geometry; the caret sits flush against its outer edge. A preview wrapped
+// across lines has one client rect per line fragment; the caret hugs the
+// fragment at its own end, never the multi-line union box.
 export function findAtomCaretRect(view: EditorView): CaretRect | undefined {
   const state = view.state
   const head = state.selection.head
@@ -66,10 +68,12 @@ export function findAtomCaretRect(view: EditorView): CaretRect | undefined {
     if (range == null || (range.from !== head && range.to !== head)) continue
     const preview = findAtomPreviewElement(view, range.from + 1)
     if (preview == null) continue
-    const rect = preview.getBoundingClientRect()
-    if (rect.height === 0) continue
-    const left = range.to === head ? rect.right : rect.left
-    return { left, top: rect.top, height: rect.height }
+    const fragments = Array.from(preview.getClientRects()).filter((rect) => rect.height > 0)
+    if (fragments.length === 0) continue
+    const atEnd = range.to === head
+    const fragment = atEnd ? fragments[fragments.length - 1] : fragments[0]
+    const left = atEnd ? fragment.right : fragment.left
+    return { left, top: fragment.top, height: fragment.height }
   }
   return undefined
 }

--- a/packages/core/src/extensions/virtual-caret.test.ts
+++ b/packages/core/src/extensions/virtual-caret.test.ts
@@ -211,6 +211,48 @@ describe('virtual caret next to atom marks', () => {
   })
 })
 
+describe('virtual caret at a line-wrapped wikilink', () => {
+  const wikilink = page.getByTestId('wikilink')
+  const longTarget = 'a very long note name that keeps going and going '.repeat(6).trim()
+
+  function getWikilinkFragments(): DOMRect[] {
+    return Array.from(wikilink.element().getClientRects())
+  }
+
+  it('keeps the caret one line tall at the start of a paragraph holding only a wrapped wikilink', async () => {
+    using fixture = setupMode('hide', `<a>[[${longTarget}]]`)
+    void fixture
+    await expect.element(caret).toBeVisible()
+    const fragments = getWikilinkFragments()
+    expect(fragments.length).toBeGreaterThanOrEqual(2)
+    const caretHeight = Number.parseFloat(getCaretElement().style.height)
+    expect(caretHeight).toBeLessThan(fragments[0].height * 1.5)
+  })
+
+  it('keeps the caret one line tall at the end of a paragraph holding only a wrapped wikilink', async () => {
+    using fixture = setupMode('hide', `[[${longTarget}]]<a>`)
+    void fixture
+    await expect.element(caret).toBeVisible()
+    const fragments = getWikilinkFragments()
+    expect(fragments.length).toBeGreaterThanOrEqual(2)
+    const lastFragment = fragments[fragments.length - 1]
+    const caretHeight = Number.parseFloat(getCaretElement().style.height)
+    expect(caretHeight).toBeLessThan(lastFragment.height * 1.5)
+  })
+
+  it('draws the end-of-paragraph caret on the last line fragment', async () => {
+    using fixture = setupMode('hide', `[[${longTarget}]]<a>`)
+    void fixture
+    await expect.element(caret).toBeVisible()
+    const fragments = getWikilinkFragments()
+    expect(fragments.length).toBeGreaterThanOrEqual(2)
+    const lastFragment = fragments[fragments.length - 1]
+    const caretRect = getCaretElement().getBoundingClientRect()
+    expect(Math.abs(caretRect.left - lastFragment.right)).toBeLessThanOrEqual(2)
+    expect(caretRect.top).toBeGreaterThanOrEqual(lastFragment.top - 2)
+  })
+})
+
 describe('virtual caret tails (hide mode)', () => {
   it('shows a right tail after a closing run', async () => {
     using fixture = setupMode('hide', 'foo **bold**<a> bar')


### PR DESCRIPTION
The caret beside an atom mark boundary measured the preview's bounding box, so a wikilink wrapped across lines drew a caret spanning every line, and the end-of-paragraph caret landed at the wrong x/y. Measure the preview's line fragment beside the caret instead.


Before 

<img width="1089" height="296" alt="image" src="https://github.com/user-attachments/assets/e7f49c02-b735-4009-8c0e-795582753df8" />

<img width="1021" height="288" alt="image" src="https://github.com/user-attachments/assets/941b7bd9-5820-4f27-b36b-e58ec30b9657" />

After 

<img width="1060" height="270" alt="image" src="https://github.com/user-attachments/assets/1d313202-56f0-45bb-8865-e1546c267f66" />


<img width="1013" height="258" alt="image" src="https://github.com/user-attachments/assets/517deea8-6fd0-499f-8bdd-a3b9da4130e6" />


