### PR TITLE
feat: support Markdown reference links

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,8 @@
     "@prosekit/pm": "^0.1.19-beta.3",
     "@prosekit/web": "^0.9.0-beta.21",
     "katex": "^0.17.0",
+    "micromark-util-decode-string": "^2.0.1",
+    "micromark-util-normalize-identifier": "^2.0.1",
     "prosemirror-flat-list": "^0.7.1",
     "prosemirror-highlight": "^0.15.3",
     "rehype-parse": "^9.0.1",

--- a/packages/core/src/converters/md-to-pm.ts
+++ b/packages/core/src/converters/md-to-pm.ts
@@ -155,6 +155,10 @@ function convertBlock(
       return [convertHeading(nodes, cursor, text, 2, true)]
     case LEZER_NODE_IDS.Paragraph:
       return [convertParagraph(nodes, cursor, text)]
+    case LEZER_NODE_IDS.LinkReference:
+      // Definitions remain literal source-backed paragraphs. The inline-mark
+      // layer resolves references document-wide without changing their bytes.
+      return [convertParagraph(nodes, cursor, text)]
     case LEZER_NODE_IDS.CommentBlock:
       // A comment is not rendered output: map it onto the invisible `htmlComment`
       // node so it stays in the document (and round-trips) without reading as

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -225,7 +225,7 @@ describe('inline', () => {
     expect(roundtrip('<?php echo 1; ?>')).toBe('<?php echo 1; ?>\n')
   })
 
-  it.fails('keeps a link reference definition', () => {
+  it('keeps a link reference definition', () => {
     expect(roundtrip('[foo]: /url')).toBe('[foo]: /url\n')
   })
 })

--- a/packages/core/src/extensions/get-link-unit-at.test.ts
+++ b/packages/core/src/extensions/get-link-unit-at.test.ts
@@ -29,6 +29,21 @@ describe('getLinkUnitAt', () => {
     expect(fixture.doc.textBetween(link.dest!.from, link.dest!.to)).toBe('http://x "the title"')
   })
 
+  it('returns a resolved reference href without editable inline ranges', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(
+      n.doc(n.paragraph('Read [the plan][doc].'), n.paragraph('[doc]: docs/plan.md "Plan"')),
+    )
+    const link = getLinkUnitAt(fixture.state, findText(fixture.doc, 'the plan') + 1)!
+    expect(link.href).toBe('docs/plan.md')
+    expect(link.title).toBe('Plan')
+    expect(link.label).toBeUndefined()
+    expect(link.dest).toBeUndefined()
+    expect(fixture.doc.textBetween(link.unit.from, link.unit.to)).toBe('[the plan][doc]')
+    expect(fixture.doc.textBetween(link.text.from, link.text.to)).toBe('the plan')
+  })
+
   it('resolves href when the position is on the url run, not the label', () => {
     using fixture = setupFixture()
     const { n } = fixture

--- a/packages/core/src/extensions/get-link-unit-at.ts
+++ b/packages/core/src/extensions/get-link-unit-at.ts
@@ -101,6 +101,22 @@ export function getLinkUnitAt(state: EditorState, pos: number): LinkUnit | undef
     }
   }
 
+  if (packAttrs.data.reference === true) {
+    // The parser's mdLinkText run includes the opening `[` but ends before
+    // the label's closing `]`; trim that one source character for the visible
+    // anchor range. Clicks normally originate inside this run.
+    const text =
+      linkText === undefined
+        ? { from: unit.from, to: unit.to }
+        : { from: linkText.from + 1, to: linkText.to }
+    return {
+      unit: { from: unit.from, to: unit.to },
+      text,
+      href: packAttrs.data.href,
+      title: packAttrs.data.title,
+    }
+  }
+
   // `[` at unit.from, `)` at unit.to - 1. With a url, `]` sits two chars before
   // the url start (`](`); with an empty `()`, `]` is two chars before the `)`.
   const uri = lastMarkRunIn(state, unit, 'mdLinkUri')

--- a/packages/core/src/extensions/inline-mark-plugin.test.ts
+++ b/packages/core/src/extensions/inline-mark-plugin.test.ts
@@ -314,12 +314,36 @@ describe('inlineMarkPlugin', () => {
     const pos = findText(fixture.doc, 'note')
     expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdWikilink'])
     // Delete one ']': "see [[note] end" is no longer a wikilink. The inner
-    // `[note]` becomes a shortcut reference link, so it loses mdWikilink
-    // but gains the link pack wrapper.
+    // `[note]` becomes an unresolved shortcut reference, so it stays literal.
     const firstBracket = findText(fixture.doc, ']')
     fixture.view.dispatch(fixture.state.tr.delete(firstBracket + 1, firstBracket + 2))
     const after = findText(fixture.doc, 'note')
-    expect(marksAt(fixture.doc, after + 1)).toEqual(['mdPack'])
+    expect(marksAt(fixture.doc, after + 1)).toEqual([])
+  })
+
+  it('resolves references document-wide and refreshes when a definition changes', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('Read [Plan][doc].'), n.paragraph('[doc]: docs/old.md "Old"')))
+
+    const label = findText(fixture.doc, 'Plan')
+    const before = fixture.doc
+      .resolve(label + 1)
+      .marks()
+      .find((mark) => mark.type.name === 'mdLinkText')
+    expect(before?.attrs.href).toBe('docs/old.md')
+
+    const destination = findText(fixture.doc, 'docs/old.md')
+    fixture.view.dispatch(
+      fixture.state.tr.insertText('docs/new.md', destination, destination + 'docs/old.md'.length),
+    )
+
+    const after = fixture.doc
+      .resolve(label + 1)
+      .marks()
+      .find((mark) => mark.type.name === 'mdLinkText')
+    expect(after?.attrs.href).toBe('docs/new.md')
+    expect(marksAt(fixture.doc, findText(fixture.doc, '[doc]:') + 2)).toEqual([])
   })
 
   it('removes mdTag when text is glued in front of the #', () => {

--- a/packages/core/src/extensions/inline-mark-plugin.test.ts
+++ b/packages/core/src/extensions/inline-mark-plugin.test.ts
@@ -5,6 +5,10 @@ import { setupFixture } from '../testing/index.ts'
 import { marksAt } from '../testing/marks-at.ts'
 
 import { getCacheStats, resetCacheStats } from './inline-mark-plugin.ts'
+import {
+  getReferenceDefinitionParseCount,
+  resetReferenceDefinitionParseCount,
+} from './reference-links.ts'
 
 describe('inlineMarkPlugin', () => {
   it('applies mdStrong inside **bold**', () => {
@@ -344,6 +348,133 @@ describe('inlineMarkPlugin', () => {
       .find((mark) => mark.type.name === 'mdLinkText')
     expect(after?.attrs.href).toBe('docs/new.md')
     expect(marksAt(fixture.doc, findText(fixture.doc, '[doc]:') + 2)).toEqual([])
+  })
+
+  it('discovers a definition created after the editor mounts', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('Read [Plan][doc].'), n.paragraph('[doc] /old')))
+
+    const definition = fixture.doc.child(0).nodeSize + 1
+    fixture.view.dispatch(fixture.state.tr.insertText(':', definition + '[doc]'.length))
+
+    const label = findText(fixture.doc, 'Plan')
+    const link = fixture.doc
+      .resolve(label + 1)
+      .marks()
+      .find((mark) => mark.type.name === 'mdLinkText')
+    expect(link?.attrs.href).toBe('/old')
+  })
+
+  it('promotes the next duplicate when the first definition is deleted', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(
+      n.doc(
+        n.paragraph('Read [Plan][doc].'),
+        n.paragraph('[doc]: /first'),
+        n.paragraph('[DOC]: /second'),
+      ),
+    )
+
+    const firstDefinitionPosition = fixture.doc.child(0).nodeSize
+    const firstDefinitionSize = fixture.doc.child(1).nodeSize
+    fixture.view.dispatch(
+      fixture.state.tr.delete(
+        firstDefinitionPosition,
+        firstDefinitionPosition + firstDefinitionSize,
+      ),
+    )
+
+    const label = findText(fixture.doc, 'Plan')
+    const link = fixture.doc
+      .resolve(label + 1)
+      .marks()
+      .find((mark) => mark.type.name === 'mdLinkText')
+    expect(link?.attrs.href).toBe('/second')
+  })
+
+  it('keeps a newly created definition after its stale inline marks are removed', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(
+      n.doc(
+        n.paragraph('[doc] /new'),
+        n.paragraph('Read [Plan][doc].'),
+        n.paragraph('[doc]: /old'),
+        n.paragraph('ordinary'),
+      ),
+    )
+
+    const firstLabel = 1
+    fixture.view.dispatch(fixture.state.tr.insertText(':', firstLabel + '[doc]'.length))
+
+    const firstUpdateLabel = findText(fixture.doc, 'Plan')
+    const firstUpdateLink = fixture.doc
+      .resolve(firstUpdateLabel + 1)
+      .marks()
+      .find((mark) => mark.type.name === 'mdLinkText')
+    expect(firstUpdateLink?.attrs.href).toBe('/new')
+
+    const ordinary = findText(fixture.doc, 'ordinary')
+    fixture.view.dispatch(fixture.state.tr.insertText('X', ordinary, ordinary + 1))
+
+    const label = findText(fixture.doc, 'Plan')
+    const link = fixture.doc
+      .resolve(label + 1)
+      .marks()
+      .find((mark) => mark.type.name === 'mdLinkText')
+    expect(link?.attrs.href).toBe('/new')
+  })
+
+  it('does not rescan a large document when an unrelated paragraph changes', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    const ordinary = Array.from({ length: 1_000 }, (_, index) => n.paragraph(`line ${index}`))
+    fixture.set(n.doc(n.paragraph('[doc]: /docs'), ...ordinary))
+
+    resetReferenceDefinitionParseCount()
+    const lastLine = findText(fixture.doc, 'line 999')
+    fixture.view.dispatch(fixture.state.tr.insertText('X', lastLine, lastLine + 1))
+    expect(getReferenceDefinitionParseCount()).toBe(0)
+  })
+
+  it('resolves definition-shaped text in a heading against a real definition', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('[doc]: /real'), n.heading({ level: 1 }, '[doc]: /other')))
+
+    const heading = fixture.doc.child(1)
+    const link = heading
+      .resolve(2)
+      .marks()
+      .find((mark) => mark.type.name === 'mdLinkText')
+    expect(link?.attrs.href).toBe('/real')
+  })
+
+  it('invalidates cached chunks when unchanged text changes definition context', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(
+      n.doc(n.paragraph('[doc]: /real'), n.list({ kind: 'bullet' }, n.paragraph('[doc]: /other'))),
+    )
+
+    const listPosition = fixture.doc.child(0).nodeSize
+    const list = fixture.doc.nodeAt(listPosition)!
+    fixture.view.dispatch(
+      fixture.state.tr.setNodeMarkup(listPosition, undefined, {
+        ...list.attrs,
+        kind: 'task',
+        checked: false,
+      }),
+    )
+
+    const labelPosition = listPosition + 3
+    const link = fixture.doc
+      .resolve(labelPosition)
+      .marks()
+      .find((mark) => mark.type.name === 'mdLinkText')
+    expect(link?.attrs.href).toBe('/real')
   })
 
   it('removes mdTag when text is glued in front of the #', () => {

--- a/packages/core/src/extensions/inline-mark-plugin.ts
+++ b/packages/core/src/extensions/inline-mark-plugin.ts
@@ -23,7 +23,12 @@ import type { PositionRange } from '../utils/range.ts'
 import { BatchSetMarkStep } from './batch-set-mark-step.ts'
 import { inlineTextToMarkChunks, type InlineMarkOptions } from './inline-text-to-mark-chunks.ts'
 import type { MarkChunk } from './mark-chunk.ts'
-import { collectReferenceDefinitions, type ReferenceDefinitionIndex } from './reference-links.ts'
+import {
+  collectReferenceDefinitions,
+  rebindReferenceDefinitionNodes,
+  type ReferenceDefinitionIndex,
+  updateReferenceDefinitions,
+} from './reference-links.ts'
 import { getMarkBuildersForSchema } from './schema.ts'
 
 const META_KEY = 'inline-marks-applied'
@@ -79,6 +84,11 @@ function computeAffectedRange(
 }
 
 function createInlineMarkPlugin(options: InlineMarkOptions | undefined): Plugin {
+  interface InlineMarkPluginState {
+    readonly references: ReferenceDefinitionIndex
+  }
+
+  const pluginKey = new PluginKey<InlineMarkPluginState>('inline-mark')
   /**
    * Cache of chunks per textblock node, keyed by the immutable
    * `ProseMirrorNode` instance. Stored chunks are baseOffset-relative
@@ -89,11 +99,11 @@ function createInlineMarkPlugin(options: InlineMarkOptions | undefined): Plugin 
    */
   interface CachedChunks {
     readonly referenceSignature: string
+    readonly isReferenceDefinition: boolean
     readonly chunks: readonly MarkChunk[]
   }
 
   const chunkCache = new WeakMap<EditorNode, CachedChunks>()
-  let lastReferenceSignature: string | undefined
 
   function chunksForTextblock(
     node: EditorNode,
@@ -102,20 +112,24 @@ function createInlineMarkPlugin(options: InlineMarkOptions | undefined): Plugin 
     references: ReferenceDefinitionIndex,
   ): readonly MarkChunk[] {
     const cached = chunkCache.get(node)
+    const isReferenceDefinition = references.nodes.has(node)
     let relative: readonly MarkChunk[]
-    if (cached?.referenceSignature === references.signature) {
+    if (
+      cached?.referenceSignature === references.signature &&
+      cached.isReferenceDefinition === isReferenceDefinition
+    ) {
       chunkCacheHits++
       relative = cached.chunks
     } else {
       chunkCacheParses++
-      relative = inlineTextToMarkChunks(
-        getMarkBuildersForSchema(schema),
-        node.textContent,
-        options,
-        { referenceDefinitions: references.definitions },
-      )
+      relative = inlineTextToMarkChunks(getMarkBuildersForSchema(schema), node.textContent, {
+        ...options,
+        referenceDefinitions: references.definitions,
+        isReferenceDefinition,
+      })
       chunkCache.set(node, {
         referenceSignature: references.signature,
+        isReferenceDefinition,
         chunks: relative,
       })
     }
@@ -152,16 +166,30 @@ function createInlineMarkPlugin(options: InlineMarkOptions | undefined): Plugin 
     return chunks
   }
 
-  return new Plugin({
-    key: new PluginKey('inline-mark'),
-    appendTransaction(transactions, _oldState, newState) {
+  return new Plugin<InlineMarkPluginState>({
+    key: pluginKey,
+    state: {
+      init(_config, state) {
+        return { references: collectReferenceDefinitions(state.doc) }
+      },
+      apply(transaction, value, _oldState, newState) {
+        if (transaction.getMeta(META_KEY)) {
+          return { references: rebindReferenceDefinitionNodes(value.references, newState.doc) }
+        }
+        return {
+          references: updateReferenceDefinitions(value.references, transaction, newState.doc),
+        }
+      },
+    },
+    appendTransaction(transactions, oldState, newState) {
       // Drop transactions we appended ourselves to avoid recursing.
       for (const tr of transactions) {
         if (tr.getMeta(META_KEY)) return null
       }
-      const references = collectReferenceDefinitions(newState.doc)
-      const definitionsChanged = lastReferenceSignature !== references.signature
-      lastReferenceSignature = references.signature
+      const references = pluginKey.getState(newState)?.references
+      if (references === undefined) return null
+      const previousReferences = pluginKey.getState(oldState)?.references
+      const definitionsChanged = previousReferences?.signature !== references.signature
       const range = definitionsChanged
         ? { from: 0, to: newState.doc.content.size }
         : computeAffectedRange(transactions, newState)

--- a/packages/core/src/extensions/inline-mark-plugin.ts
+++ b/packages/core/src/extensions/inline-mark-plugin.ts
@@ -23,6 +23,7 @@ import type { PositionRange } from '../utils/range.ts'
 import { BatchSetMarkStep } from './batch-set-mark-step.ts'
 import { inlineTextToMarkChunks, type InlineMarkOptions } from './inline-text-to-mark-chunks.ts'
 import type { MarkChunk } from './mark-chunk.ts'
+import { collectReferenceDefinitions, type ReferenceDefinitionIndex } from './reference-links.ts'
 import { getMarkBuildersForSchema } from './schema.ts'
 
 const META_KEY = 'inline-marks-applied'
@@ -86,20 +87,37 @@ function createInlineMarkPlugin(options: InlineMarkOptions | undefined): Plugin 
    * the doc (a paragraph below it was inserted or deleted). Scoped to the
    * plugin instance because the chunks depend on this editor's `options`.
    */
-  const chunkCache = new WeakMap<EditorNode, readonly MarkChunk[]>()
+  interface CachedChunks {
+    readonly referenceSignature: string
+    readonly chunks: readonly MarkChunk[]
+  }
+
+  const chunkCache = new WeakMap<EditorNode, CachedChunks>()
+  let lastReferenceSignature: string | undefined
 
   function chunksForTextblock(
     node: EditorNode,
     baseOffset: number,
     schema: Schema,
+    references: ReferenceDefinitionIndex,
   ): readonly MarkChunk[] {
-    let relative = chunkCache.get(node)
-    if (relative) {
+    const cached = chunkCache.get(node)
+    let relative: readonly MarkChunk[]
+    if (cached?.referenceSignature === references.signature) {
       chunkCacheHits++
+      relative = cached.chunks
     } else {
       chunkCacheParses++
-      relative = inlineTextToMarkChunks(getMarkBuildersForSchema(schema), node.textContent, options)
-      chunkCache.set(node, relative)
+      relative = inlineTextToMarkChunks(
+        getMarkBuildersForSchema(schema),
+        node.textContent,
+        options,
+        { referenceDefinitions: references.definitions },
+      )
+      chunkCache.set(node, {
+        referenceSignature: references.signature,
+        chunks: relative,
+      })
     }
     if (baseOffset === 0) return relative
     const shifted: MarkChunk[] = []
@@ -117,13 +135,17 @@ function createInlineMarkPlugin(options: InlineMarkOptions | undefined): Plugin 
    * containers (blockquote, list, tableCell), so it picks up nested
    * textblocks without each container needing to be listed explicitly.
    */
-  function collectChunksForRange(state: EditorState, range: PositionRange): MarkChunk[] {
+  function collectChunksForRange(
+    state: EditorState,
+    range: PositionRange,
+    references: ReferenceDefinitionIndex,
+  ): MarkChunk[] {
     const chunks: MarkChunk[] = []
     state.doc.nodesBetween(range.from, range.to, (node, pos) => {
       if (node.type.spec.code) return false
       if (!node.isTextblock) return true
       if (node.childCount === 0) return false
-      const nodeChunks = chunksForTextblock(node, pos + 1, state.schema)
+      const nodeChunks = chunksForTextblock(node, pos + 1, state.schema, references)
       if (nodeChunks.length > 0) chunks.push(...nodeChunks)
       return false
     })
@@ -137,8 +159,13 @@ function createInlineMarkPlugin(options: InlineMarkOptions | undefined): Plugin 
       for (const tr of transactions) {
         if (tr.getMeta(META_KEY)) return null
       }
-      const range = computeAffectedRange(transactions, newState)
-      const chunks = collectChunksForRange(newState, range)
+      const references = collectReferenceDefinitions(newState.doc)
+      const definitionsChanged = lastReferenceSignature !== references.signature
+      lastReferenceSignature = references.signature
+      const range = definitionsChanged
+        ? { from: 0, to: newState.doc.content.size }
+        : computeAffectedRange(transactions, newState)
+      const chunks = collectChunksForRange(newState, range, references)
       if (chunks.length === 0) return null
       const tr = newState.tr.step(new BatchSetMarkStep(chunks))
       tr.setMeta(META_KEY, true)

--- a/packages/core/src/extensions/inline-marks.ts
+++ b/packages/core/src/extensions/inline-marks.ts
@@ -230,7 +230,7 @@ export type MdPackSimpleKey =
 export type MdPackAttrs =
   | {
       key: 'link'
-      data: { href: string; title: string }
+      data: { href: string; title: string; reference?: true }
     }
   | {
       key: 'image'

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
@@ -9,6 +9,11 @@ import {
   type InlineMarkOptions,
 } from './inline-text-to-mark-chunks.ts'
 import type { MarkChunk } from './mark-chunk.ts'
+import {
+  normalizeReferenceLabel,
+  type ReferenceDefinition,
+  type ReferenceDefinitions,
+} from './reference-links.ts'
 import type { TypedMarkBuilders } from './schema.ts'
 
 function formatMarkChunk([from, to, marks]: MarkChunk): [string, string] {
@@ -38,15 +43,30 @@ const getMarkBuilders = once((): TypedMarkBuilders => {
   return createMarkBuilders<EditorExtension>(schema)
 })
 
-function parse(text: string, options?: InlineMarkOptions): string {
+function parse(
+  text: string,
+  options?: InlineMarkOptions,
+  referenceDefinitions?: ReferenceDefinitions,
+): string {
   const markBuilders = getMarkBuilders()
-  const chunks = inlineTextToMarkChunks(markBuilders, text, options)
+  const chunks = inlineTextToMarkChunks(markBuilders, text, options, { referenceDefinitions })
   const formatted = chunks.map(formatMarkChunk)
   const headLength = Math.max(...formatted.map(([head]) => head.length))
   const lines = formatted.map(([head, body]) => {
     return (head.padEnd(headLength, ' ') + ' ' + body).trim()
   })
   return '\n' + lines.join('\n') + '\n'
+}
+
+function references(
+  ...values: ReadonlyArray<readonly [label: string, href: string, title?: string]>
+): ReferenceDefinitions {
+  const definitions = new Map<string, ReferenceDefinition>()
+  for (const [label, href, title = ''] of values) {
+    const key = normalizeReferenceLabel(label)
+    definitions.set(key, { key, href, title })
+  }
+  return definitions
 }
 
 describe('plain text', () => {
@@ -386,14 +406,21 @@ describe('image', () => {
   it('reference', () => {
     expect(parse('a ![b][id] c')).toMatchInlineSnapshot(`
       "
-      [0, 2]
-      [2, 4]   mdPack(key=link,data={"href":"","title":""}) + mdMark
-      [4, 5]   mdPack(key=link,data={"href":"","title":""})
-      [5, 6]   mdPack(key=link,data={"href":"","title":""}) + mdMark
-      [6, 10]  mdPack(key=link,data={"href":"","title":""})
-      [10, 12]
+      [0, 12]
       "
     `)
+  })
+
+  it.each([
+    ['full', '![preview][asset]'],
+    ['collapsed', '![asset][]'],
+    ['shortcut', '![asset]'],
+  ])('resolves a %s reference image', (_kind, source) => {
+    expect(parse(source, undefined, references(['asset', 'assets/preview.png', 'Preview']))).toBe(
+      `\n[0, ${source.length}] mdImage(src=assets/preview.png,alt=${
+        source.includes('preview') ? 'preview' : 'asset'
+      },title=Preview)\n`,
+    )
   })
 
   it('folds a trailing width comment into the image mark', () => {
@@ -867,13 +894,10 @@ describe('wikilink', () => {
   })
 
   it('unclosed', () => {
-    // The inner `[a]` becomes a shortcut reference link (lezer behavior).
+    // The inner `[a]` is an unresolved shortcut reference, so it stays literal.
     expect(parse('[[a]')).toMatchInlineSnapshot(`
       "
-      [0, 1]
-      [1, 2] mdPack(key=link,data={"href":"","title":""}) + mdMark
-      [2, 3] mdPack(key=link,data={"href":"","title":""})
-      [3, 4] mdPack(key=link,data={"href":"","title":""}) + mdMark
+      [0, 4]
       "
     `)
   })
@@ -988,5 +1012,45 @@ describe('file link', () => {
     parse('[shortcut]', { resolveFileLink })
     parse('[empty]()', { resolveFileLink })
     expect(resolveFileLink).not.toHaveBeenCalled()
+  })
+
+  it('passes a resolved reference destination to the file resolver', () => {
+    const resolveFileLink = vi.fn(() => true)
+    expect(
+      parse(
+        '[Quarterly][report]',
+        { resolveFileLink },
+        references(['report', 'docs/report.pdf', 'Q3']),
+      ),
+    ).toBe('\n[0, 19] mdFile(href=docs/report.pdf,name=Quarterly,title=Q3)\n')
+    expect(resolveFileLink).toHaveBeenCalledWith({
+      href: 'docs/report.pdf',
+      label: 'Quarterly',
+      title: 'Q3',
+    })
+  })
+})
+
+describe('reference link', () => {
+  const definitions = references(['Doc', 'docs/plan.md#scope', 'Plan'])
+
+  it.each([
+    ['full', '[Read it][doc]'],
+    ['collapsed', '[Doc][]'],
+    ['shortcut', '[DOC]'],
+  ])('resolves a %s form', (_kind, source) => {
+    const output = parse(source, undefined, definitions)
+    expect(output).toContain('mdLinkText(href=docs/plan.md#scope)')
+    expect(output).toContain(
+      'mdPack(key=link,data={"href":"docs/plan.md#scope","title":"Plan","reference":true})',
+    )
+  })
+
+  it('leaves an unresolved shortcut literal', () => {
+    expect(parse('[missing]', undefined, definitions)).toBe('\n[0, 9]\n')
+  })
+
+  it('does not resolve reference-looking text inside its definition', () => {
+    expect(parse('[Doc]: docs/plan.md', undefined, definitions)).toBe('\n[0, 19]\n')
   })
 })

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
@@ -49,7 +49,10 @@ function parse(
   referenceDefinitions?: ReferenceDefinitions,
 ): string {
   const markBuilders = getMarkBuilders()
-  const chunks = inlineTextToMarkChunks(markBuilders, text, options, { referenceDefinitions })
+  const chunks = inlineTextToMarkChunks(markBuilders, text, {
+    ...options,
+    referenceDefinitions,
+  })
   const formatted = chunks.map(formatMarkChunk)
   const headLength = Math.max(...formatted.map(([head]) => head.length))
   const lines = formatted.map(([head, body]) => {
@@ -1051,6 +1054,19 @@ describe('reference link', () => {
   })
 
   it('does not resolve reference-looking text inside its definition', () => {
-    expect(parse('[Doc]: docs/plan.md', undefined, definitions)).toBe('\n[0, 19]\n')
+    expect(parse('[Doc]: docs/plan.md', { isReferenceDefinition: true }, definitions)).toBe(
+      '\n[0, 19]\n',
+    )
+  })
+
+  it('does not equate an authored escape with unescaped punctuation', () => {
+    const escaped = references([String.raw`foo\!`, '/escaped'])
+    expect(parse('[foo!]', undefined, escaped)).toBe('\n[0, 6]\n')
+    expect(parse(String.raw`[foo\!]`, undefined, escaped)).toContain('mdLinkText(href=/escaped)')
+  })
+
+  it('uses CommonMark Unicode case folding', () => {
+    const unicode = references(['Straße', '/unicode'])
+    expect(parse('[STRASSE]', undefined, unicode)).toContain('mdLinkText(href=/unicode)')
   })
 })

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.ts
@@ -18,7 +18,6 @@ import type { MarkName } from './mark-names.ts'
 import { marksEqual } from './marks-equal.ts'
 import {
   normalizeReferenceLabel,
-  parseReferenceDefinition,
   type ReferenceDefinition,
   type ReferenceDefinitions,
 } from './reference-links.ts'
@@ -77,13 +76,14 @@ export interface FileLinkOptions {
   resolveFileLink?: FileLinkResolver
 }
 
-/** Host options that influence source-backed inline atom parsing. */
-export type InlineMarkOptions = FileLinkOptions & WikiEmbedOptions
-
-/** Document-level context needed to resolve CommonMark reference links. */
-export interface InlineMarkContext {
-  referenceDefinitions?: ReferenceDefinitions
-}
+/** Host options and document context that influence inline parsing. */
+export type InlineMarkOptions = FileLinkOptions &
+  WikiEmbedOptions & {
+    /** Document-level definitions used to resolve CommonMark reference links. */
+    referenceDefinitions?: ReferenceDefinitions
+    /** This textblock is itself a source-backed reference definition. */
+    isReferenceDefinition?: boolean
+  }
 
 /**
  * Walk a textblock's inline content and produce a list of mark chunks
@@ -97,15 +97,11 @@ export function inlineTextToMarkChunks(
   text: string,
   /** Host options; omit for the default parse. */
   options?: InlineMarkOptions,
-  /** Document-level parse context; definitions never alter the source text. */
-  context?: InlineMarkContext,
 ): MarkChunk[] {
   const elements = parseInline(text)
   const out: MarkChunk[] = []
   const referenceDefinitions =
-    context?.referenceDefinitions !== undefined && parseReferenceDefinition(text) === null
-      ? context.referenceDefinitions
-      : undefined
+    options?.isReferenceDefinition === true ? undefined : options?.referenceDefinitions
   walk(elements, [], 0, text.length, text, marks, out, options, referenceDefinitions)
   return out
 }

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.ts
@@ -16,6 +16,12 @@ import { parseMagicComment, type MagicComment } from './magic-comment.ts'
 import type { MarkChunk } from './mark-chunk.ts'
 import type { MarkName } from './mark-names.ts'
 import { marksEqual } from './marks-equal.ts'
+import {
+  normalizeReferenceLabel,
+  parseReferenceDefinition,
+  type ReferenceDefinition,
+  type ReferenceDefinitions,
+} from './reference-links.ts'
 import type { TypedMarkBuilders } from './schema.ts'
 import { parseWikiEmbed, wikiEmbedBasename, type WikiEmbedOptions } from './wiki-embed.ts'
 import { parseWikilink } from './wikilink.ts'
@@ -74,6 +80,11 @@ export interface FileLinkOptions {
 /** Host options that influence source-backed inline atom parsing. */
 export type InlineMarkOptions = FileLinkOptions & WikiEmbedOptions
 
+/** Document-level context needed to resolve CommonMark reference links. */
+export interface InlineMarkContext {
+  referenceDefinitions?: ReferenceDefinitions
+}
+
 /**
  * Walk a textblock's inline content and produce a list of mark chunks
  * with positions relative to the start of `text` (i.e. zero-based).
@@ -86,10 +97,16 @@ export function inlineTextToMarkChunks(
   text: string,
   /** Host options; omit for the default parse. */
   options?: InlineMarkOptions,
+  /** Document-level parse context; definitions never alter the source text. */
+  context?: InlineMarkContext,
 ): MarkChunk[] {
   const elements = parseInline(text)
   const out: MarkChunk[] = []
-  walk(elements, [], 0, text.length, text, marks, out, options)
+  const referenceDefinitions =
+    context?.referenceDefinitions !== undefined && parseReferenceDefinition(text) === null
+      ? context.referenceDefinitions
+      : undefined
+  walk(elements, [], 0, text.length, text, marks, out, options, referenceDefinitions)
   return out
 }
 
@@ -107,6 +124,7 @@ function walk(
   marks: TypedMarkBuilders,
   out: MarkChunk[],
   options: InlineMarkOptions | undefined,
+  referenceDefinitions: ReferenceDefinitions | undefined,
 ): void {
   let pos = rangeStart
   for (let index = 0; index < nodes.length; index++) {
@@ -116,15 +134,15 @@ function walk(
     }
     const type: number = node.type
     if (type === LEZER_NODE_IDS.Link) {
-      const fileMarks = claimFileLink(node, parentMarks, text, marks, options)
+      const fileMarks = claimFileLink(node, parentMarks, text, marks, options, referenceDefinitions)
       if (fileMarks) {
         emit(out, node.from, node.to, fileMarks)
       } else {
-        walkLink(node, parentMarks, text, marks, out, options)
+        walkLink(node, parentMarks, text, marks, out, options, referenceDefinitions)
       }
     } else if (type === LEZER_NODE_IDS.Image) {
       const trailing = takeMagicComment(node, nodes[index + 1], text)
-      walkImage(node, parentMarks, text, marks, out, trailing)
+      walkImage(node, parentMarks, text, marks, out, referenceDefinitions, trailing)
       if (trailing) index++ // skip the folded comment
       pos = trailing ? trailing.to : node.to
       continue
@@ -168,7 +186,17 @@ function walk(
       if (node.children.length === 0) {
         emit(out, node.from, node.to, childMarks)
       } else {
-        walk(node.children, childMarks, node.from, node.to, text, marks, out, options)
+        walk(
+          node.children,
+          childMarks,
+          node.from,
+          node.to,
+          text,
+          marks,
+          out,
+          options,
+          referenceDefinitions,
+        )
       }
     }
     pos = node.to
@@ -185,6 +213,8 @@ interface LinkParts {
   labelTo: number
   urlNode: InlineElement | null
   titleNode: InlineElement | null
+  referenceLabelNode: InlineElement | null
+  linkMarkCount: number
 }
 
 /**
@@ -197,6 +227,7 @@ function scanLinkParts(node: InlineElement): LinkParts {
   let labelTo = -1
   let urlNode: InlineElement | null = null
   let titleNode: InlineElement | null = null
+  let referenceLabelNode: InlineElement | null = null
   let bracketCount = 0
   for (const child of node.children) {
     if (child.type === LEZER_NODE_IDS.LinkMark) {
@@ -207,9 +238,59 @@ function scanLinkParts(node: InlineElement): LinkParts {
       urlNode = child
     } else if (child.type === LEZER_NODE_IDS.LinkTitle && titleNode === null) {
       titleNode = child
+    } else if (child.type === LEZER_NODE_IDS.LinkLabel && referenceLabelNode === null) {
+      referenceLabelNode = child
     }
   }
-  return { labelFrom, labelTo, urlNode, titleNode }
+  return {
+    labelFrom,
+    labelTo,
+    urlNode,
+    titleNode,
+    referenceLabelNode,
+    linkMarkCount: bracketCount,
+  }
+}
+
+interface ResolvedLinkParts {
+  href: string
+  title: string
+  isReference: boolean
+  definition: ReferenceDefinition | null
+}
+
+function resolvedLinkParts(
+  parts: LinkParts,
+  text: string,
+  referenceDefinitions: ReferenceDefinitions | undefined,
+): ResolvedLinkParts {
+  if (parts.urlNode !== null) {
+    return {
+      href: text.slice(parts.urlNode.from, parts.urlNode.to),
+      title:
+        parts.titleNode === null
+          ? ''
+          : unquoteTitle(text.slice(parts.titleNode.from, parts.titleNode.to)),
+      isReference: false,
+      definition: null,
+    }
+  }
+
+  const isReference = parts.referenceLabelNode !== null || parts.linkMarkCount === 2
+  if (!isReference || parts.labelFrom < 0 || parts.labelTo < 0) {
+    return { href: '', title: '', isReference: false, definition: null }
+  }
+  const label = text.slice(parts.labelFrom, parts.labelTo)
+  const explicit = parts.referenceLabelNode
+  const authoredKey =
+    explicit === null ? label : text.slice(explicit.from + 1, explicit.to - 1) || label
+  const definition = referenceDefinitions?.get(normalizeReferenceLabel(authoredKey)) ?? null
+  return {
+    href: definition?.href ?? '',
+    title: definition?.title ?? '',
+    isReference: true,
+    definition,
+  }
 }
 
 /** The last path segment of `href` (query/hash stripped), decoded when possible. */
@@ -235,15 +316,21 @@ function claimFileLink(
   text: string,
   marks: TypedMarkBuilders,
   options: InlineMarkOptions | undefined,
+  referenceDefinitions: ReferenceDefinitions | undefined,
 ): readonly Mark[] | undefined {
   const resolveFileLink = options?.resolveFileLink
   if (!resolveFileLink) return undefined
-  const { labelFrom, labelTo, urlNode, titleNode } = scanLinkParts(node)
-  if (labelFrom < 0 || labelTo < 0 || !urlNode) return undefined
-  const href = text.slice(urlNode.from, urlNode.to)
+  const parts = scanLinkParts(node)
+  const { labelFrom, labelTo } = parts
+  if (labelFrom < 0 || labelTo < 0) return undefined
+  const { href, title, isReference, definition } = resolvedLinkParts(
+    parts,
+    text,
+    referenceDefinitions,
+  )
+  if (isReference && definition === null) return undefined
   if (!href) return undefined
   const label = text.slice(labelFrom, labelTo)
-  const title = titleNode ? unquoteTitle(text.slice(titleNode.from, titleNode.to)) : ''
   if (!resolveFileLink({ href, label, title })) return undefined
   const name = label || hrefBasename(href)
   return [...parentMarks, marks.mdFile.create({ href, name, title } satisfies MdFileAttrs)]
@@ -273,14 +360,26 @@ function walkLink(
   marks: TypedMarkBuilders,
   out: MarkChunk[],
   options: InlineMarkOptions | undefined,
+  referenceDefinitions: ReferenceDefinitions | undefined,
 ): void {
-  const { labelTo: labelEnd, urlNode, titleNode } = scanLinkParts(node)
-  const href = urlNode ? text.slice(urlNode.from, urlNode.to) : ''
-  const title = titleNode ? unquoteTitle(text.slice(titleNode.from, titleNode.to)) : ''
+  const parts = scanLinkParts(node)
+  const { labelTo: labelEnd } = parts
+  const { href, title, isReference, definition } = resolvedLinkParts(
+    parts,
+    text,
+    referenceDefinitions,
+  )
+  if (isReference && definition === null) {
+    emit(out, node.from, node.to, parentMarks)
+    return
+  }
   const linkTextMark = href ? marks.mdLinkText.create({ href } satisfies MdLinkTextAttrs) : null
   const inLabel = (pos: number): boolean => labelEnd >= 0 && pos < labelEnd && linkTextMark !== null
 
-  const pack = marks.mdPack.create({ key: 'link', data: { href, title } } satisfies MdPackAttrs)
+  const pack = marks.mdPack.create({
+    key: 'link',
+    data: isReference ? { href, title, reference: true } : { href, title },
+  } satisfies MdPackAttrs)
   const base = [...parentMarks, pack]
 
   let pos = node.from
@@ -302,7 +401,10 @@ function walkLink(
       pos = child.to
       continue
     }
-    const maybeMarkName = MARK_NAME_BY_TYPE_ID.get(child.type)
+    const maybeMarkName =
+      isReference && child.type === LEZER_NODE_IDS.LinkLabel
+        ? 'mdMark'
+        : MARK_NAME_BY_TYPE_ID.get(child.type)
     const childMarks = maybeMarkName
       ? [...baseForChild, marks[maybeMarkName].create()]
       : baseForChild
@@ -311,7 +413,17 @@ function walkLink(
     } else {
       // A link label cannot contain another `[label](url)` link, but custom
       // atom syntax inside the label still uses the host resolvers.
-      walk(child.children, childMarks, child.from, child.to, text, marks, out, options)
+      walk(
+        child.children,
+        childMarks,
+        child.from,
+        child.to,
+        text,
+        marks,
+        out,
+        options,
+        referenceDefinitions,
+      )
     }
     pos = child.to
   }
@@ -350,23 +462,26 @@ function walkImage(
   text: string,
   marks: TypedMarkBuilders,
   out: MarkChunk[],
+  referenceDefinitions: ReferenceDefinitions | undefined,
   trailing?: AdjacentMagicComment,
 ): void {
-  const urlNode = node.children.find((child) => child.type === LEZER_NODE_IDS.URL)
-  if (!urlNode) {
-    // A reference image `![alt][id]` has no `URL` child; fall back to the link
-    // walk, which renders nothing yet.
-    walkLink(node, parentMarks, text, marks, out, undefined)
+  const parts = scanLinkParts(node)
+  const resolved = resolvedLinkParts(parts, text, referenceDefinitions)
+  if (resolved.isReference && resolved.definition === null) {
+    emit(out, node.from, trailing?.to ?? node.to, parentMarks)
+    return
+  }
+  if (!parts.urlNode && !resolved.isReference) {
+    walkLink(node, parentMarks, text, marks, out, undefined, referenceDefinitions)
     return
   }
 
   const bracketNodes = node.children.filter((child) => child.type === LEZER_NODE_IDS.LinkMark)
-  const titleNode = node.children.find((child) => child.type === LEZER_NODE_IDS.LinkTitle)
 
-  const src: string = text.slice(urlNode.from, urlNode.to)
+  const src = resolved.href
   const alt: string =
     bracketNodes.length >= 2 ? text.slice(bracketNodes[0].to, bracketNodes[1].from) : ''
-  const title: string = titleNode ? unquoteTitle(text.slice(titleNode.from, titleNode.to)) : ''
+  const title = resolved.title
   const width = trailing?.magic.width ?? null
   const height = trailing?.magic.height ?? null
   const to = trailing?.to ?? node.to

--- a/packages/core/src/extensions/link-commands.ts
+++ b/packages/core/src/extensions/link-commands.ts
@@ -131,6 +131,7 @@ function openLinkEdit(onLinkEdit: LinkEditHandler): Command {
     const link = getLinkUnitAt(state, state.selection.from)
 
     if (link) {
+      if (link.label === undefined || link.dest === undefined) return false
       if (dispatch && view) {
         const {
           unit: { from, to },

--- a/packages/core/src/extensions/reference-links.test.ts
+++ b/packages/core/src/extensions/reference-links.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { markdownToDoc } from '../converters/md-to-pm.ts'
+
+import {
+  collectReferenceDefinitions,
+  normalizeReferenceLabel,
+  parseReferenceDefinition,
+} from './reference-links.ts'
+
+describe('normalizeReferenceLabel', () => {
+  it('unescapes punctuation, collapses whitespace, and case-folds', () => {
+    expect(normalizeReferenceLabel('  A\\*\t multi\nLINE  ')).toBe('a* multi line')
+  })
+})
+
+describe('parseReferenceDefinition', () => {
+  it('parses an angle-bracket destination and title', () => {
+    expect(parseReferenceDefinition('[Plan]: <docs/Q3 plan.md> "Quarterly plan"')).toEqual({
+      key: 'plan',
+      href: 'docs/Q3 plan.md',
+      title: 'Quarterly plan',
+    })
+  })
+
+  it('parses a title on the following line', () => {
+    expect(parseReferenceDefinition("[Plan]: docs/plan.md\n  'Quarterly plan'")).toEqual({
+      key: 'plan',
+      href: 'docs/plan.md',
+      title: 'Quarterly plan',
+    })
+  })
+
+  it('rejects ordinary text', () => {
+    expect(parseReferenceDefinition('Read [Plan][plan].')).toBeNull()
+  })
+})
+
+describe('collectReferenceDefinitions', () => {
+  it('collects definitions document-wide and keeps the first duplicate', () => {
+    const doc = markdownToDoc(
+      ['Read [Plan][plan].', '', '[PLAN]: docs/first.md "First"', '', '[plan]: second.md'].join(
+        '\n',
+      ),
+    )
+
+    const index = collectReferenceDefinitions(doc)
+    expect([...index.definitions.values()]).toEqual([
+      { key: 'plan', href: 'docs/first.md', title: 'First' },
+    ])
+    expect(index.signature).toBe('[["plan","docs/first.md","First"]]')
+  })
+})

--- a/packages/core/src/extensions/reference-links.test.ts
+++ b/packages/core/src/extensions/reference-links.test.ts
@@ -4,20 +4,24 @@ import { markdownToDoc } from '../converters/md-to-pm.ts'
 
 import {
   collectReferenceDefinitions,
+  getReferenceDefinitionParseCount,
   normalizeReferenceLabel,
   parseReferenceDefinition,
+  resetReferenceDefinitionParseCount,
 } from './reference-links.ts'
 
 describe('normalizeReferenceLabel', () => {
-  it('unescapes punctuation, collapses whitespace, and case-folds', () => {
-    expect(normalizeReferenceLabel('  A\\*\t multi\nLINE  ')).toBe('a* multi line')
+  it('preserves escapes, collapses whitespace, and Unicode case-folds', () => {
+    const label = `${String.raw`  A\*`}\t multi\nLINE  `
+    expect(normalizeReferenceLabel(label)).toBe(String.raw`A\* MULTI LINE`)
+    expect(normalizeReferenceLabel('Straße')).toBe(normalizeReferenceLabel('STRASSE'))
   })
 })
 
 describe('parseReferenceDefinition', () => {
   it('parses an angle-bracket destination and title', () => {
     expect(parseReferenceDefinition('[Plan]: <docs/Q3 plan.md> "Quarterly plan"')).toEqual({
-      key: 'plan',
+      key: 'PLAN',
       href: 'docs/Q3 plan.md',
       title: 'Quarterly plan',
     })
@@ -25,7 +29,7 @@ describe('parseReferenceDefinition', () => {
 
   it('parses a title on the following line', () => {
     expect(parseReferenceDefinition("[Plan]: docs/plan.md\n  'Quarterly plan'")).toEqual({
-      key: 'plan',
+      key: 'PLAN',
       href: 'docs/plan.md',
       title: 'Quarterly plan',
     })
@@ -33,6 +37,14 @@ describe('parseReferenceDefinition', () => {
 
   it('rejects ordinary text', () => {
     expect(parseReferenceDefinition('Read [Plan][plan].')).toBeNull()
+  })
+
+  it('decodes character references in destinations and titles', () => {
+    expect(parseReferenceDefinition('[Plan]: docs/A&amp;B.md "A&#x26;B"')).toEqual({
+      key: 'PLAN',
+      href: 'docs/A&B.md',
+      title: 'A&B',
+    })
   })
 })
 
@@ -46,8 +58,42 @@ describe('collectReferenceDefinitions', () => {
 
     const index = collectReferenceDefinitions(doc)
     expect([...index.definitions.values()]).toEqual([
-      { key: 'plan', href: 'docs/first.md', title: 'First' },
+      { key: 'PLAN', href: 'docs/first.md', title: 'First' },
     ])
-    expect(index.signature).toBe('[["plan","docs/first.md","First"]]')
+    expect(index.signature).toBe('[["PLAN","docs/first.md","First"]]')
+    expect(index.entries).toHaveLength(2)
+  })
+
+  it('rejects definition-shaped headings, table cells, and task items', () => {
+    const doc = markdownToDoc(
+      [
+        '# [heading]: /heading',
+        '',
+        '| Cell |',
+        '| --- |',
+        '| [table]: /table |',
+        '',
+        '- [ ] [task]: /task',
+        '',
+        '- [ ] task body',
+        '',
+        '  [task-child]: /task-child',
+        '',
+        '> [quote]: /quote',
+        '',
+        '- [bullet]: /bullet',
+      ].join('\n'),
+    )
+
+    const index = collectReferenceDefinitions(doc)
+    expect([...index.definitions.keys()]).toEqual(['TASK-CHILD', 'QUOTE', 'BULLET'])
+  })
+
+  it('uses a cheap guard before invoking the block parser', () => {
+    resetReferenceDefinitionParseCount()
+    expect(parseReferenceDefinition('ordinary paragraph')).toBeNull()
+    expect(getReferenceDefinitionParseCount()).toBe(0)
+    expect(parseReferenceDefinition('[doc]: /docs')).not.toBeNull()
+    expect(getReferenceDefinitionParseCount()).toBe(1)
   })
 })

--- a/packages/core/src/extensions/reference-links.ts
+++ b/packages/core/src/extensions/reference-links.ts
@@ -1,7 +1,22 @@
 import type { SyntaxNode } from '@lezer/common'
 import type { EditorNode } from '@prosekit/pm/model'
+import type { Transaction } from '@prosekit/pm/state'
+import { decodeString } from 'micromark-util-decode-string'
+import { normalizeIdentifier } from 'micromark-util-normalize-identifier'
 
 import { gfmParser } from '../lezer/parser.ts'
+
+let definitionParseCount = 0
+
+/** @internal Test instrumentation for definition parser work. */
+export function resetReferenceDefinitionParseCount(): void {
+  definitionParseCount = 0
+}
+
+/** @internal Test instrumentation for definition parser work. */
+export function getReferenceDefinitionParseCount(): number {
+  return definitionParseCount
+}
 
 /** One CommonMark link-reference definition resolved for rendering. */
 export interface ReferenceDefinition {
@@ -20,33 +35,35 @@ export type ReferenceDefinitions = ReadonlyMap<string, ReferenceDefinition>
 export interface ReferenceDefinitionIndex {
   definitions: ReferenceDefinitions
   signature: string
+  /** Source-backed definition blocks, including shadowed duplicates. */
+  entries: readonly ReferenceDefinitionEntry[]
+  /** Immutable editor nodes that are actual definition blocks. */
+  nodes: ReadonlySet<EditorNode>
 }
 
-const ESCAPABLE_PUNCTUATION_RE = /\\([!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/g
-
-function unescapePunctuation(value: string): string {
-  return value.replaceAll(ESCAPABLE_PUNCTUATION_RE, '$1')
+/** One source-backed definition block and its current document position. */
+export interface ReferenceDefinitionEntry {
+  node: EditorNode
+  position: number
+  definition: ReferenceDefinition
 }
 
-/** CommonMark label normalization: unescape, collapse whitespace, and case-fold. */
+/** CommonMark label normalization: collapse whitespace and Unicode case-fold. */
 export function normalizeReferenceLabel(label: string): string {
-  return unescapePunctuation(label)
-    .trim()
-    .replaceAll(/[\t\n\r ]+/g, ' ')
-    .normalize('NFC')
-    .toLowerCase()
+  return normalizeIdentifier(label)
 }
 
 function destinationValue(raw: string): string {
   const unwrapped = raw.startsWith('<') && raw.endsWith('>') ? raw.slice(1, -1) : raw
-  return unescapePunctuation(unwrapped)
+  return decodeString(unwrapped)
 }
 
 function titleValue(raw: string): string {
-  return raw.length >= 2 ? unescapePunctuation(raw.slice(1, -1)) : ''
+  return raw.length >= 2 ? decodeString(raw.slice(1, -1)) : ''
 }
 
 function firstReferenceNode(text: string): SyntaxNode | null {
+  definitionParseCount++
   let reference: SyntaxNode | null = null
   gfmParser.parse(text).iterate({
     enter(node) {
@@ -60,6 +77,10 @@ function firstReferenceNode(text: string): SyntaxNode | null {
 
 /** Parse one complete CommonMark link-reference definition textblock. */
 export function parseReferenceDefinition(text: string): ReferenceDefinition | null {
+  const firstNonWhitespace = text.search(/\S/)
+  if (firstNonWhitespace < 0 || text[firstNonWhitespace] !== '[' || !text.includes(']:')) {
+    return null
+  }
   const reference = firstReferenceNode(text)
   if (reference === null) return null
   const labelNode = reference.getChild('LinkLabel')
@@ -76,20 +97,143 @@ export function parseReferenceDefinition(text: string): ReferenceDefinition | nu
   }
 }
 
-/** Collect document-wide definitions from source-backed textblocks. */
-export function collectReferenceDefinitions(doc: EditorNode): ReferenceDefinitionIndex {
+function isDefinitionContainer(parent: EditorNode | null, index: number): boolean {
+  if (parent === null) return true
+  if (parent.type.name === 'tableCell' || parent.type.name === 'tableHeaderCell') return false
+  return parent.type.name !== 'list' || parent.attrs.kind !== 'task' || index > 0
+}
+
+/** Whether an editor textblock can represent a CommonMark definition block. */
+function isReferenceDefinitionTextblock(
+  node: EditorNode,
+  parent: EditorNode | null,
+  index: number,
+): boolean {
+  return node.type.name === 'paragraph' && isDefinitionContainer(parent, index)
+}
+
+function buildReferenceDefinitionIndex(
+  entries: readonly ReferenceDefinitionEntry[],
+): ReferenceDefinitionIndex {
+  const orderedEntries = [...entries].sort((left, right) => left.position - right.position)
   const definitions = new Map<string, ReferenceDefinition>()
-  doc.descendants((node) => {
-    if (node.type.spec.code) return false
-    if (!node.isTextblock) return true
-    const definition = parseReferenceDefinition(node.textContent)
-    if (definition !== null && !definitions.has(definition.key)) {
-      definitions.set(definition.key, definition)
+  for (const entry of orderedEntries) {
+    if (!definitions.has(entry.definition.key)) {
+      definitions.set(entry.definition.key, entry.definition)
     }
-    return false
-  })
+  }
   const signature = JSON.stringify(
     [...definitions].map(([key, definition]) => [key, definition.href, definition.title]),
   )
-  return { definitions, signature }
+  return {
+    definitions,
+    signature,
+    entries: orderedEntries,
+    nodes: new Set(orderedEntries.map((entry) => entry.node)),
+  }
+}
+
+function referenceDefinitionEntry(
+  node: EditorNode,
+  position: number,
+  parent: EditorNode | null,
+  index: number,
+): ReferenceDefinitionEntry | null {
+  if (!isReferenceDefinitionTextblock(node, parent, index)) return null
+  const definition = parseReferenceDefinition(node.textContent)
+  return definition === null ? null : { node, position, definition }
+}
+
+/** Collect document-wide definitions from source-backed textblocks. */
+export function collectReferenceDefinitions(doc: EditorNode): ReferenceDefinitionIndex {
+  const entries: ReferenceDefinitionEntry[] = []
+  doc.descendants((node, position, parent, index) => {
+    if (node.type.spec.code) return false
+    if (!node.isTextblock) return true
+    const entry = referenceDefinitionEntry(node, position, parent, index)
+    if (entry !== null) entries.push(entry)
+    return false
+  })
+  return buildReferenceDefinitionIndex(entries)
+}
+
+function changedRanges(transaction: Transaction): readonly { from: number; to: number }[] {
+  const ranges: { from: number; to: number }[] = []
+  for (const [index, stepMap] of transaction.mapping.maps.entries()) {
+    const remaining = transaction.mapping.slice(index + 1)
+    stepMap.forEach((_oldStart, _oldEnd, newStart, newEnd) => {
+      const from = remaining.map(newStart, -1)
+      const to = remaining.map(newEnd, 1)
+      ranges.push({ from: Math.min(from, to), to: Math.max(from, to) })
+    })
+  }
+  return ranges
+}
+
+function contextAt(doc: EditorNode, position: number): { parent: EditorNode; index: number } {
+  const resolved = doc.resolve(position)
+  return { parent: resolved.parent, index: resolved.index() }
+}
+
+/**
+ * Incrementally refresh definitions after one document transaction.
+ * Unchanged immutable blocks are retained; only textblocks around changed
+ * ranges are reparsed.
+ */
+export function updateReferenceDefinitions(
+  previous: ReferenceDefinitionIndex,
+  transaction: Transaction,
+  doc: EditorNode,
+): ReferenceDefinitionIndex {
+  if (!transaction.docChanged) return previous
+
+  const entriesByNode = new Map<EditorNode, ReferenceDefinitionEntry>()
+  for (const entry of previous.entries) {
+    const mapped = transaction.mapping.mapResult(entry.position, 1)
+    const node = doc.nodeAt(mapped.pos)
+    const context = contextAt(doc, mapped.pos)
+    if (
+      !mapped.deleted &&
+      node === entry.node &&
+      isReferenceDefinitionTextblock(node, context.parent, context.index)
+    ) {
+      entriesByNode.set(node, { ...entry, position: mapped.pos })
+    }
+  }
+
+  const docSize = doc.content.size
+  for (const range of changedRanges(transaction)) {
+    const from = Math.max(0, range.from - 1)
+    const to = Math.min(docSize, range.to + 1)
+    doc.nodesBetween(from, to, (node, position, parent, index) => {
+      if (node.type.spec.code) return false
+      if (!node.isTextblock) return true
+      entriesByNode.delete(node)
+      const entry = referenceDefinitionEntry(node, position, parent, index)
+      if (entry !== null) entriesByNode.set(node, entry)
+      return false
+    })
+  }
+
+  return buildReferenceDefinitionIndex([...entriesByNode.values()])
+}
+
+/** Rebind immutable definition-node identities after a position-preserving mark step. */
+export function rebindReferenceDefinitionNodes(
+  previous: ReferenceDefinitionIndex,
+  doc: EditorNode,
+): ReferenceDefinitionIndex {
+  const entries: ReferenceDefinitionEntry[] = []
+  for (const entry of previous.entries) {
+    const node = doc.nodeAt(entry.position)
+    const context = contextAt(doc, entry.position)
+    if (
+      node !== null &&
+      node.textContent === entry.node.textContent &&
+      isReferenceDefinitionTextblock(node, context.parent, context.index)
+    ) {
+      entries.push({ ...entry, node })
+    }
+  }
+  return buildReferenceDefinitionIndex(entries)
 }

--- a/packages/core/src/extensions/reference-links.ts
+++ b/packages/core/src/extensions/reference-links.ts
@@ -1,0 +1,95 @@
+import type { SyntaxNode } from '@lezer/common'
+import type { EditorNode } from '@prosekit/pm/model'
+
+import { gfmParser } from '../lezer/parser.ts'
+
+/** One CommonMark link-reference definition resolved for rendering. */
+export interface ReferenceDefinition {
+  /** Normalized label key used by full, collapsed, and shortcut references. */
+  key: string
+  /** Destination value with optional angle brackets removed. */
+  href: string
+  /** Unquoted definition title, or an empty string. */
+  title: string
+}
+
+/** First-definition-wins lookup, matching CommonMark reference semantics. */
+export type ReferenceDefinitions = ReadonlyMap<string, ReferenceDefinition>
+
+/** Document-scoped reference definitions plus a stable cache identity. */
+export interface ReferenceDefinitionIndex {
+  definitions: ReferenceDefinitions
+  signature: string
+}
+
+const ESCAPABLE_PUNCTUATION_RE = /\\([!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/g
+
+function unescapePunctuation(value: string): string {
+  return value.replaceAll(ESCAPABLE_PUNCTUATION_RE, '$1')
+}
+
+/** CommonMark label normalization: unescape, collapse whitespace, and case-fold. */
+export function normalizeReferenceLabel(label: string): string {
+  return unescapePunctuation(label)
+    .trim()
+    .replaceAll(/[\t\n\r ]+/g, ' ')
+    .normalize('NFC')
+    .toLowerCase()
+}
+
+function destinationValue(raw: string): string {
+  const unwrapped = raw.startsWith('<') && raw.endsWith('>') ? raw.slice(1, -1) : raw
+  return unescapePunctuation(unwrapped)
+}
+
+function titleValue(raw: string): string {
+  return raw.length >= 2 ? unescapePunctuation(raw.slice(1, -1)) : ''
+}
+
+function firstReferenceNode(text: string): SyntaxNode | null {
+  let reference: SyntaxNode | null = null
+  gfmParser.parse(text).iterate({
+    enter(node) {
+      if (node.name !== 'LinkReference') return true
+      reference = node.node
+      return false
+    },
+  })
+  return reference
+}
+
+/** Parse one complete CommonMark link-reference definition textblock. */
+export function parseReferenceDefinition(text: string): ReferenceDefinition | null {
+  const reference = firstReferenceNode(text)
+  if (reference === null) return null
+  const labelNode = reference.getChild('LinkLabel')
+  const urlNode = reference.getChild('URL')
+  if (labelNode === null || urlNode === null) return null
+
+  const key = normalizeReferenceLabel(text.slice(labelNode.from + 1, labelNode.to - 1))
+  if (key === '') return null
+  const titleNode = reference.getChild('LinkTitle')
+  return {
+    key,
+    href: destinationValue(text.slice(urlNode.from, urlNode.to)),
+    title: titleNode === null ? '' : titleValue(text.slice(titleNode.from, titleNode.to)),
+  }
+}
+
+/** Collect document-wide definitions from source-backed textblocks. */
+export function collectReferenceDefinitions(doc: EditorNode): ReferenceDefinitionIndex {
+  const definitions = new Map<string, ReferenceDefinition>()
+  doc.descendants((node) => {
+    if (node.type.spec.code) return false
+    if (!node.isTextblock) return true
+    const definition = parseReferenceDefinition(node.textContent)
+    if (definition !== null && !definitions.has(definition.key)) {
+      definitions.set(definition.key, definition)
+    }
+    return false
+  })
+  const signature = JSON.stringify(
+    [...definitions].map(([key, definition]) => [key, definition.href, definition.title]),
+  )
+  return { definitions, signature }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -76,7 +76,6 @@ export {
   type FileLinkOptions,
   type FileLinkPayload,
   type FileLinkResolver,
-  type InlineMarkContext,
   type InlineMarkOptions,
 } from './extensions/inline-text-to-mark-chunks.ts'
 export {
@@ -84,6 +83,7 @@ export {
   normalizeReferenceLabel,
   parseReferenceDefinition,
   type ReferenceDefinition,
+  type ReferenceDefinitionEntry,
   type ReferenceDefinitionIndex,
   type ReferenceDefinitions,
 } from './extensions/reference-links.ts'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -76,8 +76,17 @@ export {
   type FileLinkOptions,
   type FileLinkPayload,
   type FileLinkResolver,
+  type InlineMarkContext,
   type InlineMarkOptions,
 } from './extensions/inline-text-to-mark-chunks.ts'
+export {
+  collectReferenceDefinitions,
+  normalizeReferenceLabel,
+  parseReferenceDefinition,
+  type ReferenceDefinition,
+  type ReferenceDefinitionIndex,
+  type ReferenceDefinitions,
+} from './extensions/reference-links.ts'
 export { EDITOR_KEY_BINDINGS } from './extensions/key-bindings.ts'
 export {
   defineLinkClickHandler,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,6 +28,7 @@
     "@prosekit/pm": "^0.1.19-beta.3",
     "@prosekit/react": "^0.8.0-beta.21",
     "clsx": "^2.1.1",
+    "github-slugger": "^2.0.0",
     "lucide-react": "^1.24.0",
     "react-property": "^2.0.2"
   },

--- a/packages/react/src/components/editor.test.tsx
+++ b/packages/react/src/components/editor.test.tsx
@@ -367,6 +367,48 @@ describe('MeowdownEditor', () => {
     })
   })
 
+  it('round-trips and activates a resolved reference link', async () => {
+    const onLinkClick = vi.fn()
+    const ref = createRef<EditorHandle>()
+    const markdown = '[Plan][doc], [doc][], and [doc].\n\n[doc]: docs/plan.md "Plan title"'
+    await render(
+      <MeowdownEditor
+        handleRef={ref}
+        mode="hide"
+        initialMarkdown={markdown}
+        onLinkClick={onLinkClick}
+      />,
+    )
+
+    expect(ref.current?.getMarkdown()).toBe(`${markdown}\n`)
+    const links = pmRoot.getByRole('link')
+    await expect.element(links.first()).toHaveAttribute('href', 'docs/plan.md')
+    await links.first().click()
+    await vi.waitFor(() => {
+      expect(onLinkClick).toHaveBeenCalledWith(expect.objectContaining({ href: 'docs/plan.md' }))
+    })
+  })
+
+  it('renders a reference image from its resolved definition destination', async () => {
+    const onImageClick = vi.fn()
+    const markdown = '![Preview][asset]\n\n[asset]: assets/preview.png "Preview image"'
+    await render(
+      <MeowdownEditor
+        mode="hide"
+        initialMarkdown={markdown}
+        resolveImageUrl={(src) => `asset://${src}`}
+        onImageClick={onImageClick}
+      />,
+    )
+
+    const image = page.getByAltText('Preview')
+    await expect.element(image).toHaveAttribute('src', 'asset://assets/preview.png')
+    await image.click()
+    expect(onImageClick).toHaveBeenCalledWith(
+      expect.objectContaining({ src: 'assets/preview.png', alt: 'Preview' }),
+    )
+  })
+
   it('calls onTagClick when a rendered tag is clicked', async () => {
     const onTagClick = vi.fn()
     const screen = await render(

--- a/packages/react/src/components/editor.test.tsx
+++ b/packages/react/src/components/editor.test.tsx
@@ -469,6 +469,24 @@ describe('MeowdownEditor', () => {
     expect(editor.state.selection.$from.parent.textContent).toBe('**Target Heading**')
   })
 
+  it('reveals GitHub-style heading slugs, including duplicate suffixes', async () => {
+    const ref = createRef<EditorHandle>()
+    await render(
+      <MeowdownEditor
+        handleRef={ref}
+        initialMarkdown={'## Target Heading!\n\nBody\n\n## Target Heading!'}
+      />,
+    )
+
+    expect(ref.current?.revealHeading('#target-heading-1')).toBe(true)
+    const editor = ref.current?.editor
+    if (!editor) throw new Error('editor not mounted')
+    expect(editor.state.selection.$from.parent.type.name).toBe('heading')
+    expect(editor.state.selection.$from.before()).toBe(
+      editor.state.doc.child(0).nodeSize + editor.state.doc.child(1).nodeSize,
+    )
+  })
+
   it('reports a missing heading without moving the selection', async () => {
     const ref = createRef<EditorHandle>()
     await render(<MeowdownEditor handleRef={ref} initialMarkdown={'# First\n\nBody'} />)

--- a/packages/react/src/components/link-menu.test.tsx
+++ b/packages/react/src/components/link-menu.test.tsx
@@ -133,4 +133,16 @@ describe('LinkMenu', () => {
     await expect.element(pmRoot.getByText('https://new.test')).toBeInTheDocument()
     expect(ref.current?.getMarkdown()).toContain('[Docs](https://new.test)')
   })
+
+  it('does not offer destructive edits for reference links', async () => {
+    const screen = await render(
+      <MeowdownEditor initialMarkdown={'[Docs][doc]\n\n[doc]: https://example.com'} />,
+    )
+    await screen.getByText('Docs').hover()
+    await expect.element(popover.getByTestId('link-popover-read')).toBeVisible()
+    await expect.element(popover.getByRole('button', { name: 'Edit link' })).not.toBeInTheDocument()
+    await expect
+      .element(popover.getByRole('button', { name: 'Remove link' }))
+      .not.toBeInTheDocument()
+  })
 })

--- a/packages/react/src/components/link-menu.tsx
+++ b/packages/react/src/components/link-menu.tsx
@@ -86,8 +86,8 @@ function LinkInfoContent({
   href: string
   onLinkClick?: LinkClickHandler
   onLinkCopy?: LinkCopyHandler
-  onEdit: () => void
-  onRemove: () => void
+  onEdit?: () => void
+  onRemove?: () => void
 }) {
   return (
     <div className={styles.Row} data-testid="link-popover-read">
@@ -111,24 +111,28 @@ function LinkInfoContent({
         className={styles.Button}
         onCopy={() => onLinkCopy?.({ href })}
       />
-      <button
-        type="button"
-        className={styles.Button}
-        title="Edit link"
-        aria-label="Edit link"
-        onClick={onEdit}
-      >
-        <PencilIcon />
-      </button>
-      <button
-        type="button"
-        className={styles.Button}
-        title="Remove link"
-        aria-label="Remove link"
-        onClick={onRemove}
-      >
-        <UnlinkIcon />
-      </button>
+      {onEdit && (
+        <button
+          type="button"
+          className={styles.Button}
+          title="Edit link"
+          aria-label="Edit link"
+          onClick={onEdit}
+        >
+          <PencilIcon />
+        </button>
+      )}
+      {onRemove && (
+        <button
+          type="button"
+          className={styles.Button}
+          title="Remove link"
+          aria-label="Remove link"
+          onClick={onRemove}
+        >
+          <UnlinkIcon />
+        </button>
+      )}
     </div>
   )
 }
@@ -285,16 +289,24 @@ export function LinkMenu({ onLinkClick, onLinkCopy }: LinkMenuProps) {
           href={link.href}
           onLinkClick={onLinkClick}
           onLinkCopy={onLinkCopy}
-          onEdit={() => {
-            selectLinkUnit(editor, link)
-            setEdit({ from: link.unit.from, to: link.unit.to, link })
-            closeHover()
-          }}
-          onRemove={() => {
-            selectLinkUnit(editor, link)
-            editor.commands.removeLink()
-            closeHover()
-          }}
+          onEdit={
+            link.label && link.dest
+              ? () => {
+                  selectLinkUnit(editor, link)
+                  setEdit({ from: link.unit.from, to: link.unit.to, link })
+                  closeHover()
+                }
+              : undefined
+          }
+          onRemove={
+            link.label && link.dest
+              ? () => {
+                  selectLinkUnit(editor, link)
+                  editor.commands.removeLink()
+                  closeHover()
+                }
+              : undefined
+          }
         />
       </LinkPopover>
     )

--- a/packages/react/src/components/markdown-view.test.tsx
+++ b/packages/react/src/components/markdown-view.test.tsx
@@ -69,6 +69,42 @@ describe('MarkdownView', () => {
     })
     await links.first().click()
     expect(onLinkClick).toHaveBeenCalledWith(expect.objectContaining({ href: 'docs/plan.md' }))
+    await expect.element(view).not.toHaveTextContent('[doc]:')
+    await expect.element(view).not.toHaveTextContent('Plan title')
+  })
+
+  it('hides nested reference definitions but keeps their rendered links', async () => {
+    await renderView('> Read [Docs][doc].\n>\n> [doc]: /docs\n\n- [item]: /item\n\n[Item][item]')
+
+    expect(view.element().querySelectorAll('a')).toHaveLength(2)
+    await expect.element(view).not.toHaveTextContent('[doc]:')
+    await expect.element(view).not.toHaveTextContent('[item]:')
+  })
+
+  it('does not collect definition-shaped headings, table cells, or tasks', async () => {
+    await renderView(
+      '# [heading]: /heading\n\n| Cell |\n| --- |\n| [table]: /table |\n\n- [ ] [task]: /task\n\n[heading] [table] [task]',
+    )
+
+    expect(view.element().querySelectorAll('a')).toHaveLength(0)
+    await expect.element(view).toHaveTextContent('[heading]: /heading')
+    await expect.element(view).toHaveTextContent('[table]: /table')
+    await expect.element(view).toHaveTextContent('[task]: /task')
+  })
+
+  it('accepts and hides a definition after a task item body', async () => {
+    await renderView('- [ ] task body\n\n  [nested]: /nested\n\n[Docs][nested]')
+
+    expect(view.element().querySelectorAll('a')).toHaveLength(1)
+    await expect.element(view).not.toHaveTextContent('[nested]:')
+  })
+
+  it('links definition-shaped heading text through a real definition', async () => {
+    await renderView('[doc]: /real\n\n# [doc]: /other')
+
+    const link = view.locate('h1 a')
+    await expect.element(link).toHaveAttribute('href', '/real')
+    await expect.element(view).not.toHaveTextContent('[doc]: /real')
   })
 
   it('renders a reference image using its definition destination', async () => {

--- a/packages/react/src/components/markdown-view.test.tsx
+++ b/packages/react/src/components/markdown-view.test.tsx
@@ -54,6 +54,49 @@ describe('MarkdownView', () => {
     await expect.element(img).toHaveAttribute('alt', 'cat')
   })
 
+  it('resolves and activates full, collapsed, and shortcut reference links', async () => {
+    const onLinkClick = vi.fn()
+    await renderView('[Full][doc], [doc][], [DOC].\n\n[doc]: docs/plan.md "Plan title"', {
+      onLinkClick,
+    })
+
+    const links = view.locate('a')
+    expect(view.element().querySelectorAll('a')).toHaveLength(3)
+    await expect.element(links.first()).toHaveAttribute('href', 'docs/plan.md')
+    view.element().addEventListener('click', (event) => event.preventDefault(), {
+      capture: true,
+      once: true,
+    })
+    await links.first().click()
+    expect(onLinkClick).toHaveBeenCalledWith(expect.objectContaining({ href: 'docs/plan.md' }))
+  })
+
+  it('renders a reference image using its definition destination', async () => {
+    const resolveImageUrl = vi.fn((src: string) => `asset://${src}`)
+    await renderView('![Preview][asset]\n\n[asset]: assets/preview.png "Preview image"', {
+      resolveImageUrl,
+    })
+
+    const image = view.getByTestId('image-preview').locate('img')
+    await expect.element(image).toHaveAttribute('src', 'asset://assets/preview.png')
+    await expect.element(image).toHaveAttribute('alt', 'Preview')
+    expect(resolveImageUrl).toHaveBeenCalledWith('assets/preview.png')
+  })
+
+  it('passes a resolved reference href to the file resolver', async () => {
+    const resolveFileLink = vi.fn(() => true)
+    await renderView('[Quarterly][report]\n\n[report]: docs/report.pdf "Q3"', {
+      resolveFileLink,
+    })
+
+    await expect.element(view.getByTestId('file-pill')).toHaveTextContent('Quarterly')
+    expect(resolveFileLink).toHaveBeenCalledWith({
+      href: 'docs/report.pdf',
+      label: 'Quarterly',
+      title: 'Q3',
+    })
+  })
+
   it('renders a resolved wiki image with its alias and width', async () => {
     await renderView('![[assets/cat.png|120]]', {
       resolveWikiEmbed: () => ({ kind: 'image' }),

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -1,5 +1,6 @@
 import {
   defaultResolveImageUrl,
+  collectReferenceDefinitions,
   formatFileSize,
   getFileKind,
   getCodeTokens,
@@ -27,6 +28,7 @@ import {
   type MdWikilinkAttrs,
   type MeowdownListAttrs,
   type NodeName,
+  type ReferenceDefinitions,
   type WikiEmbedResolver,
   type WikilinkClickHandler,
 } from '@meowdown/core'
@@ -129,6 +131,7 @@ interface RenderContext {
   resolveFileLink?: FileLinkResolver
   resolveWikiEmbed?: WikiEmbedResolver
   resolveFileInfo?: FileInfoResolver
+  referenceDefinitions: ReferenceDefinitions
   onWikilinkClick?: WikilinkClickHandler
   onLinkClick?: LinkClickHandler
   onImageClick?: ImageClickHandler
@@ -540,10 +543,17 @@ function renderRuns(
 function renderInline(node: ProseMirrorNode, context: RenderContext): ReactNode {
   const text = node.textContent
   if (!text) return null
-  const chunks: readonly MarkChunk[] = inlineTextToMarkChunks(getMarkBuilders(), text, {
-    resolveFileLink: context.resolveFileLink,
-    resolveWikiEmbed: context.resolveWikiEmbed,
-  })
+  const chunks: readonly MarkChunk[] = inlineTextToMarkChunks(
+    getMarkBuilders(),
+    text,
+    {
+      resolveFileLink: context.resolveFileLink,
+      resolveWikiEmbed: context.resolveWikiEmbed,
+    },
+    {
+      referenceDefinitions: context.referenceDefinitions,
+    },
+  )
   // Sort each chunk's marks into ProseMirror's canonical order so the grouping
   // and nesting match the editor.
   const runs = chunks.map(
@@ -648,12 +658,14 @@ export function MarkdownView({
 }: MarkdownViewProps): ReactElement {
   const content = useMemo(() => {
     const doc = markdownToDoc(markdown, { frontmatter })
+    const { definitions: referenceDefinitions } = collectReferenceDefinitions(doc)
     const context: RenderContext = {
       interactive,
       resolveImageUrl,
       resolveFileLink,
       resolveWikiEmbed,
       resolveFileInfo,
+      referenceDefinitions,
       onWikilinkClick: interactive ? onWikilinkClick : undefined,
       onLinkClick: interactive ? onLinkClick : undefined,
       onImageClick: interactive ? onImageClick : undefined,

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -132,6 +132,7 @@ interface RenderContext {
   resolveWikiEmbed?: WikiEmbedResolver
   resolveFileInfo?: FileInfoResolver
   referenceDefinitions: ReferenceDefinitions
+  referenceDefinitionNodes: ReadonlySet<ProseMirrorNode>
   onWikilinkClick?: WikilinkClickHandler
   onLinkClick?: LinkClickHandler
   onImageClick?: ImageClickHandler
@@ -543,17 +544,12 @@ function renderRuns(
 function renderInline(node: ProseMirrorNode, context: RenderContext): ReactNode {
   const text = node.textContent
   if (!text) return null
-  const chunks: readonly MarkChunk[] = inlineTextToMarkChunks(
-    getMarkBuilders(),
-    text,
-    {
-      resolveFileLink: context.resolveFileLink,
-      resolveWikiEmbed: context.resolveWikiEmbed,
-    },
-    {
-      referenceDefinitions: context.referenceDefinitions,
-    },
-  )
+  const chunks: readonly MarkChunk[] = inlineTextToMarkChunks(getMarkBuilders(), text, {
+    resolveFileLink: context.resolveFileLink,
+    resolveWikiEmbed: context.resolveWikiEmbed,
+    referenceDefinitions: context.referenceDefinitions,
+    isReferenceDefinition: context.referenceDefinitionNodes.has(node),
+  })
   // Sort each chunk's marks into ProseMirror's canonical order so the grouping
   // and nesting match the editor.
   const runs = chunks.map(
@@ -597,6 +593,8 @@ function renderBlock(node: ProseMirrorNode, context: RenderContext): ReactNode {
     }
     return <CodeBlock key={key} code={node.textContent} language={language} />
   }
+
+  if (context.referenceDefinitionNodes.has(node)) return null
 
   const toDOM = node.type.spec.toDOM
   if (node.isTextblock) {
@@ -658,7 +656,8 @@ export function MarkdownView({
 }: MarkdownViewProps): ReactElement {
   const content = useMemo(() => {
     const doc = markdownToDoc(markdown, { frontmatter })
-    const { definitions: referenceDefinitions } = collectReferenceDefinitions(doc)
+    const referenceIndex = collectReferenceDefinitions(doc)
+    const referenceDefinitions = referenceIndex.definitions
     const context: RenderContext = {
       interactive,
       resolveImageUrl,
@@ -666,6 +665,7 @@ export function MarkdownView({
       resolveWikiEmbed,
       resolveFileInfo,
       referenceDefinitions,
+      referenceDefinitionNodes: referenceIndex.nodes,
       onWikilinkClick: interactive ? onWikilinkClick : undefined,
       onLinkClick: interactive ? onLinkClick : undefined,
       onImageClick: interactive ? onImageClick : undefined,

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -28,6 +28,7 @@ import type { EditorNode, Mark } from '@prosekit/pm/model'
 import { Selection, TextSelection } from '@prosekit/pm/state'
 import { ProseKit } from '@prosekit/react'
 import { clsx } from 'clsx/lite'
+import GithubSlugger from 'github-slugger'
 import {
   useCallback,
   useImperativeHandle,
@@ -161,15 +162,21 @@ function headingDisplayText(heading: EditorNode): string {
 }
 
 function findHeadingPosition(doc: EditorNode, fragment: string): number | undefined {
-  const target = headingLookupKey(decodeHeadingFragment(fragment))
+  const decodedTarget = decodeHeadingFragment(fragment)
+  const target = headingLookupKey(decodedTarget)
   if (!target) return
+  const slugTarget = decodedTarget.normalize('NFKC').toLowerCase()
+  const slugger = new GithubSlugger()
   let match: number | undefined
   doc.descendants((node, pos) => {
     if (match != null) return false
+    if (node.type.name !== 'heading') return true
+    const displayText = headingDisplayText(node)
+    const slug = slugger.slug(displayText)
     if (
-      node.type.name === 'heading' &&
-      (headingLookupKey(node.textContent) === target ||
-        headingLookupKey(headingDisplayText(node)) === target)
+      headingLookupKey(node.textContent) === target ||
+      headingLookupKey(displayText) === target ||
+      slug === slugTarget
     ) {
       match = pos + 1
       return false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      github-slugger:
+        specifier: ^2.0.0
+        version: 2.0.0
       lucide-react:
         specifier: ^1.24.0
         version: 1.24.0(react@19.2.7)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,12 @@ importers:
       katex:
         specifier: ^0.17.0
         version: 0.17.0
+      micromark-util-decode-string:
+        specifier: ^2.0.1
+        version: 2.0.1
+      micromark-util-normalize-identifier:
+        specifier: ^2.0.1
+        version: 2.0.1
       prosemirror-flat-list:
         specifier: ^0.7.1
         version: 0.7.1


### PR DESCRIPTION
## Summary

- resolve CommonMark full, collapsed, and shortcut reference links and images with first-definition-wins semantics
- pass resolved destinations through live editor marks, static rendering, file/image resolvers, and click handling
- preserve literal source and reference definitions while refreshing dependent marks when definitions change

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- 421 focused converter, parser, editor, and static-view tests