### PR TITLE
feat(react): add `caretGlide` prop

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -56,6 +56,8 @@ See the full API reference [here](https://npmx.dev/package-docs/@meowdown%2Freac
 
 Slash menu host items can include `keywords` to match hidden terms without changing the displayed label.
 
+The caret glides between positions by default; pass `caretGlide={false}` to move it instantly (hosts can also tune the duration via the `--meowdown-caret-glide` CSS variable).
+
 ### Wiki embeds
 
 Obsidian-style wiki embeds (`![[path]]`, with optional `|width` or

--- a/packages/react/src/components/editor.test.tsx
+++ b/packages/react/src/components/editor.test.tsx
@@ -314,6 +314,22 @@ describe('MeowdownEditor', () => {
     await expect.element(page.locate('.test-wrap')).toBeInTheDocument()
   })
 
+  // The test browser forces `prefers-reduced-motion: reduce`, which zeroes the
+  // caret transition outright, so assert the `--meowdown-caret-glide` variable
+  // the transition reads instead of the transition itself.
+  it('disables the caret glide with caretGlide={false}', async () => {
+    const screen = await render(<MeowdownEditor initialMarkdown="Hi" />)
+    await pmRoot.click()
+    const caret = page.getByTestId('virtual-caret')
+    await expect.element(caret).toBeVisible()
+    const caretGlideValue = () =>
+      getComputedStyle(caret.element()).getPropertyValue('--meowdown-caret-glide')
+    expect(caretGlideValue()).toBe('80ms')
+
+    await screen.rerender(<MeowdownEditor initialMarkdown="Hi" caretGlide={false} />)
+    expect(caretGlideValue()).toBe('0ms')
+  })
+
   it('renders children inside the ProseKit context in rich modes', async () => {
     await render(
       <MeowdownEditor initialMarkdown="Hi">

--- a/packages/react/src/components/editor.tsx
+++ b/packages/react/src/components/editor.tsx
@@ -18,7 +18,7 @@ import type {
 } from '@meowdown/core'
 import type { SelectionJSON } from '@prosekit/core'
 import { clsx } from 'clsx/lite'
-import { useImperativeHandle, useRef, type ReactNode, type Ref } from 'react'
+import { useImperativeHandle, useRef, type CSSProperties, type ReactNode, type Ref } from 'react'
 
 import type { TimeFormat } from '../utils/date-format.ts'
 
@@ -35,6 +35,8 @@ import type {
 } from './types.ts'
 
 export type EditorMode = MarkMode
+
+const CARET_GLIDE_OFF = { '--meowdown-caret-glide': '0ms' } as CSSProperties
 
 export interface EditorProps {
   /**
@@ -249,6 +251,13 @@ export interface EditorProps {
   blockHandle?: boolean
 
   /**
+   * Glides the caret between positions instead of jumping instantly. On by
+   * default. Set to `false` to disable the movement animation; equivalent to
+   * setting the `--meowdown-caret-glide` CSS variable to `0ms`.
+   */
+  caretGlide?: boolean
+
+  /**
    * Placeholder text shown when the whole document is empty. A function
    * receives the editor state. Pass a stable function.
    */
@@ -312,6 +321,7 @@ export function MeowdownEditor({
   substitution = true,
   frontmatter = false,
   blockHandle = true,
+  caretGlide = true,
   placeholder,
   readOnly,
   spellCheck,
@@ -401,7 +411,10 @@ export function MeowdownEditor({
   }, [])
 
   return (
-    <div className={clsx('meowdown', wrapperClassName)}>
+    <div
+      className={clsx('meowdown', wrapperClassName)}
+      style={caretGlide ? undefined : CARET_GLIDE_OFF}
+    >
       <ProseKitEditor
         ref={childRef}
         markMode={mode}


### PR DESCRIPTION
Adds a `caretGlide` prop to `MeowdownEditor` (on by default): pass `caretGlide={false}` to disable the caret movement animation, implemented by setting `--meowdown-caret-glide: 0ms` on the wrapper.