### PR TITLE
feat: add `/text` slash menu item

### DIFF
--- a/packages/core/src/extensions/commands.test.ts
+++ b/packages/core/src/extensions/commands.test.ts
@@ -105,30 +105,51 @@ describe('turnIntoText', () => {
     using fixture = setupFixture()
     const { editor, n } = fixture
     fixture.set(n.doc(n.heading({ level: 1 }, 'He<a>llo')))
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "# Hello
+      "
+    `)
 
     expect(editor.commands.turnIntoText()).toBe(true)
 
-    expect(docToMarkdown(fixture.doc)).toBe('Hello\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "Hello
+      "
+    `)
   })
 
   it('returns false on a plain top-level paragraph', () => {
     using fixture = setupFixture()
     const { editor, n } = fixture
     fixture.set(n.doc(n.paragraph('He<a>llo')))
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "Hello
+      "
+    `)
 
     expect(editor.commands.turnIntoText()).toBe(false)
 
-    expect(docToMarkdown(fixture.doc)).toBe('Hello\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "Hello
+      "
+    `)
   })
 
   it('unwraps a bullet list item', () => {
     using fixture = setupFixture()
     const { editor, n } = fixture
     fixture.set(n.doc(n.list({ kind: 'bullet' }, n.paragraph('a<a>'))))
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "- a
+      "
+    `)
 
     expect(editor.commands.turnIntoText()).toBe(true)
 
-    expect(docToMarkdown(fixture.doc)).toBe('a\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "a
+      "
+    `)
   })
 
   it('unwraps only the middle item of three', () => {
@@ -141,20 +162,40 @@ describe('turnIntoText', () => {
         n.list({ kind: 'bullet' }, n.paragraph('c')),
       ),
     )
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "- a
+      - b
+      - c
+      "
+    `)
 
     expect(editor.commands.turnIntoText()).toBe(true)
 
-    expect(docToMarkdown(fixture.doc)).toBe('- a\n\nb\n\n- c\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "- a
+
+      b
+
+      - c
+      "
+    `)
   })
 
   it('unwraps a checked task item, dropping the checkbox', () => {
     using fixture = setupFixture()
     const { editor, n } = fixture
     fixture.set(n.doc(n.list({ kind: 'task', checked: true }, n.paragraph('a<a>'))))
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "- [x] a
+      "
+    `)
 
     expect(editor.commands.turnIntoText()).toBe(true)
 
-    expect(docToMarkdown(fixture.doc)).toBe('a\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "a
+      "
+    `)
   })
 
   it('turns a nested item into a continuation paragraph of its parent', () => {
@@ -169,20 +210,37 @@ describe('turnIntoText', () => {
         ),
       ),
     )
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "- a
+        - b
+      "
+    `)
 
     expect(editor.commands.turnIntoText()).toBe(true)
 
-    expect(docToMarkdown(fixture.doc)).toBe('- a\n\n  b\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "- a
+
+        b
+      "
+    `)
   })
 
   it('lifts a paragraph out of a blockquote', () => {
     using fixture = setupFixture()
     const { editor, n } = fixture
     fixture.set(n.doc(n.blockquote(n.paragraph('q<a>uote'))))
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "> quote
+      "
+    `)
 
     expect(editor.commands.turnIntoText()).toBe(true)
 
-    expect(docToMarkdown(fixture.doc)).toBe('quote\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "quote
+      "
+    `)
   })
 
   it('splits the quote when lifting its middle paragraph', () => {
@@ -191,44 +249,86 @@ describe('turnIntoText', () => {
     fixture.set(
       n.doc(n.blockquote(n.paragraph('one'), n.paragraph('t<a>wo'), n.paragraph('three'))),
     )
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "> one
+      >
+      > two
+      >
+      > three
+      "
+    `)
 
     expect(editor.commands.turnIntoText()).toBe(true)
 
-    expect(docToMarkdown(fixture.doc)).toBe('> one\n\ntwo\n\n> three\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "> one
+
+      two
+
+      > three
+      "
+    `)
   })
 
   it('peels a heading inside a list item one layer per call', () => {
     using fixture = setupFixture()
     const { editor, n } = fixture
     fixture.set(n.doc(n.list({ kind: 'bullet' }, n.heading({ level: 1 }, 'foo<a>'))))
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "- # foo
+      "
+    `)
 
     expect(editor.commands.turnIntoText()).toBe(true)
-    expect(docToMarkdown(fixture.doc)).toBe('- foo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "- foo
+      "
+    `)
 
     expect(editor.commands.turnIntoText()).toBe(true)
-    expect(docToMarkdown(fixture.doc)).toBe('foo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "foo
+      "
+    `)
   })
 
   it('peels a list inside a blockquote one layer per call', () => {
     using fixture = setupFixture()
     const { editor, n } = fixture
     fixture.set(n.doc(n.blockquote(n.list({ kind: 'bullet' }, n.paragraph('a<a>')))))
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "> - a
+      "
+    `)
 
     expect(editor.commands.turnIntoText()).toBe(true)
-    expect(docToMarkdown(fixture.doc)).toBe('> a\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "> a
+      "
+    `)
 
     expect(editor.commands.turnIntoText()).toBe(true)
-    expect(docToMarkdown(fixture.doc)).toBe('a\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "a
+      "
+    `)
   })
 
   it('keeps the caret in the text', () => {
     using fixture = setupFixture()
     const { editor, n } = fixture
     fixture.set(n.doc(n.heading({ level: 1 }, 'He<a>llo')))
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "# Hello
+      "
+    `)
 
     editor.commands.turnIntoText()
     editor.commands.insertText({ text: 'X' })
 
-    expect(docToMarkdown(fixture.doc)).toBe('HeXllo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "HeXllo
+      "
+    `)
   })
 })

--- a/packages/core/src/extensions/commands.test.ts
+++ b/packages/core/src/extensions/commands.test.ts
@@ -8,53 +8,104 @@ describe('insertMarkdown', () => {
     using fixture = setupFixture()
     const { editor, n } = fixture
     fixture.set(n.doc(n.paragraph('Hello <a>world')))
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "Hello world
+      "
+    `)
 
     expect(editor.commands.insertMarkdown('brave **new** ')).toBe(true)
 
-    expect(docToMarkdown(fixture.doc)).toBe('Hello brave **new** world\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "Hello brave **new** world
+      "
+    `)
   })
 
   it('collapses an active selection instead of deleting it', () => {
     using fixture = setupFixture()
     const { editor, n } = fixture
     fixture.set(n.doc(n.paragraph('<a>Hello<b> world')))
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "Hello world
+      "
+    `)
 
     editor.commands.insertMarkdown('Goodbye ')
 
-    expect(docToMarkdown(fixture.doc)).toBe('Goodbye Hello world\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "Goodbye Hello world
+      "
+    `)
   })
 
   it('inserts a multi-block fragment as blocks with the cursor at its end', () => {
     using fixture = setupFixture()
     const { editor, n } = fixture
     fixture.set(n.doc(n.paragraph('Hello<a>'), n.paragraph('World')))
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "Hello
+
+      World
+      "
+    `)
 
     editor.commands.insertMarkdown('# Title\n\n- item')
     editor.commands.insertText({ text: '!' })
 
-    expect(docToMarkdown(fixture.doc)).toBe('Hello\n\n# Title\n\n- item!\n\nWorld\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "Hello
+
+      # Title
+
+      - item!
+
+      World
+      "
+    `)
   })
 
   it('undoes an inserted fragment as a single history entry', () => {
     using fixture = setupFixture()
     const { editor, n } = fixture
     fixture.set(n.doc(n.paragraph('Hello<a>')))
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "Hello
+      "
+    `)
 
     editor.commands.insertMarkdown('# Title\n\n- item')
-    editor.commands.undo()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "Hello
 
-    expect(docToMarkdown(fixture.doc)).toBe('Hello\n')
+      # Title
+
+      - item
+      "
+    `)
+
+    editor.commands.undo()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "Hello
+      "
+    `)
   })
 
   it('ignores an empty or whitespace-only fragment', () => {
     using fixture = setupFixture()
     const { editor, n } = fixture
     fixture.set(n.doc(n.paragraph('Hello<a>')))
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "Hello
+      "
+    `)
 
     expect(editor.commands.insertMarkdown('')).toBe(false)
     expect(editor.commands.insertMarkdown('  \n\t ')).toBe(false)
 
-    expect(docToMarkdown(fixture.doc)).toBe('Hello\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "Hello
+      "
+    `)
   })
 })
 
@@ -63,40 +114,72 @@ describe('insertTrigger', () => {
     using fixture = setupFixture()
     const { editor, n } = fixture
     fixture.set(n.doc(n.paragraph('Hello <a>')))
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "Hello
+      "
+    `)
 
     expect(editor.commands.insertTrigger('/')).toBe(true)
 
-    expect(docToMarkdown(fixture.doc)).toBe('Hello /\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "Hello /
+      "
+    `)
   })
 
   it('prefixes a space after a non-space character', () => {
     using fixture = setupFixture()
     const { editor, n } = fixture
     fixture.set(n.doc(n.paragraph('Hello<a>')))
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "Hello
+      "
+    `)
 
     editor.commands.insertTrigger('[[')
 
-    expect(docToMarkdown(fixture.doc)).toBe('Hello [[\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "Hello [[
+      "
+    `)
   })
 
   it('does nothing in a code block', () => {
     using fixture = setupFixture()
     const { editor, n } = fixture
     fixture.set(n.doc(n.codeBlock('const a<a>')))
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "\`\`\`
+      const a
+      \`\`\`
+      "
+    `)
 
     expect(editor.commands.insertTrigger('/')).toBe(false)
 
-    expect(docToMarkdown(fixture.doc)).toBe('```\nconst a\n```\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "\`\`\`
+      const a
+      \`\`\`
+      "
+    `)
   })
 
   it('ignores empty trigger text', () => {
     using fixture = setupFixture()
     const { editor, n } = fixture
     fixture.set(n.doc(n.paragraph('Hello<a>')))
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "Hello
+      "
+    `)
 
     expect(editor.commands.insertTrigger('')).toBe(false)
 
-    expect(docToMarkdown(fixture.doc)).toBe('Hello\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      "Hello
+      "
+    `)
   })
 })
 

--- a/packages/core/src/extensions/commands.test.ts
+++ b/packages/core/src/extensions/commands.test.ts
@@ -99,3 +99,136 @@ describe('insertTrigger', () => {
     expect(docToMarkdown(fixture.doc)).toBe('Hello\n')
   })
 })
+
+describe('turnIntoText', () => {
+  it('turns a heading into a paragraph', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(n.doc(n.heading({ level: 1 }, 'He<a>llo')))
+
+    expect(editor.commands.turnIntoText()).toBe(true)
+
+    expect(docToMarkdown(fixture.doc)).toBe('Hello\n')
+  })
+
+  it('returns false on a plain top-level paragraph', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(n.doc(n.paragraph('He<a>llo')))
+
+    expect(editor.commands.turnIntoText()).toBe(false)
+
+    expect(docToMarkdown(fixture.doc)).toBe('Hello\n')
+  })
+
+  it('unwraps a bullet list item', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(n.doc(n.list({ kind: 'bullet' }, n.paragraph('a<a>'))))
+
+    expect(editor.commands.turnIntoText()).toBe(true)
+
+    expect(docToMarkdown(fixture.doc)).toBe('a\n')
+  })
+
+  it('unwraps only the middle item of three', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(
+      n.doc(
+        n.list({ kind: 'bullet' }, n.paragraph('a')),
+        n.list({ kind: 'bullet' }, n.paragraph('b<a>')),
+        n.list({ kind: 'bullet' }, n.paragraph('c')),
+      ),
+    )
+
+    expect(editor.commands.turnIntoText()).toBe(true)
+
+    expect(docToMarkdown(fixture.doc)).toBe('- a\n\nb\n\n- c\n')
+  })
+
+  it('unwraps a checked task item, dropping the checkbox', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(n.doc(n.list({ kind: 'task', checked: true }, n.paragraph('a<a>'))))
+
+    expect(editor.commands.turnIntoText()).toBe(true)
+
+    expect(docToMarkdown(fixture.doc)).toBe('a\n')
+  })
+
+  it('turns a nested item into a continuation paragraph of its parent', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(
+      n.doc(
+        n.list(
+          { kind: 'bullet' },
+          n.paragraph('a'),
+          n.list({ kind: 'bullet' }, n.paragraph('b<a>')),
+        ),
+      ),
+    )
+
+    expect(editor.commands.turnIntoText()).toBe(true)
+
+    expect(docToMarkdown(fixture.doc)).toBe('- a\n\n  b\n')
+  })
+
+  it('lifts a paragraph out of a blockquote', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(n.doc(n.blockquote(n.paragraph('q<a>uote'))))
+
+    expect(editor.commands.turnIntoText()).toBe(true)
+
+    expect(docToMarkdown(fixture.doc)).toBe('quote\n')
+  })
+
+  it('splits the quote when lifting its middle paragraph', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(
+      n.doc(n.blockquote(n.paragraph('one'), n.paragraph('t<a>wo'), n.paragraph('three'))),
+    )
+
+    expect(editor.commands.turnIntoText()).toBe(true)
+
+    expect(docToMarkdown(fixture.doc)).toBe('> one\n\ntwo\n\n> three\n')
+  })
+
+  it('peels a heading inside a list item one layer per call', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(n.doc(n.list({ kind: 'bullet' }, n.heading({ level: 1 }, 'foo<a>'))))
+
+    expect(editor.commands.turnIntoText()).toBe(true)
+    expect(docToMarkdown(fixture.doc)).toBe('- foo\n')
+
+    expect(editor.commands.turnIntoText()).toBe(true)
+    expect(docToMarkdown(fixture.doc)).toBe('foo\n')
+  })
+
+  it('peels a list inside a blockquote one layer per call', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(n.doc(n.blockquote(n.list({ kind: 'bullet' }, n.paragraph('a<a>')))))
+
+    expect(editor.commands.turnIntoText()).toBe(true)
+    expect(docToMarkdown(fixture.doc)).toBe('> a\n')
+
+    expect(editor.commands.turnIntoText()).toBe(true)
+    expect(docToMarkdown(fixture.doc)).toBe('a\n')
+  })
+
+  it('keeps the caret in the text', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(n.doc(n.heading({ level: 1 }, 'He<a>llo')))
+
+    editor.commands.turnIntoText()
+    editor.commands.insertText({ text: 'X' })
+
+    expect(docToMarkdown(fixture.doc)).toBe('HeXllo\n')
+  })
+})

--- a/packages/core/src/extensions/commands.ts
+++ b/packages/core/src/extensions/commands.ts
@@ -1,5 +1,7 @@
-import { defineCommands, isTextSelection } from '@prosekit/core'
+import { defineCommands, isTextSelection, setBlockType } from '@prosekit/core'
 import { triggerAutocomplete } from '@prosekit/extensions/autocomplete'
+import { unwrapList } from '@prosekit/extensions/list'
+import { chainCommands, lift } from '@prosekit/pm/commands'
 import { Slice, type ResolvedPos } from '@prosekit/pm/model'
 import { TextSelection, type Command } from '@prosekit/pm/state'
 
@@ -81,6 +83,15 @@ function insertTrigger(text: string): Command {
   }
 }
 
+/**
+ * Turns the current block into plain text, peeling one layer per call: a
+ * non-paragraph textblock becomes a paragraph, then a paragraph in a list
+ * loses its marker, then a paragraph in a blockquote lifts out of it.
+ */
+function turnIntoText(): Command {
+  return chainCommands(setBlockType({ type: 'paragraph' satisfies NodeName }), unwrapList(), lift)
+}
+
 function scrollIntoView(): Command {
   return (state, dispatch) => {
     if (dispatch) {
@@ -97,5 +108,6 @@ export function defineEditorCommands() {
     scrollIntoView,
     selectText,
     selectTextBetween,
+    turnIntoText,
   })
 }

--- a/packages/react/src/components/slash-menu.test.tsx
+++ b/packages/react/src/components/slash-menu.test.tsx
@@ -14,6 +14,7 @@ const pmRoot = page.locate('.ProseMirror')
 const menu = page.getByTestId('slash-menu')
 
 const LABELS = [
+  'Text',
   'Heading 1',
   'Heading 2',
   'Heading 3',
@@ -106,6 +107,38 @@ describe('SlashMenu', () => {
     await expect.element(pmRoot.locate('h1')).toBeInTheDocument()
     await userEvent.keyboard('Hello')
     expect(ref.current?.getMarkdown()).toBe('# Hello\n')
+  })
+
+  it('turns a heading back into a paragraph', async () => {
+    const ref = createRef<EditorHandle>()
+    await render(<ProseKitEditor ref={ref} />)
+    await pmRoot.click()
+    await userEvent.keyboard('/head')
+    await menu.getByText('Heading 1').click()
+    await userEvent.keyboard('Hello /text')
+    await expect.element(pmRoot.locate('h1')).toBeInTheDocument()
+    await menu.getByText('Text', { exact: true }).click()
+
+    await expect.element(pmRoot.locate('h1')).not.toBeInTheDocument()
+    expect(ref.current?.getMarkdown()).toMatchInlineSnapshot(`
+      "Hello
+      "
+    `)
+  })
+
+  it('removes the bullet when Text is selected in a list item', async () => {
+    const ref = createRef<EditorHandle>()
+    await render(<ProseKitEditor ref={ref} />)
+    await pmRoot.click()
+    await userEvent.keyboard('- Buy milk /text')
+    await expect.element(pmRoot.locate('.prosemirror-flat-list')).toBeInTheDocument()
+    await menu.getByText('Text', { exact: true }).click()
+
+    await expect.element(pmRoot.locate('.prosemirror-flat-list')).not.toBeInTheDocument()
+    expect(ref.current?.getMarkdown()).toMatchInlineSnapshot(`
+      "Buy milk
+      "
+    `)
   })
 
   it('wraps the current block in a circle checkbox task', async () => {
@@ -322,7 +355,15 @@ describe('SlashMenu', () => {
     await userEvent.keyboard('/')
     await expect.element(menu).toBeVisible()
     await expect.element(menu.getByText('Now')).toBeVisible()
-    for (const label of ['Heading 1', 'Blockquote', 'Bullet list', 'Code block', 'Math', 'Table']) {
+    for (const label of [
+      'Text',
+      'Heading 1',
+      'Blockquote',
+      'Bullet list',
+      'Code block',
+      'Math',
+      'Table',
+    ]) {
       await expect.element(menu.getByText(label)).not.toBeInTheDocument()
     }
   })

--- a/packages/react/src/components/slash-menu.tsx
+++ b/packages/react/src/components/slash-menu.tsx
@@ -164,6 +164,11 @@ export function SlashMenu({
           {!inTableCell && (
             <>
               <SlashMenuItem
+                label="Text"
+                keywords={['paragraph', 'plain']}
+                onSelect={() => editor.commands.turnIntoText()}
+              />
+              <SlashMenuItem
                 label="Heading 1"
                 kbd="#"
                 onSelect={() => editor.commands.setHeading({ level: 1 })}


### PR DESCRIPTION
Adds a `Text` item to the slash menu, backed by a new `turnIntoText` core command: `chainCommands` over set-paragraph, `unwrapList`, and `lift`. Each call peels one layer, so a heading becomes a paragraph, a list item loses its marker, and a paragraph in a blockquote lifts out of the quote.