### PR TITLE
feat: resolve wikilink targets after selection

### DIFF
--- a/packages/core/src/extensions/extension.ts
+++ b/packages/core/src/extensions/extension.ts
@@ -38,6 +38,7 @@ import { defineScrollToSelection } from './scroll-to-selection.ts'
 import { defineSelectDocBoundary } from './select-doc-boundary.ts'
 import { defineTable } from './table.ts'
 import { defineVirtualCaret } from './virtual-caret.ts'
+import { defineWikilinkTargetResolution } from './wikilink-target-resolution.ts'
 import { defineWikilink } from './wikilink.ts'
 
 function defineEditorExtensionImpl(options: EditorExtensionOptions) {
@@ -86,6 +87,7 @@ function defineEditorExtensionImpl(options: EditorExtensionOptions) {
     defineModClickPrevention(),
     defineEditorCommands(),
     definePendingReplacement(),
+    defineWikilinkTargetResolution(),
   )
 }
 

--- a/packages/core/src/extensions/wikilink-target-resolution.ts
+++ b/packages/core/src/extensions/wikilink-target-resolution.ts
@@ -1,0 +1,169 @@
+import { defineCommands, definePlugin, union } from '@prosekit/core'
+import { Plugin, PluginKey, type Command, type Transaction } from '@prosekit/pm/state'
+
+interface PendingTargetResolution {
+  readonly id: string
+  readonly from: number
+  readonly to: number
+  readonly source: string
+  readonly dirty: boolean
+}
+
+interface TargetResolutionState {
+  readonly pending: ReadonlyMap<string, PendingTargetResolution>
+}
+
+type TargetResolutionMeta =
+  | { readonly type: 'track'; readonly pending: PendingTargetResolution }
+  | { readonly type: 'discard'; readonly id: string }
+
+const targetResolutionKey = new PluginKey<TargetResolutionState>('meowdownWikilinkTargetResolution')
+
+function applyMeta(
+  meta: TargetResolutionMeta,
+  value: TargetResolutionState,
+): TargetResolutionState {
+  const pending = new Map(value.pending)
+  switch (meta.type) {
+    case 'track':
+      pending.set(meta.pending.id, meta.pending)
+      break
+    case 'discard':
+      pending.delete(meta.id)
+      break
+  }
+  return { pending }
+}
+
+function mapPending(transaction: Transaction, value: TargetResolutionState): TargetResolutionState {
+  const pending = new Map<string, PendingTargetResolution>()
+  for (const resolution of value.pending.values()) {
+    const fromResult = transaction.mapping.mapResult(resolution.from, 1)
+    const toResult = transaction.mapping.mapResult(resolution.to, -1)
+    const from = Math.min(fromResult.pos, toResult.pos)
+    const to = Math.max(fromResult.pos, toResult.pos)
+    const sourceGone = (fromResult.deletedAfter && toResult.deletedBefore) || from >= to
+    if (sourceGone) continue
+    pending.set(resolution.id, {
+      ...resolution,
+      from,
+      to,
+      dirty: resolution.dirty || transaction.doc.textBetween(from, to) !== resolution.source,
+    })
+  }
+  return { pending }
+}
+
+const targetResolutionPlugin = new Plugin<TargetResolutionState>({
+  key: targetResolutionKey,
+  state: {
+    init: () => ({ pending: new Map() }),
+    apply: (transaction, value) => {
+      const meta = transaction.getMeta(targetResolutionKey) as TargetResolutionMeta | undefined
+      const nextValue = meta ? applyMeta(meta, value) : value
+      if (transaction.docChanged && nextValue.pending.size > 0) {
+        return mapPending(transaction, nextValue)
+      }
+      return nextValue
+    },
+  },
+})
+
+/** Identifies a provisional wikilink range to follow while its target resolves. */
+export interface TrackWikilinkTargetResolutionOptions {
+  /** Unique identifier shared with the settle or discard command. */
+  readonly id: string
+  /** Inclusive start of the inserted wikilink in the ProseMirror document. */
+  readonly from: number
+  /** Exclusive end of the inserted wikilink in the ProseMirror document. */
+  readonly to: number
+  /** Exact text expected inside the tracked range. */
+  readonly source: string
+}
+
+function trackWikilinkTargetResolution(options: TrackWikilinkTargetResolutionOptions): Command {
+  return (state, dispatch) => {
+    const { id, from, to, source } = options
+    if (
+      id === '' ||
+      from < 0 ||
+      from >= to ||
+      to > state.doc.content.size ||
+      state.doc.textBetween(from, to) !== source
+    ) {
+      return false
+    }
+    dispatch?.(
+      state.tr.setMeta(targetResolutionKey, {
+        type: 'track',
+        pending: { id, from, to, source, dirty: false },
+      } satisfies TargetResolutionMeta),
+    )
+    return true
+  }
+}
+
+/** Supplies the final result for a tracked provisional wikilink. */
+export interface SettleWikilinkTargetResolutionOptions {
+  /** Identifier passed when the provisional range was tracked. */
+  readonly id: string
+  /** Final wikilink target, or null to remove the provisional link. */
+  readonly target: string | null
+}
+
+function settleWikilinkTargetResolution(options: SettleWikilinkTargetResolutionOptions): Command {
+  return (state, dispatch) => {
+    const resolution = targetResolutionKey.getState(state)?.pending.get(options.id)
+    if (!resolution) return false
+    if (dispatch) {
+      const transaction = state.tr
+        .setMeta(targetResolutionKey, {
+          type: 'discard',
+          id: options.id,
+        } satisfies TargetResolutionMeta)
+        .setMeta('addToHistory', false)
+      const currentSource = state.doc.textBetween(resolution.from, resolution.to)
+      if (!resolution.dirty && currentSource === resolution.source) {
+        if (options.target === null) {
+          transaction.delete(resolution.from, resolution.to)
+        } else {
+          const source = `[[${options.target}]]`
+          if (source !== currentSource) {
+            transaction.insertText(source, resolution.from, resolution.to)
+          }
+        }
+      }
+      dispatch(transaction)
+    }
+    return true
+  }
+}
+
+function discardWikilinkTargetResolution(id: string): Command {
+  return (state, dispatch) => {
+    if (!targetResolutionKey.getState(state)?.pending.has(id)) return false
+    dispatch?.(
+      state.tr.setMeta(targetResolutionKey, {
+        type: 'discard',
+        id,
+      } satisfies TargetResolutionMeta),
+    )
+    return true
+  }
+}
+
+/**
+ * Tracks provisional wikilinks while a host resolves their final targets.
+ * Ranges map through unrelated edits; an edited or deleted provisional link
+ * is never overwritten when the asynchronous answer arrives.
+ */
+export function defineWikilinkTargetResolution() {
+  return union(
+    definePlugin(targetResolutionPlugin),
+    defineCommands({
+      trackWikilinkTargetResolution,
+      settleWikilinkTargetResolution,
+      discardWikilinkTargetResolution,
+    }),
+  )
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -145,6 +145,10 @@ export {
   type WikilinkHoverHandler,
   type WikilinkHoverHit,
 } from './extensions/wikilink-hover.ts'
+export type {
+  SettleWikilinkTargetResolutionOptions,
+  TrackWikilinkTargetResolutionOptions,
+} from './extensions/wikilink-target-resolution.ts'
 export { defineWikilinkTrigger } from './extensions/wikilink-trigger.ts'
 export type { PositionRange } from './utils/range.ts'
 export { getSelectedText } from './utils/selected-text.ts'

--- a/packages/react/src/components/types.ts
+++ b/packages/react/src/components/types.ts
@@ -167,6 +167,13 @@ export interface WikilinkItem {
   label?: string
   /** Secondary text shown beside the label. */
   detail?: string
+  /**
+   * Resolves the final target after the provisional link is inserted. A
+   * different target replaces only that mapped link; null removes it. If the
+   * resolver rejects or the user edits the provisional link first, its text
+   * is left unchanged.
+   */
+  resolveTarget?: (target: string) => string | null | Promise<string | null>
   /** Side effect run after the link is inserted (e.g. create the note). */
   onSelect?: () => void
 }

--- a/packages/react/src/components/wikilink-menu.test.tsx
+++ b/packages/react/src/components/wikilink-menu.test.tsx
@@ -200,6 +200,167 @@ describe('WikilinkMenu', () => {
     expect(onSelect).toHaveBeenCalled()
   })
 
+  it('maps an asynchronously resolved target through an edit before the link', async () => {
+    const ref = createRef<EditorHandle>()
+    let resolveTarget!: (target: string | null) => void
+    const richSearch = (): WikilinkItem[] => [
+      {
+        target: 'Jane Smith',
+        resolveTarget: () =>
+          new Promise((resolve) => {
+            resolveTarget = resolve
+          }),
+      },
+    ]
+    await render(<ProseKitEditor ref={ref} onWikilinkSearch={richSearch} />)
+    await pmRoot.click()
+    await userEvent.keyboard('Hello @jane')
+    await menu.getByText('Jane Smith').click()
+
+    expect(ref.current?.getMarkdown()).toContain('Hello [[Jane Smith]]')
+    ref.current?.setSelection('start')
+    ref.current?.insertMarkdown('!')
+    resolveTarget('Jane Doe')
+
+    await vi.waitFor(() => {
+      expect(ref.current?.getMarkdown()).toContain('!Hello [[Jane Doe]]')
+    })
+  })
+
+  it('maps other pending links when an earlier target settles first', async () => {
+    const ref = createRef<EditorHandle>()
+    const resolvers = new Map<string, (target: string | null) => void>()
+    const richSearch = (query: string): WikilinkItem[] => {
+      const target = query.toLowerCase().startsWith('jane') ? 'Jane Smith' : 'Ada Lovelace'
+      return [
+        {
+          target,
+          resolveTarget: () =>
+            new Promise((resolve) => {
+              resolvers.set(target, resolve)
+            }),
+        },
+      ]
+    }
+    await render(<ProseKitEditor ref={ref} onWikilinkSearch={richSearch} />)
+    await pmRoot.click()
+    await userEvent.keyboard('@jane')
+    await menu.getByText('Jane Smith').click()
+    await userEvent.keyboard(' and @ada')
+    await menu.getByText('Ada Lovelace').click()
+
+    resolvers.get('Jane Smith')?.('Jane Alexandra Doe')
+    await vi.waitFor(() => {
+      expect(ref.current?.getMarkdown()).toContain('[[Jane Alexandra Doe]] and [[Ada Lovelace]]')
+    })
+    resolvers.get('Ada Lovelace')?.('Ada Byron')
+
+    await vi.waitFor(() => {
+      expect(ref.current?.getMarkdown()).toContain('[[Jane Alexandra Doe]] and [[Ada Byron]]')
+    })
+  })
+
+  it('removes only the provisional link when target resolution returns null', async () => {
+    const ref = createRef<EditorHandle>()
+    let resolveTarget!: (target: string | null) => void
+    const richSearch = (): WikilinkItem[] => [
+      {
+        target: 'Jane Smith',
+        resolveTarget: () =>
+          new Promise((resolve) => {
+            resolveTarget = resolve
+          }),
+      },
+    ]
+    await render(<ProseKitEditor ref={ref} onWikilinkSearch={richSearch} />)
+    await pmRoot.click()
+    await userEvent.keyboard('Hello @jane')
+    await menu.getByText('Jane Smith').click()
+    ref.current?.insertMarkdown('!')
+
+    resolveTarget(null)
+
+    await vi.waitFor(() => {
+      expect(ref.current?.getMarkdown()).toContain('Hello !')
+      expect(ref.current?.getMarkdown()).not.toContain('Jane Smith')
+    })
+  })
+
+  it('does not overwrite the document after the provisional link is edited away', async () => {
+    const ref = createRef<EditorHandle>()
+    let resolveTarget!: (target: string | null) => void
+    const richSearch = (): WikilinkItem[] => [
+      {
+        target: 'Jane Smith',
+        resolveTarget: () =>
+          new Promise((resolve) => {
+            resolveTarget = resolve
+          }),
+      },
+    ]
+    await render(<ProseKitEditor ref={ref} onWikilinkSearch={richSearch} />)
+    await pmRoot.click()
+    await userEvent.keyboard('@jane')
+    await menu.getByText('Jane Smith').click()
+
+    ref.current?.setMarkdown('User edit')
+    resolveTarget('Jane Doe')
+    await new Promise<void>((resolve) => queueMicrotask(resolve))
+
+    expect(ref.current?.getMarkdown()).toBe('User edit\n')
+  })
+
+  it('keeps the provisional link when target resolution rejects', async () => {
+    const ref = createRef<EditorHandle>()
+    let rejectTarget!: (reason: Error) => void
+    const richSearch = (): WikilinkItem[] => [
+      {
+        target: 'Jane Smith',
+        resolveTarget: () =>
+          new Promise((_resolve, reject) => {
+            rejectTarget = reject
+          }),
+      },
+    ]
+    await render(<ProseKitEditor ref={ref} onWikilinkSearch={richSearch} />)
+    await pmRoot.click()
+    await userEvent.keyboard('@jane')
+    await menu.getByText('Jane Smith').click()
+
+    rejectTarget(new Error('lookup failed'))
+    await new Promise<void>((resolve) => queueMicrotask(resolve))
+
+    expect(ref.current?.getMarkdown()).toContain('[[Jane Smith]]')
+  })
+
+  it('keeps asynchronous target correction out of undo history', async () => {
+    const ref = createRef<EditorHandle>()
+    let resolveTarget!: (target: string | null) => void
+    const richSearch = (): WikilinkItem[] => [
+      {
+        target: 'Jane Smith',
+        resolveTarget: () =>
+          new Promise((resolve) => {
+            resolveTarget = resolve
+          }),
+      },
+    ]
+    await render(<ProseKitEditor ref={ref} onWikilinkSearch={richSearch} />)
+    await pmRoot.click()
+    await userEvent.keyboard('@jane')
+    await menu.getByText('Jane Smith').click()
+    await new Promise<void>((resolve) => setTimeout(resolve, 600))
+
+    resolveTarget('Jane Doe')
+    await vi.waitFor(() => {
+      expect(ref.current?.getMarkdown()).toContain('[[Jane Doe]]')
+    })
+    await userEvent.keyboard('{ControlOrMeta>}z{/ControlOrMeta}')
+
+    expect(ref.current?.getMarkdown()).not.toContain('Jane Doe')
+    expect(ref.current?.getMarkdown()).not.toContain('Jane Smith')
+  })
+
   it('keeps long rows within the menu width', async () => {
     const longTitle = 'A very long note title '.repeat(12)
     const richSearch = (): WikilinkItem[] => [

--- a/packages/react/src/components/wikilink-menu.tsx
+++ b/packages/react/src/components/wikilink-menu.tsx
@@ -1,4 +1,4 @@
-import type { EditorExtension } from '@meowdown/core'
+import type { EditorExtension, TypedEditor } from '@meowdown/core'
 import { canUseRegexLookbehind } from '@prosekit/core'
 import { useEditor } from '@prosekit/react'
 import {
@@ -36,6 +36,36 @@ function queryFromRegexMatch(match: RegExpExecArray): string {
 
 interface WikilinkMenuProps {
   onWikilinkSearch: WikilinkSearchHandler
+}
+
+let nextTargetResolutionId = 0
+
+function resolveItemTarget(
+  editor: TypedEditor,
+  item: WikilinkItem,
+  from: number,
+  to: number,
+): void {
+  if (!item.resolveTarget) return
+  const id = `wikilink-target-${++nextTargetResolutionId}`
+  const source = `[[${item.target}]]`
+  if (!editor.commands.trackWikilinkTargetResolution({ id, from, to, source })) return
+
+  let target: string | null | Promise<string | null>
+  try {
+    target = item.resolveTarget(item.target)
+  } catch {
+    editor.commands.discardWikilinkTargetResolution(id)
+    return
+  }
+  void Promise.resolve(target).then(
+    (resolvedTarget) => {
+      editor.commands.settleWikilinkTargetResolution({ id, target: resolvedTarget })
+    },
+    () => {
+      editor.commands.discardWikilinkTargetResolution(id)
+    },
+  )
 }
 
 // Deliberately not shared with TagMenu: the two menus are expected to
@@ -90,7 +120,9 @@ export function WikilinkMenu({ onWikilinkSearch }: WikilinkMenuProps) {
               key={item.target}
               className={styles.Item}
               onSelect={() => {
+                const from = editor.state.selection.from
                 editor.commands.insertText({ text: `[[${item.target}]]` })
+                resolveItemTarget(editor, item, from, editor.state.selection.from)
                 item.onSelect?.()
               }}
             >


### PR DESCRIPTION
## Summary

- add an optional async `WikilinkItem.resolveTarget` hook
- track the provisional wikilink range through intervening document edits
- replace or remove only an untouched provisional link when resolution settles
- keep target correction out of undo history and preserve the provisional link on resolver failure

## Why

Hosts can discover that autocomplete state is stale only at selection time. This lets them revalidate the final target without delaying insertion or rewriting unrelated editor content.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test --run packages/react/src/components/wikilink-menu.test.tsx` (40 tests)
- `pnpm build`