### PR TITLE
fix: anchor popovers on the atom preview

### DIFF
--- a/packages/core/src/extensions/caret-rect.ts
+++ b/packages/core/src/extensions/caret-rect.ts
@@ -1,6 +1,6 @@
 import type { EditorView } from '@prosekit/pm/view'
 
-import { tryCoordsAtPos } from '../utils/caret-coords.ts'
+import { tryCoordsAtPos, type CaretCoords } from '../utils/caret-coords.ts'
 
 import { ATOM_SOURCE_MARK_NAMES } from './atom-mark-navigation.ts'
 import { getMarkRangeAt } from './get-mark-range-at.ts'
@@ -74,6 +74,29 @@ export function findAtomCaretRect(view: EditorView): CaretRect | undefined {
     const fragment = atEnd ? fragments[fragments.length - 1] : fragments[0]
     const left = atEnd ? fragment.right : fragment.left
     return { left, top: fragment.top, height: fragment.height }
+  }
+  return undefined
+}
+
+/**
+ * The preview fragment rect for a range edge touching an atom unit: the
+ * visible geometry standing in for source text that measures as nothing.
+ * `edge` picks the line fragment the range extends from.
+ */
+export function findAtomEdgeRect(
+  view: EditorView,
+  pos: number,
+  edge: 'start' | 'end',
+): CaretCoords | undefined {
+  const state = view.state
+  for (const markName of ATOM_SOURCE_MARK_NAMES) {
+    const range = getMarkRangeAt(state, pos, markName)
+    if (range == null) continue
+    const preview = findAtomPreviewElement(view, range.from + 1)
+    if (preview == null) continue
+    const fragments = Array.from(preview.getClientRects()).filter((rect) => rect.height > 0)
+    if (fragments.length === 0) continue
+    return edge === 'start' ? fragments[0] : fragments[fragments.length - 1]
   }
   return undefined
 }

--- a/packages/core/src/extensions/caret-rect.ts
+++ b/packages/core/src/extensions/caret-rect.ts
@@ -81,12 +81,13 @@ export function findAtomCaretRect(view: EditorView): CaretRect | undefined {
 /**
  * The preview fragment rect for a range edge touching an atom unit: the
  * visible geometry standing in for source text that measures as nothing.
- * `edge` picks the line fragment the range extends from.
+ * `side` points into the range, like `coordsAtPos`: `1` for a start edge
+ * (first line fragment), `-1` for an end edge (last line fragment).
  */
 export function findAtomEdgeRect(
   view: EditorView,
   pos: number,
-  edge: 'start' | 'end',
+  side: -1 | 1,
 ): CaretCoords | undefined {
   const state = view.state
   for (const markName of ATOM_SOURCE_MARK_NAMES) {
@@ -96,7 +97,7 @@ export function findAtomEdgeRect(
     if (preview == null) continue
     const fragments = Array.from(preview.getClientRects()).filter((rect) => rect.height > 0)
     if (fragments.length === 0) continue
-    return edge === 'start' ? fragments[0] : fragments[fragments.length - 1]
+    return side === 1 ? fragments[0] : fragments[fragments.length - 1]
   }
   return undefined
 }

--- a/packages/core/src/extensions/caret-rect.ts
+++ b/packages/core/src/extensions/caret-rect.ts
@@ -81,8 +81,8 @@ export function findAtomCaretRect(view: EditorView): CaretRect | undefined {
 /**
  * The preview fragment rect for a range edge touching an atom unit: the
  * visible geometry standing in for source text that measures as nothing.
- * `side` points into the range, like `coordsAtPos`: `1` for a start edge
- * (first line fragment), `-1` for an end edge (last line fragment).
+ * `side` points into the range: `1` for a start edge (first line fragment),
+ * `-1` for an end edge (last line fragment).
  */
 export function findAtomEdgeRect(
   view: EditorView,

--- a/packages/core/src/extensions/hidden-run.ts
+++ b/packages/core/src/extensions/hidden-run.ts
@@ -69,8 +69,9 @@ export function isHiddenRunInterior(state: EditorState, pos: number): boolean {
 export function getHiddenRunAround(state: EditorState, pos: number): HiddenRun | undefined {
   if (!isHiddenRunInterior(state, pos)) return undefined
   const before = getHiddenRunBefore(state, pos)
+  if (before == null) return undefined
   const after = getHiddenRunAfter(state, pos)
-  if (before == null || after == null) return undefined
+  if (after == null) return undefined
   return { from: before.from, to: after.to }
 }
 

--- a/packages/core/src/extensions/hidden-run.ts
+++ b/packages/core/src/extensions/hidden-run.ts
@@ -22,10 +22,10 @@ export interface HiddenRun {
 // Marks of the character occupying [pos, pos + 1), or undefined when that slot
 // is not a text character (block boundary, inline atom node, end of block).
 function getCharMarks(state: EditorState, pos: number): readonly Mark[] | undefined {
-  if (pos < 0 || pos + 1 > state.doc.content.size) return undefined
+  if (pos < 0 || pos + 1 > state.doc.content.size) return
   const $pos = state.doc.resolve(pos)
   const child = $pos.parent.maybeChild($pos.index())
-  if (child == null || !child.isText) return undefined
+  if (child == null || !child.isText) return
   return child.marks
 }
 
@@ -43,7 +43,7 @@ function isInsideNonCodeTextblock(state: EditorState, pos: number): boolean {
 
 /** The maximal contiguous hidden run ending exactly at `pos`, or undefined. */
 export function getHiddenRunBefore(state: EditorState, pos: number): HiddenRun | undefined {
-  if (!isInsideNonCodeTextblock(state, pos)) return undefined
+  if (!isInsideNonCodeTextblock(state, pos)) return
   const blockStart = state.doc.resolve(pos).start()
   let from = pos
   while (from > blockStart && isHiddenChar(state, from - 1)) from--
@@ -52,7 +52,7 @@ export function getHiddenRunBefore(state: EditorState, pos: number): HiddenRun |
 
 /** The maximal contiguous hidden run starting exactly at `pos`, or undefined. */
 export function getHiddenRunAfter(state: EditorState, pos: number): HiddenRun | undefined {
-  if (!isInsideNonCodeTextblock(state, pos)) return undefined
+  if (!isInsideNonCodeTextblock(state, pos)) return
   const blockEnd = state.doc.resolve(pos).end()
   let to = pos
   while (to < blockEnd && isHiddenChar(state, to)) to++
@@ -67,11 +67,11 @@ export function isHiddenRunInterior(state: EditorState, pos: number): boolean {
 
 /** The full run around an interior position, or undefined for rest positions. */
 export function getHiddenRunAround(state: EditorState, pos: number): HiddenRun | undefined {
-  if (!isHiddenRunInterior(state, pos)) return undefined
+  if (!isHiddenRunInterior(state, pos)) return
   const before = getHiddenRunBefore(state, pos)
-  if (before == null) return undefined
+  if (!before) return
   const after = getHiddenRunAfter(state, pos)
-  if (after == null) return undefined
+  if (!after) return
   return { from: before.from, to: after.to }
 }
 
@@ -88,10 +88,10 @@ export function getInnermostPackRangeAt(
   charPos: number,
 ): HiddenRun | undefined {
   const marks = getCharMarks(state, charPos)
-  if (marks == null) return undefined
+  if (marks == null) return
   const packType = getMarkType(state.schema, 'mdPack' satisfies MarkName)
   const packs = marks.filter((mark) => mark.type === packType)
-  if (packs.length === 0) return undefined
+  if (packs.length === 0) return
   const $pos = state.doc.resolve(charPos)
   const blockStart = $pos.start()
   const blockEnd = $pos.end()
@@ -155,10 +155,10 @@ export type CaretTail = 'left' | 'right'
 // Typing affinity: the tail points to the side whose formatting a typed
 // character would adopt, which is the opposite side of the hidden run.
 export function getCaretTail(state: EditorState, pos: number): CaretTail | undefined {
-  if (!isInsideNonCodeTextblock(state, pos)) return undefined
+  if (!isInsideNonCodeTextblock(state, pos)) return
   const hiddenBefore = isHiddenChar(state, pos - 1)
   const hiddenAfter = isHiddenChar(state, pos)
-  if (hiddenBefore === hiddenAfter) return undefined
+  if (hiddenBefore === hiddenAfter) return
   return hiddenAfter ? 'left' : 'right'
 }
 

--- a/packages/core/src/utils/virtual-element.ts
+++ b/packages/core/src/utils/virtual-element.ts
@@ -11,7 +11,7 @@ export type { VirtualElement }
 
 // A range edge against a hidden syntax run has no glyph of its own; the
 // nearest visible glyph past the run's far end carries the line geometry.
-// `side` points into the range, like `coordsAtPos`.
+// `side` points into the range.
 function tryHiddenRunCoords(view: EditorView, pos: number, side: -1 | 1): CaretCoords | undefined {
   if (side === 1) {
     const run = getHiddenRunAfter(view.state, pos)

--- a/packages/core/src/utils/virtual-element.ts
+++ b/packages/core/src/utils/virtual-element.ts
@@ -13,8 +13,13 @@ export type { VirtualElement }
 // nearest visible glyph past the run's far end carries the line geometry.
 // `side` points into the range, like `coordsAtPos`.
 function tryHiddenRunCoords(view: EditorView, pos: number, side: -1 | 1): CaretCoords | undefined {
-  const run = side === 1 ? getHiddenRunAfter(view.state, pos) : getHiddenRunBefore(view.state, pos)
-  return run == null ? undefined : tryCoordsAtPos(view, run.to, side)
+  if (side === 1) {
+    const run = getHiddenRunAfter(view.state, pos)
+    return run && tryCoordsAtPos(view, run.to, side)
+  } else {
+    const run = getHiddenRunBefore(view.state, pos)
+    return run && tryCoordsAtPos(view, run.from, -1)
+  }
 }
 
 /**

--- a/packages/core/src/utils/virtual-element.ts
+++ b/packages/core/src/utils/virtual-element.ts
@@ -11,14 +11,10 @@ export type { VirtualElement }
 
 // A range edge against a hidden syntax run has no glyph of its own; the
 // nearest visible glyph past the run's far end carries the line geometry.
-// `side` points into the range.
+// `side` points into the range, like `coordsAtPos`.
 function tryHiddenRunCoords(view: EditorView, pos: number, side: -1 | 1): CaretCoords | undefined {
-  if (side === 1) {
-    const run = getHiddenRunAfter(view.state, pos)
-    return run == null ? undefined : tryCoordsAtPos(view, run.to, 1)
-  }
-  const run = getHiddenRunBefore(view.state, pos)
-  return run == null ? undefined : tryCoordsAtPos(view, run.from, -1)
+  const run = side === 1 ? getHiddenRunAfter(view.state, pos) : getHiddenRunBefore(view.state, pos)
+  return run == null ? undefined : tryCoordsAtPos(view, run.to, side)
 }
 
 /**

--- a/packages/core/src/utils/virtual-element.ts
+++ b/packages/core/src/utils/virtual-element.ts
@@ -11,12 +11,9 @@ export type { VirtualElement }
 
 // A range edge against a hidden syntax run has no glyph of its own; the
 // nearest visible glyph past the run's far end carries the line geometry.
-function tryHiddenRunCoords(
-  view: EditorView,
-  pos: number,
-  edge: 'start' | 'end',
-): CaretCoords | undefined {
-  if (edge === 'start') {
+// `side` points into the range, like `coordsAtPos`.
+function tryHiddenRunCoords(view: EditorView, pos: number, side: -1 | 1): CaretCoords | undefined {
+  if (side === 1) {
     const run = getHiddenRunAfter(view.state, pos)
     return run == null ? undefined : tryCoordsAtPos(view, run.to, 1)
   }
@@ -29,7 +26,7 @@ function tryHiddenRunCoords(
  *
  * Positioning libraries re-measure asynchronously (resize observers, animation
  * frames), so a measurement can fire after the view is destroyed or the range
- * no longer resolves — those return the last known rect instead of throwing.
+ * no longer resolves; those return the last known rect instead of throwing.
  */
 export function getVirtualElementFromRange(view: EditorView, range: PositionRange): VirtualElement {
   let lastRect = new DOMRect(0, 0, 0, 0)
@@ -44,15 +41,16 @@ export function getVirtualElementFromRange(view: EditorView, range: PositionRang
     // against plain hidden syntax anchors on the visible glyph past the run.
     const start =
       tryCoordsAtPos(view, range.from, 1) ??
-      findAtomEdgeRect(view, range.from, 'start') ??
-      tryHiddenRunCoords(view, range.from, 'start') ??
+      findAtomEdgeRect(view, range.from, 1) ??
+      tryHiddenRunCoords(view, range.from, 1) ??
       tryCoordsAtPos(view, range.from, -1)
+    if (start == null) return lastRect
     const end =
       tryCoordsAtPos(view, range.to, -1) ??
-      findAtomEdgeRect(view, range.to, 'end') ??
-      tryHiddenRunCoords(view, range.to, 'end') ??
+      findAtomEdgeRect(view, range.to, -1) ??
+      tryHiddenRunCoords(view, range.to, -1) ??
       tryCoordsAtPos(view, range.to, 1)
-    if (start == null || end == null) return lastRect
+    if (end == null) return lastRect
     const left = Math.min(start.left, end.left)
     const right = Math.max(start.right, end.right)
     const top = Math.min(start.top, end.top)

--- a/packages/core/src/utils/virtual-element.ts
+++ b/packages/core/src/utils/virtual-element.ts
@@ -2,11 +2,27 @@ import type { VirtualElement } from '@floating-ui/dom'
 import type { EditorView } from '@prosekit/pm/view'
 
 import { findAtomEdgeRect } from '../extensions/caret-rect.ts'
+import { getHiddenRunAfter, getHiddenRunBefore } from '../extensions/hidden-run.ts'
 
-import { tryCoordsAtPos } from './caret-coords.ts'
+import { tryCoordsAtPos, type CaretCoords } from './caret-coords.ts'
 import type { PositionRange } from './range.ts'
 
 export type { VirtualElement }
+
+// A range edge against a hidden syntax run has no glyph of its own; the
+// nearest visible glyph past the run's far end carries the line geometry.
+function tryHiddenRunCoords(
+  view: EditorView,
+  pos: number,
+  edge: 'start' | 'end',
+): CaretCoords | undefined {
+  if (edge === 'start') {
+    const run = getHiddenRunAfter(view.state, pos)
+    return run == null ? undefined : tryCoordsAtPos(view, run.to, 1)
+  }
+  const run = getHiddenRunBefore(view.state, pos)
+  return run == null ? undefined : tryCoordsAtPos(view, run.from, -1)
+}
 
 /**
  * Returns a Floating-UI virtual element tracking a document range.
@@ -24,14 +40,17 @@ export function getVirtualElementFromRange(view: EditorView, range: PositionRang
     // at a block boundary has no visible neighbor and yields a bogus
     // zero rect, anchoring the popover at the viewport corner. An edge
     // touching an atom unit (image, wikilink, file) has no measurable glyph on
-    // either side; its preview element is the visible geometry.
+    // either side; its preview element is the visible geometry. An edge
+    // against plain hidden syntax anchors on the visible glyph past the run.
     const start =
       tryCoordsAtPos(view, range.from, 1) ??
       findAtomEdgeRect(view, range.from, 'start') ??
+      tryHiddenRunCoords(view, range.from, 'start') ??
       tryCoordsAtPos(view, range.from, -1)
     const end =
       tryCoordsAtPos(view, range.to, -1) ??
       findAtomEdgeRect(view, range.to, 'end') ??
+      tryHiddenRunCoords(view, range.to, 'end') ??
       tryCoordsAtPos(view, range.to, 1)
     if (start == null || end == null) return lastRect
     const left = Math.min(start.left, end.left)

--- a/packages/core/src/utils/virtual-element.ts
+++ b/packages/core/src/utils/virtual-element.ts
@@ -1,6 +1,8 @@
 import type { VirtualElement } from '@floating-ui/dom'
 import type { EditorView } from '@prosekit/pm/view'
 
+import { findAtomEdgeRect } from '../extensions/caret-rect.ts'
+
 import { tryCoordsAtPos } from './caret-coords.ts'
 import type { PositionRange } from './range.ts'
 
@@ -20,9 +22,17 @@ export function getVirtualElementFromRange(view: EditorView, range: PositionRang
     // Bias both measurements into the range's own content. Measured outward
     // (the default `side`), an edge that sits against hidden markdown syntax
     // at a block boundary has no visible neighbor and yields a bogus
-    // zero rect, anchoring the popover at the viewport corner.
-    const start = tryCoordsAtPos(view, range.from, 1) ?? tryCoordsAtPos(view, range.from, -1)
-    const end = tryCoordsAtPos(view, range.to, -1) ?? tryCoordsAtPos(view, range.to, 1)
+    // zero rect, anchoring the popover at the viewport corner. An edge
+    // touching an atom unit (image, wikilink, file) has no measurable glyph on
+    // either side; its preview element is the visible geometry.
+    const start =
+      tryCoordsAtPos(view, range.from, 1) ??
+      findAtomEdgeRect(view, range.from, 'start') ??
+      tryCoordsAtPos(view, range.from, -1)
+    const end =
+      tryCoordsAtPos(view, range.to, -1) ??
+      findAtomEdgeRect(view, range.to, 'end') ??
+      tryCoordsAtPos(view, range.to, 1)
     if (start == null || end == null) return lastRect
     const left = Math.min(start.left, end.left)
     const right = Math.max(start.right, end.right)

--- a/packages/react/src/components/link-menu.test.tsx
+++ b/packages/react/src/components/link-menu.test.tsx
@@ -107,7 +107,6 @@ describe('LinkMenu', () => {
     await userEvent.keyboard('{ControlOrMeta>}k{/ControlOrMeta}')
     await expect.element(popover.getByTestId('link-popover-edit')).toBeVisible()
 
-    // The popover is positioned asynchronously; poll until it settles.
     await vi.waitFor(() => {
       const linkRect = wikilink.element().getBoundingClientRect()
       const popRect = popover.element().getBoundingClientRect()

--- a/packages/react/src/components/link-menu.test.tsx
+++ b/packages/react/src/components/link-menu.test.tsx
@@ -94,6 +94,58 @@ describe('LinkMenu', () => {
     expect(Math.abs(popCenter - linkCenter)).toBeLessThan(20)
   })
 
+  it('anchors the edit form to a selected wikilink alone in its block', async () => {
+    // The wikilink source is hidden atom text (`font-size: 0`) and both
+    // selection edges sit at block boundaries, so a raw-selection anchor has
+    // no visible glyph to measure on either side.
+    // Wide enough for the popup to center on the pill without being pushed
+    // aside by the viewport edge.
+    await render(<MeowdownEditor initialMarkdown="[[A rather long note title for the anchor]]" />)
+    const wikilink = pmRoot.getByTestId('wikilink')
+    await wikilink.click()
+    await userEvent.keyboard('{ControlOrMeta>}a{/ControlOrMeta}')
+    await userEvent.keyboard('{ControlOrMeta>}k{/ControlOrMeta}')
+    await expect.element(popover.getByTestId('link-popover-edit')).toBeVisible()
+
+    // The popover is positioned asynchronously; poll until it settles.
+    await vi.waitFor(() => {
+      const linkRect = wikilink.element().getBoundingClientRect()
+      const popRect = popover.element().getBoundingClientRect()
+      expect(popRect.top).toBeGreaterThanOrEqual(linkRect.bottom + 7)
+      expect(popRect.top).toBeLessThan(linkRect.bottom + 40)
+      const linkCenter = (linkRect.left + linkRect.right) / 2
+      const popCenter = (popRect.left + popRect.right) / 2
+      expect(Math.abs(popCenter - linkCenter)).toBeLessThan(20)
+    })
+  })
+
+  it('anchors the edit form to a selection ending in hidden link syntax', async () => {
+    // Select-all reaches the block end behind the hidden `](url)` run, so the
+    // raw-selection end edge has no visible glyph on either side; the anchor
+    // must fall back to the last visible glyph before the run.
+    await render(
+      <MeowdownEditor initialMarkdown="read the [long linked documentation](https://example.com)" />,
+    )
+    const label = pmRoot.getByText('long linked documentation')
+    await label.click()
+    await userEvent.keyboard('{ControlOrMeta>}a{/ControlOrMeta}')
+    await userEvent.keyboard('{ControlOrMeta>}k{/ControlOrMeta}')
+    await expect.element(popover.getByTestId('link-popover-edit')).toBeVisible()
+
+    await vi.waitFor(() => {
+      const labelRect = label.element().getBoundingClientRect()
+      const popRect = popover.element().getBoundingClientRect()
+      expect(popRect.top).toBeGreaterThanOrEqual(labelRect.bottom + 7)
+      expect(popRect.top).toBeLessThan(labelRect.bottom + 40)
+      // The anchor spans the visible text: from the paragraph's first glyph to
+      // the end of the label, skipping the hidden trailing syntax.
+      const paragraphRect = pmRoot.getByText('read the').element().getBoundingClientRect()
+      const anchorCenter = (paragraphRect.left + labelRect.right) / 2
+      const popCenter = (popRect.left + popRect.right) / 2
+      expect(Math.abs(popCenter - anchorCenter)).toBeLessThan(20)
+    })
+  })
+
   it('creates a link from a selection with Mod-k', async () => {
     const ref = createRef<EditorHandle>()
     const screen = await render(<MeowdownEditor handleRef={ref} initialMarkdown="Docs" />)


### PR DESCRIPTION
Pressing Mod-k over a wikilink selected alone in its block pinned the link edit popover at the viewport corner: the selection edges sit in hidden atom source text, so both `coordsAtPos` probes fail on every engine. `getVirtualElementFromRange` now falls back to the atom preview rect, and to the visible glyph past a plain hidden syntax run (a selection ending behind `](url)` hit the same corner), before probing outward. The selection menu and pending replacement preview share the same helper and are fixed by the same change.


https://github.com/user-attachments/assets/38dfa616-4507-4cf7-ac1b-ab83039b072e


