### PR TITLE
feat(core): add `getTextblockDisplayText`

### DIFF
--- a/packages/core/src/extensions/clipboard/plain-text.ts
+++ b/packages/core/src/extensions/clipboard/plain-text.ts
@@ -5,10 +5,9 @@ import { Plugin, PluginKey } from '@prosekit/pm/state'
 
 import { docToMarkdown } from '../../converters/pm-to-md.ts'
 import type { MdWikilinkAttrs } from '../inline-marks.ts'
+import { groupInlineRuns, hasSyntaxMark } from '../inline-runs.ts'
 import { getMarkMode } from '../mark-mode.ts'
 import type { MarkName } from '../mark-names.ts'
-
-import { groupInlineRuns, hasSyntaxMark } from './semantic-inline.ts'
 
 /**
  * Serialize a slice to Markdown. The copied fragment is wrapped in a `doc` so

--- a/packages/core/src/extensions/clipboard/semantic-inline.ts
+++ b/packages/core/src/extensions/clipboard/semantic-inline.ts
@@ -8,22 +8,7 @@ import type {
   MdLinkTextAttrs,
   MdWikilinkAttrs,
 } from '../inline-marks.ts'
-import type { MarkName } from '../mark-names.ts'
-
-/** Syntax characters, dropped from the semantic clipboard HTML. */
-const SYNTAX_MARK_NAMES: ReadonlySet<string> = new Set<MarkName>([
-  'mdMark',
-  'mdLinkUri',
-  'mdLinkTitle',
-])
-
-/** Marks covering a whole source unit, emitted as one replacement per unit. */
-const ATOM_MARK_NAMES: ReadonlySet<string> = new Set<MarkName>([
-  'mdImage',
-  'mdWikilink',
-  'mdMath',
-  'mdFile',
-])
+import { ATOM_MARK_NAMES, SYNTAX_MARK_NAMES, type MarkName } from '../mark-names.ts'
 
 const SEMANTIC_TAGS: Partial<Record<MarkName, string>> = {
   mdStrong: 'strong',

--- a/packages/core/src/extensions/clipboard/semantic-inline.ts
+++ b/packages/core/src/extensions/clipboard/semantic-inline.ts
@@ -8,7 +8,8 @@ import type {
   MdLinkTextAttrs,
   MdWikilinkAttrs,
 } from '../inline-marks.ts'
-import { ATOM_MARK_NAMES, SYNTAX_MARK_NAMES, type MarkName } from '../mark-names.ts'
+import { groupInlineRuns, hasSyntaxMark } from '../inline-runs.ts'
+import type { MarkName } from '../mark-names.ts'
 
 const SEMANTIC_TAGS: Partial<Record<MarkName, string>> = {
   mdStrong: 'strong',
@@ -17,41 +18,6 @@ const SEMANTIC_TAGS: Partial<Record<MarkName, string>> = {
   mdDel: 'del',
   mdHighlight: 'mark',
   mdLinkText: 'a',
-}
-
-function findAtomMark(marks: readonly Mark[]): Mark | undefined {
-  return marks.find((mark) => ATOM_MARK_NAMES.has(mark.type.name))
-}
-
-export function hasSyntaxMark(marks: readonly Mark[]): boolean {
-  return marks.some((mark) => SYNTAX_MARK_NAMES.has(mark.type.name))
-}
-
-export interface InlineRun {
-  atom: Mark | undefined
-  text: string
-  children: ProseMirrorNode[]
-}
-
-/**
- * Group a textblock's text nodes into atom units and plain runs. A unit's
- * text nodes share one mark instance (the inline parser creates each unit
- * mark once), so instance identity splits adjacent same-attrs units.
- */
-export function groupInlineRuns(textblock: ProseMirrorNode): InlineRun[] {
-  const runs: InlineRun[] = []
-  textblock.forEach((child) => {
-    if (!child.isText || !child.text) return
-    const atom = findAtomMark(child.marks)
-    const last = runs.at(-1)
-    if (atom != null && last != null && last.atom === atom) {
-      last.text += child.text
-      last.children.push(child)
-      return
-    }
-    runs.push({ atom, text: child.text, children: [child] })
-  })
-  return runs
 }
 
 /**

--- a/packages/core/src/extensions/hidden-run.ts
+++ b/packages/core/src/extensions/hidden-run.ts
@@ -2,17 +2,7 @@ import { getMarkType } from '@prosekit/core'
 import type { Mark } from '@prosekit/pm/model'
 import type { EditorState } from '@prosekit/pm/state'
 
-import type { MarkName } from './mark-names.ts'
-
-// The marks whose text hide mode renders at font-size 0. Mirrors the CSS rules
-// in style.css and CLIPBOARD_STRIP_MARK_NAMES in mark-mode.ts. Atom sources
-// (mdImage / mdWikilink / mdFile) are not here: defineAtomMarkNavigation owns
-// them.
-const HIDDEN_MARK_NAMES: ReadonlySet<MarkName> = new Set<MarkName>([
-  'mdMark',
-  'mdLinkUri',
-  'mdLinkTitle',
-])
+import { SYNTAX_MARK_NAMES, type MarkName } from './mark-names.ts'
 
 export interface HiddenRun {
   from: number
@@ -32,7 +22,7 @@ function getCharMarks(state: EditorState, pos: number): readonly Mark[] | undefi
 export function isHiddenChar(state: EditorState, pos: number): boolean {
   const marks = getCharMarks(state, pos)
   if (marks == null) return false
-  return marks.some((mark) => HIDDEN_MARK_NAMES.has(mark.type.name as MarkName))
+  return marks.some((mark) => SYNTAX_MARK_NAMES.has(mark.type.name))
 }
 
 function isInsideNonCodeTextblock(state: EditorState, pos: number): boolean {

--- a/packages/core/src/extensions/inline-runs.ts
+++ b/packages/core/src/extensions/inline-runs.ts
@@ -1,0 +1,38 @@
+import type { Mark, ProseMirrorNode } from '@prosekit/pm/model'
+
+import { ATOM_MARK_NAMES, SYNTAX_MARK_NAMES } from './mark-names.ts'
+
+function findAtomMark(marks: readonly Mark[]): Mark | undefined {
+  return marks.find((mark) => ATOM_MARK_NAMES.has(mark.type.name))
+}
+
+export function hasSyntaxMark(marks: readonly Mark[]): boolean {
+  return marks.some((mark) => SYNTAX_MARK_NAMES.has(mark.type.name))
+}
+
+export interface InlineRun {
+  atom: Mark | undefined
+  text: string
+  children: ProseMirrorNode[]
+}
+
+/**
+ * Group a textblock's text nodes into atom units and plain runs. A unit's
+ * text nodes share one mark instance (the inline parser creates each unit
+ * mark once), so instance identity splits adjacent same-attrs units.
+ */
+export function groupInlineRuns(textblock: ProseMirrorNode): InlineRun[] {
+  const runs: InlineRun[] = []
+  textblock.forEach((child) => {
+    if (!child.isText || !child.text) return
+    const atom = findAtomMark(child.marks)
+    const last = runs.at(-1)
+    if (atom != null && last != null && last.atom === atom) {
+      last.text += child.text
+      last.children.push(child)
+      return
+    }
+    runs.push({ atom, text: child.text, children: [child] })
+  })
+  return runs
+}

--- a/packages/core/src/extensions/mark-names.ts
+++ b/packages/core/src/extensions/mark-names.ts
@@ -17,3 +17,22 @@ export const MARK_NAMES = [
 ] as const
 
 export type MarkName = (typeof MARK_NAMES)[number]
+
+// Marks whose text is Markdown syntax rather than content. Hide mode renders
+// these runs at font-size 0 (mirroring the CSS rules in style.css), and text
+// projections drop them.
+export const SYNTAX_MARK_NAMES: ReadonlySet<string> = new Set<MarkName>([
+  'mdMark',
+  'mdLinkUri',
+  'mdLinkTitle',
+])
+
+// Marks covering a whole source unit, emitted as one replacement per unit by
+// text projections. The subset whose mark views hide the raw source behind a
+// preview lives in ATOM_SOURCE_MARK_NAMES in atom-mark-navigation.ts.
+export const ATOM_MARK_NAMES: ReadonlySet<string> = new Set<MarkName>([
+  'mdWikilink',
+  'mdImage',
+  'mdFile',
+  'mdMath',
+])

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -147,6 +147,7 @@ export {
 } from './extensions/wikilink-hover.ts'
 export { defineWikilinkTrigger } from './extensions/wikilink-trigger.ts'
 export type { PositionRange } from './utils/range.ts'
+export { getTextblockDisplayText } from './utils/display-text.ts'
 export { getSelectedText } from './utils/selected-text.ts'
 export { getVirtualElementFromRange, type VirtualElement } from './utils/virtual-element.ts'
 export { defineSpellCheckPlugin } from './extensions/spell-check.ts'

--- a/packages/core/src/utils/clean-text.ts
+++ b/packages/core/src/utils/clean-text.ts
@@ -1,12 +1,6 @@
 import type { Slice } from '@prosekit/pm/model'
 
-import type { MarkName } from '../extensions/mark-names.ts'
-
-const CLEAN_TEXT_STRIP_MARK_NAMES: ReadonlySet<MarkName> = new Set<MarkName>([
-  'mdMark',
-  'mdLinkUri',
-  'mdLinkTitle',
-])
+import { SYNTAX_MARK_NAMES, type MarkName } from '../extensions/mark-names.ts'
 
 interface CleanTextOptions {
   /** Keep math delimiters so the projected text remains valid Markdown. */
@@ -26,7 +20,7 @@ export function cleanTextFromSlice(slice: Slice, options: CleanTextOptions = {})
       if (!textNode.isText || !textNode.text) return true
       const textNodeMarks = textNode.marks.map((mark) => mark.type.name as MarkName)
       const stripped =
-        textNodeMarks.some((markName) => CLEAN_TEXT_STRIP_MARK_NAMES.has(markName)) &&
+        textNodeMarks.some((markName) => SYNTAX_MARK_NAMES.has(markName)) &&
         !(options.preserveMathSource && textNodeMarks.includes('mdMath'))
       if (!stripped) parts.push(textNode.text)
       return false

--- a/packages/core/src/utils/display-text.test.ts
+++ b/packages/core/src/utils/display-text.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { setupFixture } from '../testing/index.ts'
+
+import { getTextblockDisplayText } from './display-text.ts'
+
+describe('getTextblockDisplayText', () => {
+  it('keeps plain text and drops inline syntax runs', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.heading({ level: 2 }, 'Hello **bold** and [label](https://example.com)')))
+    expect(getTextblockDisplayText(fixture.doc.child(0))).toBe('Hello bold and label')
+  })
+
+  it('replaces a wikilink with its display text, falling back to the target', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.heading({ level: 1 }, 'see [[target|shown]] and [[bare]]')))
+    expect(getTextblockDisplayText(fixture.doc.child(0))).toBe('see shown and bare')
+  })
+
+  it('replaces an image with its alt text and math with its formula', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.heading({ level: 1 }, '![pic](a.png) equals $x+y$')))
+    expect(getTextblockDisplayText(fixture.doc.child(0))).toBe('pic equals x+y')
+  })
+
+  it('replaces a file pill with its name', () => {
+    using fixture = setupFixture({ extensionOptions: { resolveFileLink: () => true } })
+    const { n } = fixture
+    fixture.set(n.doc(n.heading({ level: 1 }, 'read [report.pdf](files/report.pdf)')))
+    expect(getTextblockDisplayText(fixture.doc.child(0))).toBe('read report.pdf')
+  })
+
+  it('cannot split adjacent identical atoms', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    // Adjacent same-attrs units merge into one text node carrying one mark
+    // instance, so the document cannot tell the two units apart.
+    fixture.set(n.doc(n.heading({ level: 1 }, '[[a]][[a]]')))
+    expect(getTextblockDisplayText(fixture.doc.child(0))).toBe('a')
+  })
+})

--- a/packages/core/src/utils/display-text.ts
+++ b/packages/core/src/utils/display-text.ts
@@ -1,0 +1,45 @@
+import type { Mark, ProseMirrorNode } from '@prosekit/pm/model'
+
+import type {
+  MdFileAttrs,
+  MdImageAttrs,
+  MdMathAttrs,
+  MdWikilinkAttrs,
+} from '../extensions/inline-marks.ts'
+import { groupInlineRuns, hasSyntaxMark } from '../extensions/inline-runs.ts'
+import type { MarkName } from '../extensions/mark-names.ts'
+
+function getAtomDisplayText(atom: Mark): string {
+  switch (atom.type.name as MarkName) {
+    case 'mdWikilink': {
+      const attrs = atom.attrs as MdWikilinkAttrs
+      return attrs.display || attrs.target
+    }
+    case 'mdImage':
+      return (atom.attrs as MdImageAttrs).alt
+    case 'mdFile':
+      return (atom.attrs as MdFileAttrs).name
+    case 'mdMath':
+      return (atom.attrs as MdMathAttrs).formula
+    default:
+      return ''
+  }
+}
+
+/**
+ * The textblock as its live-preview marks display it: syntax runs are
+ * omitted and each atom unit is replaced by its display text.
+ */
+export function getTextblockDisplayText(textblock: ProseMirrorNode): string {
+  let output = ''
+  for (const run of groupInlineRuns(textblock)) {
+    if (run.atom != null) {
+      output += getAtomDisplayText(run.atom)
+      continue
+    }
+    for (const child of run.children) {
+      if (!hasSyntaxMark(child.marks)) output += child.text ?? ''
+    }
+  }
+  return output
+}

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -2,6 +2,7 @@ import {
   defineEditorExtension,
   docToMarkdown,
   getSelectedText,
+  getTextblockDisplayText,
   markdownToDoc,
   type AcceptPendingReplacementOptions,
   type EditorExtension,
@@ -24,7 +25,7 @@ import {
 } from '@meowdown/core'
 import { clamp } from '@ocavue/utils'
 import { createEditor, union, type SelectionJSON } from '@prosekit/core'
-import type { EditorNode, Mark } from '@prosekit/pm/model'
+import type { EditorNode } from '@prosekit/pm/model'
 import { Selection, TextSelection } from '@prosekit/pm/state'
 import { ProseKit } from '@prosekit/react'
 import { clsx } from 'clsx/lite'
@@ -124,43 +125,6 @@ function headingLookupKey(value: string): string {
   return value.normalize('NFKC').trim().replaceAll(/\s+/g, ' ').toLowerCase()
 }
 
-const HEADING_HIDDEN_MARKS = new Set(['mdMark', 'mdLinkUri', 'mdLinkTitle'])
-const HEADING_ATOM_MARKS = new Set(['mdWikilink', 'mdImage', 'mdFile', 'mdMath'])
-
-function headingAtomText(mark: Mark): string {
-  const attrs = mark.attrs as Readonly<Record<string, unknown>>
-  const stringAttr = (name: string): string => {
-    const value = attrs[name]
-    return typeof value === 'string' ? value : ''
-  }
-  if (mark.type.name === 'mdWikilink') {
-    return stringAttr('display') || stringAttr('target')
-  }
-  if (mark.type.name === 'mdImage') return stringAttr('alt')
-  if (mark.type.name === 'mdFile') return stringAttr('name')
-  if (mark.type.name === 'mdMath') return stringAttr('formula')
-  return ''
-}
-
-/** The heading as its live-preview marks display it, with syntax runs omitted. */
-function headingDisplayText(heading: EditorNode): string {
-  let output = ''
-  let previousAtom: Mark | undefined
-  heading.forEach((child) => {
-    if (!child.isText || !child.text) return
-    const atom = child.marks.find((mark) => HEADING_ATOM_MARKS.has(mark.type.name))
-    if (atom) {
-      if (!previousAtom?.eq(atom)) output += headingAtomText(atom)
-      previousAtom = atom
-      return
-    }
-    previousAtom = undefined
-    if (child.marks.some((mark) => HEADING_HIDDEN_MARKS.has(mark.type.name))) return
-    output += child.text
-  })
-  return output
-}
-
 function findHeadingPosition(doc: EditorNode, fragment: string): number | undefined {
   const decodedTarget = decodeHeadingFragment(fragment)
   const target = headingLookupKey(decodedTarget)
@@ -171,7 +135,7 @@ function findHeadingPosition(doc: EditorNode, fragment: string): number | undefi
   doc.descendants((node, pos) => {
     if (match != null) return false
     if (node.type.name !== 'heading') return true
-    const displayText = headingDisplayText(node)
+    const displayText = getTextblockDisplayText(node)
     const slug = slugger.slug(displayText)
     if (
       headingLookupKey(node.textContent) === target ||


### PR DESCRIPTION
Extract the heading display-text projection from `@meowdown/react` into a shared `getTextblockDisplayText` util in `@meowdown/core`, deduplicating the `SYNTAX_MARK_NAMES` / `ATOM_MARK_NAMES` sets that were defined in four places.