### PR TITLE
refactor: ban `type.name` string comparisons

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,3 +1,4 @@
+import { meowdownConfig } from '@meowdown/eslint-rules'
 import { defineESLintConfig } from '@ocavue/eslint-config'
 
 export default defineESLintConfig(
@@ -12,4 +13,5 @@ export default defineESLintConfig(
   {
     ignores: ['**/*.module.d.css.ts'],
   },
+  meowdownConfig,
 )

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "postinstall": "simple-git-hooks"
   },
   "devDependencies": {
+    "@meowdown/eslint-rules": "workspace:*",
     "@ocavue/eslint-config": "^4.12.1",
     "@ocavue/tsconfig": "^0.7.1",
     "@types/node": "^24.0.0",

--- a/packages/core/src/converters/md-to-pm.test.ts
+++ b/packages/core/src/converters/md-to-pm.test.ts
@@ -1,6 +1,7 @@
 import dedent from 'dedent'
 import { describe, expect, it } from 'vitest'
 
+import { isNodeOfType } from '../extensions/node-names.ts'
 import type { MeowdownTableCellAttrs, TableColumnAlign } from '../extensions/table-column-align.ts'
 
 import { dedentContinuation, markdownToDoc, measureContentColumn, sliceColumn } from './md-to-pm.ts'
@@ -397,7 +398,7 @@ describe('markdownToDoc', () => {
     `
     const table = markdownToDoc(md).child(0)
     table.descendants((node) => {
-      if (node.type.name !== 'tableCell' && node.type.name !== 'tableHeaderCell') return true
+      if (!isNodeOfType(node, 'tableCell') && !isNodeOfType(node, 'tableHeaderCell')) return true
       expect(node.childCount).toBe(1)
       expect(node.child(0).type.name).toBe('paragraph')
       return false

--- a/packages/core/src/converters/pm-to-md.ts
+++ b/packages/core/src/converters/pm-to-md.ts
@@ -6,7 +6,7 @@ import type { MeowdownHeadingAttrs } from '../extensions/heading.ts'
 import type { MeowdownHorizontalRuleAttrs } from '../extensions/horizontal-rule.ts'
 import type { MeowdownHTMLCommentAttrs } from '../extensions/html-comment.ts'
 import type { MeowdownListAttrs } from '../extensions/list.ts'
-import type { NodeName } from '../extensions/node-names.ts'
+import { isNodeOfType, type NodeName } from '../extensions/node-names.ts'
 import type { MeowdownTableCellAttrs, TableColumnAlign } from '../extensions/table-column-align.ts'
 import { CHAR_BACKTICK, CHAR_TILDE } from '../unicode.ts'
 import { longestCharRun } from '../utils/backticks.ts'
@@ -289,14 +289,14 @@ function emitBlockChildren(node: ProseMirrorNode, out: MdOut, tightItem = false)
   let index = 0
   while (index < count) {
     const child = node.child(index)
-    if (child.type.name !== ('list' satisfies NodeName)) {
+    if (!isNodeOfType(child, 'list')) {
       if (tightItem && index > 0) out.suppressBlank()
       emit(child, out)
       index++
       continue
     }
     let runEnd = index + 1
-    while (runEnd < count && node.child(runEnd).type.name === ('list' satisfies NodeName)) runEnd++
+    while (runEnd < count && isNodeOfType(node.child(runEnd), 'list')) runEnd++
     const tightRun = isTightRun(node, index, runEnd)
     for (let item = index; item < runEnd; item++) {
       const isRunStart = item === index
@@ -472,7 +472,7 @@ function emitTable(node: ProseMirrorNode, out: MdOut): void {
     let isHeaderRow = false
     for (let c = 0; c < row.childCount; c++) {
       const cell = row.child(c)
-      if (cell.type.name === ('tableHeaderCell' satisfies NodeName)) isHeaderRow = true
+      if (isNodeOfType(cell, 'tableHeaderCell')) isHeaderRow = true
       cells.push(extractCellText(cell))
     }
     if (isHeaderRow && headerIdx < 0) headerIdx = r

--- a/packages/core/src/extensions/bullet-after-heading.test.ts
+++ b/packages/core/src/extensions/bullet-after-heading.test.ts
@@ -6,9 +6,10 @@ import { userEvent } from 'vitest/browser'
 import { setupFixture } from '../testing/index.ts'
 
 import { defineBulletAfterHeading } from './bullet-after-heading.ts'
+import { isNodeOfType } from './node-names.ts'
 
 function isBulletList(node: ProseMirrorNode): boolean {
-  return node.type.name === 'list' && node.attrs.kind === 'bullet'
+  return isNodeOfType(node, 'list') && node.attrs.kind === 'bullet'
 }
 
 describe('defineBulletAfterHeading', () => {

--- a/packages/core/src/extensions/bullet-after-heading.ts
+++ b/packages/core/src/extensions/bullet-after-heading.ts
@@ -8,7 +8,7 @@ import {
 import type { ListAttrs } from '@prosekit/extensions/list'
 import { TextSelection, type Command } from '@prosekit/pm/state'
 
-import type { NodeName } from './node-names.ts'
+import { isNodeOfType, type NodeName } from './node-names.ts'
 
 /**
  * Claim Enter only when the selection is an empty caret at the very end of the
@@ -22,7 +22,7 @@ const bulletAfterHeadingOnEnter: Command = (state, dispatch) => {
   if (!empty || $from.depth !== 1 || $from.index(0) !== 0) {
     return false
   }
-  if ($from.parent.type.name !== ('heading' satisfies NodeName)) {
+  if (!isNodeOfType($from.parent, 'heading')) {
     return false
   }
   // Only at the end of the heading's text; Enter elsewhere splits as usual.

--- a/packages/core/src/extensions/clipboard/plain-text.ts
+++ b/packages/core/src/extensions/clipboard/plain-text.ts
@@ -7,7 +7,7 @@ import { docToMarkdown } from '../../converters/pm-to-md.ts'
 import type { MdWikilinkAttrs } from '../inline-marks.ts'
 import { groupInlineRuns, hasSyntaxMark } from '../inline-runs.ts'
 import { getMarkMode } from '../mark-mode.ts'
-import type { MarkName } from '../mark-names.ts'
+import { isMarkOfType } from '../mark-names.ts'
 
 /**
  * Serialize a slice to Markdown. The copied fragment is wrapped in a `doc` so
@@ -76,7 +76,7 @@ function filterTextblock(textblock: ProseMirrorNode): ProseMirrorNode {
   for (const run of groupInlineRuns(textblock)) {
     const atom = run.atom
     if (atom != null) {
-      if (atom.type.name === ('mdWikilink' satisfies MarkName)) {
+      if (isMarkOfType(atom, 'mdWikilink')) {
         const attrs = atom.attrs as MdWikilinkAttrs
         const visible = attrs.display || attrs.target
         if (visible) parts.push(schema.text(visible))

--- a/packages/core/src/extensions/clipboard/semantic-inline.test.ts
+++ b/packages/core/src/extensions/clipboard/semantic-inline.test.ts
@@ -4,16 +4,16 @@ import { describe, expect, it } from 'vitest'
 import { markdownToDoc } from '../../converters/md-to-pm.ts'
 import { setupFixture, type Fixture } from '../../testing/index.ts'
 import { headingClipboardDOM } from '../heading.ts'
+import { isNodeOfType } from '../node-names.ts'
 import { paragraphClipboardDOM } from '../paragraph.ts'
 
 function firstTextblockDOM(fixture: Fixture, markdown: string): string {
   const { editor, view } = fixture
   fixture.set(markdownToDoc(markdown, { nodes: editor.nodes }))
   const textblock = view.state.doc.child(0)
-  const element =
-    textblock.type.name === 'heading'
-      ? headingClipboardDOM(textblock)
-      : paragraphClipboardDOM(textblock)
+  const element = isNodeOfType(textblock, 'heading')
+    ? headingClipboardDOM(textblock)
+    : paragraphClipboardDOM(textblock)
   return formatHTML(element.outerHTML)
 }
 

--- a/packages/core/src/extensions/clipboard/semantic-inline.ts
+++ b/packages/core/src/extensions/clipboard/semantic-inline.ts
@@ -9,7 +9,7 @@ import type {
   MdWikilinkAttrs,
 } from '../inline-marks.ts'
 import { groupInlineRuns, hasSyntaxMark } from '../inline-runs.ts'
-import type { MarkName } from '../mark-names.ts'
+import { isMarkOfType, type MarkName } from '../mark-names.ts'
 
 const SEMANTIC_TAGS: Partial<Record<MarkName, string>> = {
   mdStrong: 'strong',
@@ -94,7 +94,7 @@ function syncOpenWrappers(open: OpenWrapper[], next: readonly Mark[], out: HTMLE
   for (let index = common; index < next.length; index++) {
     const mark = next[index]
     const element = document.createElement(SEMANTIC_TAGS[mark.type.name as MarkName] ?? 'span')
-    if (mark.type.name === ('mdLinkText' satisfies MarkName)) {
+    if (isMarkOfType(mark, 'mdLinkText')) {
       element.setAttribute('href', (mark.attrs as MdLinkTextAttrs).href)
     }
     ;(open.at(-1)?.element ?? out).append(element)

--- a/packages/core/src/extensions/commands.ts
+++ b/packages/core/src/extensions/commands.ts
@@ -7,7 +7,7 @@ import { TextSelection, type Command } from '@prosekit/pm/state'
 
 import { markdownToDoc } from '../converters/md-to-pm.ts'
 
-import type { NodeName } from './node-names.ts'
+import { isNodeOfType, type NodeName } from './node-names.ts'
 import { getNodeBuildersForSchema } from './schema.ts'
 
 function selectText(anchor: number, head?: number): Command {
@@ -39,7 +39,7 @@ function insertMarkdown(markdown: string): Command {
     const content = markdownToDoc(markdown, { nodes }).content
     if (content.childCount === 0) return false
     const isSingleParagraph =
-      content.childCount === 1 && content.child(0).type.name === ('paragraph' satisfies NodeName)
+      content.childCount === 1 && isNodeOfType(content.child(0), 'paragraph')
     const slice = isSingleParagraph
       ? new Slice(content, 1, 1)
       : new Slice(content, 0, Slice.maxOpen(content).openEnd)

--- a/packages/core/src/extensions/get-link-unit-at.ts
+++ b/packages/core/src/extensions/get-link-unit-at.ts
@@ -4,7 +4,7 @@ import type { PositionRange } from '../utils/range.ts'
 
 import { getMarkRangeAt } from './get-mark-range-at.ts'
 import type { MdLinkTextAttrs, MdPackAttrs } from './inline-marks.ts'
-import type { MarkName } from './mark-names.ts'
+import { isMarkOfType, type MarkName } from './mark-names.ts'
 
 export interface LinkUnit {
   /** Whole `[text](url "title")` (or autolink) range */
@@ -42,7 +42,7 @@ function lastMarkRunIn(
 ): PositionRange | undefined {
   let found: PositionRange | undefined
   state.doc.nodesBetween(range.from, range.to, (node, nodePos) => {
-    if (node.isText && node.marks.some((mark) => mark.type.name === markName)) {
+    if (node.isText && node.marks.some((mark) => isMarkOfType(mark, markName))) {
       found = {
         from: Math.max(nodePos, range.from),
         to: Math.min(nodePos + node.nodeSize, range.to),

--- a/packages/core/src/extensions/heading.ts
+++ b/packages/core/src/extensions/heading.ts
@@ -22,7 +22,7 @@ import type { Command } from '@prosekit/pm/state'
 import { parsePositiveInteger } from '../utils/parse-integer.ts'
 
 import { createSourceTextRule, semanticTextblockDOM } from './clipboard/semantic-inline.ts'
-import type { NodeName } from './node-names.ts'
+import { isNodeOfType, type NodeName } from './node-names.ts'
 
 export interface MeowdownHeadingAttrs extends HeadingAttrs {
   /**
@@ -118,7 +118,7 @@ function toggleHeading(level: number): Command {
 
 const backspaceUnsetHeading: Command = (state, dispatch, view) => {
   const $pos = isAtBlockStart(state, view)
-  if ($pos?.parent.type.name === ('heading' satisfies NodeName)) {
+  if ($pos != null && isNodeOfType($pos.parent, 'heading')) {
     return unsetBlockType()(state, dispatch, view)
   }
   return false

--- a/packages/core/src/extensions/inline-mark-plugin.test.ts
+++ b/packages/core/src/extensions/inline-mark-plugin.test.ts
@@ -5,6 +5,7 @@ import { setupFixture } from '../testing/index.ts'
 import { marksAt } from '../testing/marks-at.ts'
 
 import { getCacheStats, resetCacheStats } from './inline-mark-plugin.ts'
+import { isMarkOfType } from './mark-names.ts'
 
 describe('inlineMarkPlugin', () => {
   it('applies mdStrong inside **bold**', () => {
@@ -101,7 +102,7 @@ describe('inlineMarkPlugin', () => {
 
     const pos = findText(fixture.doc, 'docs')
     const $pos = fixture.doc.resolve(pos + 1)
-    const linkText = $pos.marks().find((m) => m.type.name === 'mdLinkText')
+    const linkText = $pos.marks().find((m) => isMarkOfType(m, 'mdLinkText'))
     expect(linkText).toBeTruthy()
     expect(linkText!.attrs.href).toBe('http://x.test')
   })
@@ -114,7 +115,7 @@ describe('inlineMarkPlugin', () => {
 
     const pos = findText(fixture.doc, 'https://example.com')
     const $pos = fixture.doc.resolve(pos + 1)
-    const linkText = $pos.marks().find((m) => m.type.name === 'mdLinkText')
+    const linkText = $pos.marks().find((m) => isMarkOfType(m, 'mdLinkText'))
     expect(linkText).toBeTruthy()
     expect(linkText!.attrs.href).toBe('https://example.com')
   })
@@ -127,7 +128,7 @@ describe('inlineMarkPlugin', () => {
 
     const pos = findText(fixture.doc, 'google.com')
     const $pos = fixture.doc.resolve(pos + 1)
-    const linkText = $pos.marks().find((m) => m.type.name === 'mdLinkText')
+    const linkText = $pos.marks().find((m) => isMarkOfType(m, 'mdLinkText'))
     expect(linkText).toBeTruthy()
     expect(linkText!.attrs.href).toBe('https://google.com')
   })

--- a/packages/core/src/extensions/list.ts
+++ b/packages/core/src/extensions/list.ts
@@ -36,7 +36,7 @@ import {
   type ListClickHandler,
 } from 'prosemirror-flat-list'
 
-import type { NodeName } from './node-names.ts'
+import { isNodeOfType, type NodeName } from './node-names.ts'
 
 /**
  * The marker for a list item.
@@ -292,7 +292,7 @@ function getListAttrsAtSelection(state: EditorState): MeowdownListAttrs | null {
   const { $from } = state.selection
   for (let depth = $from.depth; depth > 0; depth--) {
     const node = $from.node(depth)
-    if (node.type.name === ('list' satisfies NodeName)) {
+    if (isNodeOfType(node, 'list')) {
       return node.attrs
     }
   }
@@ -371,7 +371,7 @@ function rotateCircleTask(): Command {
  */
 function isCollapsibleBullet(node: ProseMirrorNode): boolean {
   return (
-    node.type.name === ('list' satisfies NodeName) &&
+    isNodeOfType(node, 'list') &&
     node.attrs.kind === 'bullet' &&
     node.childCount >= 2 &&
     node.firstChild?.type !== node.type

--- a/packages/core/src/extensions/mark-names.ts
+++ b/packages/core/src/extensions/mark-names.ts
@@ -1,3 +1,5 @@
+import type { Mark } from '@prosekit/pm/model'
+
 export const MARK_NAMES = [
   'mdWikilink',
   'mdImage',
@@ -17,6 +19,10 @@ export const MARK_NAMES = [
 ] as const
 
 export type MarkName = (typeof MARK_NAMES)[number]
+
+export function isMarkOfType(mark: Mark, name: MarkName): boolean {
+  return mark.type.name === name
+}
 
 // Marks whose text is Markdown syntax rather than content. Hide mode renders
 // these runs at font-size 0 (mirroring the CSS rules in style.css), and text

--- a/packages/core/src/extensions/node-names.ts
+++ b/packages/core/src/extensions/node-names.ts
@@ -1,3 +1,5 @@
+import type { ProseMirrorNode } from '@prosekit/pm/model'
+
 /**
  * Every ProseMirror node name the editor schema knows about.
  */
@@ -18,3 +20,7 @@ export const NODE_NAMES = [
 ] as const
 
 export type NodeName = (typeof NODE_NAMES)[number]
+
+export function isNodeOfType(node: ProseMirrorNode, name: NodeName): boolean {
+  return node.type.name === name
+}

--- a/packages/core/src/extensions/pending-replacement.ts
+++ b/packages/core/src/extensions/pending-replacement.ts
@@ -18,6 +18,7 @@ import { Decoration, DecorationSet } from '@prosekit/pm/view'
 import { markdownToDoc } from '../converters/md-to-pm.ts'
 import type { PositionRange } from '../utils/range.ts'
 
+import { isNodeOfType } from './node-names.ts'
 import { getNodeBuildersForSchema } from './schema.ts'
 
 /** Where an accepted replacement lands relative to the source range. */
@@ -193,7 +194,8 @@ function acceptPendingReplacement(options: AcceptPendingReplacementOptions = {})
         const $to = state.doc.resolve(pending.to)
         const paragraph = parsed.childCount === 1 ? parsed.firstChild : null
         if (
-          paragraph?.type.name === 'paragraph' &&
+          paragraph != null &&
+          isNodeOfType(paragraph, 'paragraph') &&
           $from.sameParent($to) &&
           $from.parent.isTextblock
         ) {

--- a/packages/core/src/extensions/table-column-align.test.ts
+++ b/packages/core/src/extensions/table-column-align.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 import { docToMarkdown } from '../converters/pm-to-md.ts'
 import { setupFixture } from '../testing/index.ts'
 
+import { isNodeOfType } from './node-names.ts'
 import {
   getTableColumnAlign,
   type MeowdownTableCellAttrs,
@@ -41,7 +42,7 @@ function alignedTable(n: Builders): EditorNode {
 function getCellAligns(doc: EditorNode): Array<Array<TableColumnAlign | null>> {
   const rows: Array<Array<TableColumnAlign | null>> = []
   doc.descendants((node) => {
-    if (node.type.name !== 'tableRow') return true
+    if (!isNodeOfType(node, 'tableRow')) return true
     const cells: Array<TableColumnAlign | null> = []
     node.forEach((cell) => {
       cells.push((cell.attrs as MeowdownTableCellAttrs).align ?? null)
@@ -56,7 +57,7 @@ function getFirstDataCellPos(doc: EditorNode): number {
   let found = -1
   doc.descendants((node, pos) => {
     if (found >= 0) return false
-    if (node.type.name === 'tableCell') {
+    if (isNodeOfType(node, 'tableCell')) {
       found = pos
       return false
     }
@@ -68,7 +69,7 @@ function getFirstDataCellPos(doc: EditorNode): number {
 function getCellHitPositions(doc: EditorNode): number[] {
   const positions: number[] = []
   doc.descendants((node, pos) => {
-    if (node.type.name === 'tableCell' || node.type.name === 'tableHeaderCell') {
+    if (isNodeOfType(node, 'tableCell') || isNodeOfType(node, 'tableHeaderCell')) {
       positions.push(pos + 1)
       return false
     }

--- a/packages/core/src/extensions/table-column-align.ts
+++ b/packages/core/src/extensions/table-column-align.ts
@@ -17,7 +17,7 @@ import {
   type Transaction,
 } from '@prosekit/pm/state'
 
-import type { NodeName } from './node-names.ts'
+import { isNodeOfType, type NodeName } from './node-names.ts'
 
 /**
  * Column alignment of a GFM table, encoded by the delimiter row: `:--` for
@@ -75,7 +75,7 @@ function findAlignmentRowIndex(table: ProseMirrorNode): number {
   for (let rowIndex = 0; rowIndex < table.childCount; rowIndex++) {
     const row = table.child(rowIndex)
     for (let column = 0; column < row.childCount; column++) {
-      if (row.child(column).type.name === ('tableHeaderCell' satisfies NodeName)) return rowIndex
+      if (isNodeOfType(row.child(column), 'tableHeaderCell')) return rowIndex
     }
   }
   return 0
@@ -157,7 +157,7 @@ function createTableAlignSyncPlugin(): Plugin {
       const to = Math.max(from, Math.min(range.to, doc.content.size))
       let tr: Transaction | undefined
       doc.nodesBetween(from, to, (node, pos) => {
-        if (node.type.name !== ('table' satisfies NodeName)) return true
+        if (!isNodeOfType(node, 'table')) return true
         tr ??= newState.tr
         syncTableAligns(node, pos, tr)
         return false

--- a/packages/core/src/extensions/table.test.ts
+++ b/packages/core/src/extensions/table.test.ts
@@ -6,6 +6,8 @@ import { userEvent } from 'vitest/browser'
 
 import { setupFixture } from '../testing/index.ts'
 
+import { isNodeOfType, type NodeName } from './node-names.ts'
+
 describe('table', () => {
   it('deletes the whole selected table when Backspace', async () => {
     using fixture = setupFixture()
@@ -187,14 +189,14 @@ function cellCaretTable(n: ReturnType<typeof setupFixture>['n']): EditorNode {
   )
 }
 
-function hasNodeType(doc: EditorNode, name: string): boolean {
+function hasNodeType(doc: EditorNode, name: NodeName): boolean {
   return countNodeType(doc, name) > 0
 }
 
-function countNodeType(doc: EditorNode, name: string): number {
+function countNodeType(doc: EditorNode, name: NodeName): number {
   let count = 0
   doc.descendants((node) => {
-    if (node.type.name === name) count++
+    if (isNodeOfType(node, name)) count++
     return true
   })
   return count
@@ -203,7 +205,7 @@ function countNodeType(doc: EditorNode, name: string): number {
 function cellChildTypeNames(doc: EditorNode): string[] {
   const names = new Set<string>()
   doc.descendants((node) => {
-    if (node.type.name === 'tableCell' || node.type.name === 'tableHeaderCell') {
+    if (isNodeOfType(node, 'tableCell') || isNodeOfType(node, 'tableHeaderCell')) {
       node.forEach((child) => names.add(child.type.name))
       return false
     }
@@ -215,7 +217,7 @@ function cellChildTypeNames(doc: EditorNode): string[] {
 function maxCellChildCount(doc: EditorNode): number {
   let max = 0
   doc.descendants((node) => {
-    if (node.type.name === 'tableCell' || node.type.name === 'tableHeaderCell') {
+    if (isNodeOfType(node, 'tableCell') || isNodeOfType(node, 'tableHeaderCell')) {
       max = Math.max(max, node.childCount)
       return false
     }
@@ -227,7 +229,7 @@ function maxCellChildCount(doc: EditorNode): number {
 function getCellTexts(doc: EditorNode): string[] {
   const texts: string[] = []
   doc.descendants((node) => {
-    if (node.type.name === 'tableCell' || node.type.name === 'tableHeaderCell') {
+    if (isNodeOfType(node, 'tableCell') || isNodeOfType(node, 'tableHeaderCell')) {
       texts.push(node.textContent)
       return false
     }
@@ -239,7 +241,7 @@ function getCellTexts(doc: EditorNode): string[] {
 function getCellHitPositions(doc: EditorNode): number[] {
   const positions: number[] = []
   doc.descendants((node, pos) => {
-    if (node.type.name === 'tableCell' || node.type.name === 'tableHeaderCell') {
+    if (isNodeOfType(node, 'tableCell') || isNodeOfType(node, 'tableHeaderCell')) {
       positions.push(pos + 1)
       return false
     }
@@ -255,7 +257,7 @@ function hasTable(doc: EditorNode): boolean {
 function getTablePos(doc: EditorNode): number {
   let tablePos = -1
   doc.forEach((node, offset) => {
-    if (node.type.name === 'table') tablePos = offset
+    if (isNodeOfType(node, 'table')) tablePos = offset
   })
   return tablePos
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -100,8 +100,8 @@ export type { ListMarker, MeowdownListAttrs } from './extensions/list.ts'
 export { defineLinkPaste } from './extensions/link-paste.ts'
 export type { MarkChunk } from './extensions/mark-chunk.ts'
 export type { MarkMode } from './extensions/mark-mode.ts'
-export type { MarkName } from './extensions/mark-names.ts'
-export type { NodeName } from './extensions/node-names.ts'
+export { isMarkOfType, type MarkName } from './extensions/mark-names.ts'
+export { isNodeOfType, type NodeName } from './extensions/node-names.ts'
 export {
   definePendingReplacementHandler,
   getPendingReplacement,

--- a/packages/eslint-rules/package.json
+++ b/packages/eslint-rules/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@meowdown/eslint-rules",
+  "type": "module",
+  "version": "0.0.0",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@typescript-eslint/utils": "^8.64.0"
+  },
+  "devDependencies": {
+    "@ocavue/tsconfig": "^0.7.1",
+    "@typescript-eslint/rule-tester": "^8.64.0",
+    "eslint": "^10.7.0",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/eslint-rules/src/index.ts
+++ b/packages/eslint-rules/src/index.ts
@@ -1,0 +1,18 @@
+import type { TSESLint } from '@typescript-eslint/utils'
+
+import { noTypeNameLiteral } from './no-type-name-literal.ts'
+
+export const meowdownConfig: TSESLint.FlatConfig.Config = {
+  files: ['**/*.ts', '**/*.tsx'],
+  plugins: {
+    meowdown: {
+      meta: { name: '@meowdown/eslint-rules' },
+      rules: {
+        'no-type-name-literal': noTypeNameLiteral,
+      },
+    },
+  },
+  rules: {
+    'meowdown/no-type-name-literal': 'error',
+  },
+}

--- a/packages/eslint-rules/src/no-type-name-literal.test.ts
+++ b/packages/eslint-rules/src/no-type-name-literal.test.ts
@@ -1,0 +1,51 @@
+import { RuleTester } from '@typescript-eslint/rule-tester'
+import { afterAll, describe, it } from 'vitest'
+
+import { noTypeNameLiteral } from './no-type-name-literal.ts'
+
+RuleTester.afterAll = afterAll
+RuleTester.describe = describe
+RuleTester.it = it
+
+const ruleTester = new RuleTester()
+
+ruleTester.run('no-type-name-literal', noTypeNameLiteral, {
+  valid: [
+    'node.type.name === nodeName',
+    'mark.type.name === markName',
+    'node.type.name === myObject.myProperty',
+    'mark.type.name === myObject.myProperty',
+    'const name = node.type.name',
+    'const name = mark.type.name',
+    'node.type.name === `md${suffix}`',
+    'switch (node.type.name as NodeName) { case "heading": break }',
+    'switch (mark.type.name as MarkName) { case "mdImage": break }',
+  ],
+  invalid: [
+    { code: "node.type.name === 'heading'", errors: [{ messageId: 'useHelper' }] },
+    { code: "mark.type.name === 'mdImage'", errors: [{ messageId: 'useHelper' }] },
+    { code: "node.type.name !== 'heading'", errors: [{ messageId: 'useHelper' }] },
+    { code: "mark.type.name !== 'mdImage'", errors: [{ messageId: 'useHelper' }] },
+    { code: "'heading' === node.type.name", errors: [{ messageId: 'useHelper' }] },
+    { code: "'mdImage' === mark.type.name", errors: [{ messageId: 'useHelper' }] },
+    {
+      code: "node.type.name === ('list' satisfies NodeName)",
+      errors: [{ messageId: 'useHelper' }],
+    },
+    {
+      code: "mark.type.name === ('mdCode' satisfies MarkName)",
+      errors: [{ messageId: 'useHelper' }],
+    },
+    { code: "paragraph?.type.name === 'paragraph'", errors: [{ messageId: 'useHelper' }] },
+    { code: 'node.type.name === `heading`', errors: [{ messageId: 'useHelper' }] },
+    { code: 'mark.type.name === `mdImage`', errors: [{ messageId: 'useHelper' }] },
+    {
+      code: "switch (node.type.name) { case 'heading': break }",
+      errors: [{ messageId: 'castSwitchDiscriminant' }],
+    },
+    {
+      code: "switch (mark.type.name) { case 'mdImage': break }",
+      errors: [{ messageId: 'castSwitchDiscriminant' }],
+    },
+  ],
+})

--- a/packages/eslint-rules/src/no-type-name-literal.ts
+++ b/packages/eslint-rules/src/no-type-name-literal.ts
@@ -1,0 +1,71 @@
+import { AST_NODE_TYPES } from '@typescript-eslint/utils'
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils'
+
+const COMPARISON_OPERATORS = new Set(['==', '!=', '===', '!=='])
+
+function unwrapChain(node: TSESTree.Node): TSESTree.Node {
+  return node.type === AST_NODE_TYPES.ChainExpression ? node.expression : node
+}
+
+function isTypeNameAccess(candidate: TSESTree.Node): boolean {
+  const expression = unwrapChain(candidate)
+  return (
+    expression.type === AST_NODE_TYPES.MemberExpression &&
+    !expression.computed &&
+    expression.property.type === AST_NODE_TYPES.Identifier &&
+    expression.property.name === 'name' &&
+    expression.object.type === AST_NODE_TYPES.MemberExpression &&
+    !expression.object.computed &&
+    expression.object.property.type === AST_NODE_TYPES.Identifier &&
+    expression.object.property.name === 'type'
+  )
+}
+
+function isStringConstant(candidate: TSESTree.Node): boolean {
+  if (
+    candidate.type === AST_NODE_TYPES.TSSatisfiesExpression ||
+    candidate.type === AST_NODE_TYPES.TSAsExpression
+  ) {
+    return isStringConstant(candidate.expression)
+  }
+  if (candidate.type === AST_NODE_TYPES.Literal) return typeof candidate.value === 'string'
+  return candidate.type === AST_NODE_TYPES.TemplateLiteral && candidate.expressions.length === 0
+}
+
+type MessageId = 'useHelper' | 'castSwitchDiscriminant'
+
+export const noTypeNameLiteral: TSESLint.RuleModule<MessageId> = {
+  defaultOptions: [],
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow comparing `.type.name` to a string; use `isNodeOfType` / `isMarkOfType` from `@meowdown/core`.',
+    },
+    messages: {
+      useHelper:
+        'Use `isNodeOfType(node, name)` / `isMarkOfType(mark, name)` from `@meowdown/core` instead of comparing `.type.name` to a string.',
+      castSwitchDiscriminant:
+        'Cast the discriminant (`node.type.name as NodeName` / `mark.type.name as MarkName`) so TypeScript checks every `case` clause against the union.',
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      BinaryExpression(node) {
+        if (!COMPARISON_OPERATORS.has(node.operator)) return
+        if (
+          (isTypeNameAccess(node.left) && isStringConstant(node.right)) ||
+          (isTypeNameAccess(node.right) && isStringConstant(node.left))
+        ) {
+          context.report({ node, messageId: 'useHelper' })
+        }
+      },
+      SwitchStatement(node) {
+        if (isTypeNameAccess(node.discriminant)) {
+          context.report({ node: node.discriminant, messageId: 'castSwitchDiscriminant' })
+        }
+      },
+    }
+  },
+}

--- a/packages/eslint-rules/tsconfig.json
+++ b/packages/eslint-rules/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@ocavue/tsconfig/es/app.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "erasableSyntaxOnly": true
+  }
+}

--- a/packages/eslint-rules/vitest.config.ts
+++ b/packages/eslint-rules/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineProject } from 'vitest/config'
+
+export default defineProject({
+  test: {
+    environment: 'node',
+  },
+})

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -3,6 +3,7 @@ import {
   docToMarkdown,
   getSelectedText,
   getTextblockDisplayText,
+  isNodeOfType,
   markdownToDoc,
   type AcceptPendingReplacementOptions,
   type EditorExtension,
@@ -134,7 +135,7 @@ function findHeadingPosition(doc: EditorNode, fragment: string): number | undefi
   let match: number | undefined
   doc.descendants((node, pos) => {
     if (match != null) return false
-    if (node.type.name !== 'heading') return true
+    if (!isNodeOfType(node, 'heading')) return true
     const displayText = getTextblockDisplayText(node)
     const slug = slugger.slug(displayText)
     if (

--- a/packages/react/src/components/slash-menu.test.tsx
+++ b/packages/react/src/components/slash-menu.test.tsx
@@ -1,5 +1,6 @@
 import '../testing/index.ts'
 
+import { isNodeOfType } from '@meowdown/core'
 import type { EditorNode } from '@prosekit/pm/model'
 import { TextSelection } from '@prosekit/pm/state'
 import { createRef } from 'react'
@@ -377,7 +378,7 @@ describe('SlashMenu', () => {
 function firstBodyCellCaret(doc: EditorNode): number {
   let caret = -1
   doc.descendants((node, pos) => {
-    if (caret < 0 && node.type.name === 'tableCell') caret = pos + 2
+    if (caret < 0 && isNodeOfType(node, 'tableCell')) caret = pos + 2
     return caret < 0
   })
   if (caret < 0) throw new Error('no body cell found')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,9 +9,12 @@ importers:
 
   .:
     devDependencies:
+      '@meowdown/eslint-rules':
+        specifier: workspace:*
+        version: link:packages/eslint-rules
       '@ocavue/eslint-config':
         specifier: ^4.12.1
-        version: 4.12.1(@types/estree@1.0.9)(@typescript-eslint/parser@8.63.0)(@typescript-eslint/typescript-estree@8.63.0)(@typescript-eslint/utils@8.63.0)(eslint@10.7.0)(typescript@6.0.3)
+        version: 4.12.1(@types/estree@1.0.9)(@typescript-eslint/parser@8.63.0)(@typescript-eslint/typescript-estree@8.64.0)(@typescript-eslint/utils@8.64.0)(eslint@10.7.0)(typescript@6.0.3)
       '@ocavue/tsconfig':
         specifier: ^0.7.1
         version: 0.7.1
@@ -148,6 +151,25 @@ importers:
       tsdown:
         specifier: ^0.22.8
         version: 0.22.8(@tsdown/css@0.22.8)(oxc-resolver@11.21.3)(typescript@6.0.3)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(vite@8.1.4)
+
+  packages/eslint-rules:
+    dependencies:
+      '@typescript-eslint/utils':
+        specifier: ^8.64.0
+        version: 8.64.0(eslint@10.7.0)(typescript@6.0.3)
+    devDependencies:
+      '@ocavue/tsconfig':
+        specifier: ^0.7.1
+        version: 0.7.1
+      '@typescript-eslint/rule-tester':
+        specifier: ^8.64.0
+        version: 8.64.0(eslint@10.7.0)(typescript@6.0.3)
+      eslint:
+        specifier: ^10.7.0
+        version: 10.7.0(jiti@2.7.0)
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(vite@8.1.4)
@@ -1534,18 +1556,48 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/parser@8.64.0':
+    resolution: {integrity: sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/project-service@8.63.0':
     resolution: {integrity: sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/project-service@8.64.0':
+    resolution: {integrity: sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/rule-tester@8.64.0':
+    resolution: {integrity: sha512-QmEBcU+JKvSx2DagEb/Nip7331IAQkH77QlEp5KNWs9/OvbhiUXvdf09k43dZtIRtAA0ahNDesQ+bfpjN/UsMA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@8.63.0':
     resolution: {integrity: sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.64.0':
+    resolution: {integrity: sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/tsconfig-utils@8.63.0':
     resolution: {integrity: sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/tsconfig-utils@8.64.0':
+    resolution: {integrity: sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -1561,8 +1613,18 @@ packages:
     resolution: {integrity: sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.64.0':
+    resolution: {integrity: sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.63.0':
     resolution: {integrity: sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/typescript-estree@8.64.0':
+    resolution: {integrity: sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -1574,8 +1636,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/utils@8.64.0':
+    resolution: {integrity: sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@8.63.0':
     resolution: {integrity: sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.64.0':
+    resolution: {integrity: sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.2':
@@ -2614,6 +2687,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -4135,7 +4211,7 @@ snapshots:
   '@es-joy/jsdoccomment@0.88.0':
     dependencies:
       '@types/estree': 1.0.9
-      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/types': 8.64.0
       comment-parser: 1.4.7
       esquery: 1.7.0
       jsdoc-type-pratt-parser: 7.2.0
@@ -4155,9 +4231,9 @@ snapshots:
 
   '@eslint-react/ast@5.13.2(eslint@10.7.0)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.63.0(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
       eslint: 10.7.0(jiti@2.7.0)
       string-ts: 2.3.1
       typescript: 6.0.3
@@ -4171,9 +4247,9 @@ snapshots:
       '@eslint-react/jsx': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
       '@eslint-react/shared': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
       '@eslint-react/var': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
-      '@typescript-eslint/scope-manager': 8.63.0
-      '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/utils': 8.63.0(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.64.0
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
       eslint: 10.7.0(jiti@2.7.0)
       ts-pattern: 5.9.0
       typescript: 6.0.3
@@ -4196,7 +4272,7 @@ snapshots:
 
   '@eslint-react/eslint@5.13.2(eslint@10.7.0)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.63.0(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
       eslint: 10.7.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -4208,8 +4284,8 @@ snapshots:
       '@eslint-react/eslint': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
       '@eslint-react/shared': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
       '@eslint-react/var': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
-      '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/utils': 8.63.0(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
       eslint: 10.7.0(jiti@2.7.0)
       ts-pattern: 5.9.0
       typescript: 6.0.3
@@ -4219,7 +4295,7 @@ snapshots:
   '@eslint-react/shared@5.13.2(eslint@10.7.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-react/eslint': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.63.0(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
       eslint: 10.7.0(jiti@2.7.0)
       ts-pattern: 5.9.0
       typescript: 6.0.3
@@ -4231,9 +4307,9 @@ snapshots:
     dependencies:
       '@eslint-react/ast': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
       '@eslint-react/eslint': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
-      '@typescript-eslint/scope-manager': 8.63.0
-      '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/utils': 8.63.0(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.64.0
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
       eslint: 10.7.0(jiti@2.7.0)
       ts-pattern: 5.9.0
       typescript: 6.0.3
@@ -4480,7 +4556,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@ocavue/eslint-config@4.12.1(@types/estree@1.0.9)(@typescript-eslint/parser@8.63.0)(@typescript-eslint/typescript-estree@8.63.0)(@typescript-eslint/utils@8.63.0)(eslint@10.7.0)(typescript@6.0.3)':
+  '@ocavue/eslint-config@4.12.1(@types/estree@1.0.9)(@typescript-eslint/parser@8.63.0)(@typescript-eslint/typescript-estree@8.64.0)(@typescript-eslint/utils@8.64.0)(eslint@10.7.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-plugin-eslint-comments': 4.7.2(eslint@10.7.0)
       '@eslint-react/eslint-plugin': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
@@ -4489,7 +4565,7 @@ snapshots:
       eslint-config-flat-gitignore: 2.3.0(eslint@10.7.0)
       eslint-config-prettier: 10.1.8(eslint@10.7.0)
       eslint-plugin-antfu: 3.2.3(eslint@10.7.0)
-      eslint-plugin-command: 3.5.3(@typescript-eslint/typescript-estree@8.63.0)(@typescript-eslint/utils@8.63.0)(eslint@10.7.0)
+      eslint-plugin-command: 3.5.3(@typescript-eslint/typescript-estree@8.64.0)(@typescript-eslint/utils@8.64.0)(eslint@10.7.0)
       eslint-plugin-no-only-tests: 3.4.0
       eslint-plugin-package-json: 1.5.0(@types/estree@1.0.9)(eslint@10.7.0)
       eslint-plugin-perfectionist: 5.10.0(eslint@10.7.0)(typescript@6.0.3)
@@ -5089,11 +5165,46 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.64.0(eslint@10.7.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.64.0
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.64.0
+      debug: 4.4.3
+      eslint: 10.7.0(jiti@2.7.0)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/project-service@8.63.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.63.0
+      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.64.0
       debug: 4.4.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.64.0(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.64.0
+      debug: 4.4.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/rule-tester@8.64.0(eslint@10.7.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/parser': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
+      ajv: 6.15.0
+      eslint: 10.7.0(jiti@2.7.0)
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      semver: 7.8.5
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -5103,7 +5214,16 @@ snapshots:
       '@typescript-eslint/types': 8.63.0
       '@typescript-eslint/visitor-keys': 8.63.0
 
+  '@typescript-eslint/scope-manager@8.64.0':
+    dependencies:
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/visitor-keys': 8.64.0
+
   '@typescript-eslint/tsconfig-utils@8.63.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@typescript-eslint/tsconfig-utils@8.64.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
 
@@ -5121,12 +5241,29 @@ snapshots:
 
   '@typescript-eslint/types@8.63.0': {}
 
+  '@typescript-eslint/types@8.64.0': {}
+
   '@typescript-eslint/typescript-estree@8.63.0(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/project-service': 8.63.0(typescript@6.0.3)
       '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.63.0
       '@typescript-eslint/visitor-keys': 8.63.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.64.0(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/visitor-keys': 8.64.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.5
@@ -5147,9 +5284,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.64.0(eslint@10.7.0)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0)
+      '@typescript-eslint/scope-manager': 8.64.0
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
+      eslint: 10.7.0(jiti@2.7.0)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.63.0':
     dependencies:
       '@typescript-eslint/types': 8.63.0
+      eslint-visitor-keys: 5.0.1
+
+  '@typescript-eslint/visitor-keys@8.64.0':
+    dependencies:
+      '@typescript-eslint/types': 8.64.0
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.2': {}
@@ -5173,7 +5326,7 @@ snapshots:
 
   '@unocss/eslint-plugin@66.7.5(eslint@10.7.0)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.63.0(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
       '@unocss/config': 66.7.5
       '@unocss/core': 66.7.5
       '@unocss/rule-utils': 66.7.5
@@ -5577,11 +5730,11 @@ snapshots:
     dependencies:
       eslint: 10.7.0(jiti@2.7.0)
 
-  eslint-plugin-command@3.5.3(@typescript-eslint/typescript-estree@8.63.0)(@typescript-eslint/utils@8.63.0)(eslint@10.7.0):
+  eslint-plugin-command@3.5.3(@typescript-eslint/typescript-estree@8.64.0)(@typescript-eslint/utils@8.64.0)(eslint@10.7.0):
     dependencies:
       '@es-joy/jsdoccomment': 0.88.0
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.63.0(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
       eslint: 10.7.0(jiti@2.7.0)
 
   eslint-plugin-no-only-tests@3.4.0: {}
@@ -5605,7 +5758,7 @@ snapshots:
 
   eslint-plugin-perfectionist@5.10.0(eslint@10.7.0)(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/utils': 8.63.0(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
       eslint: 10.7.0(jiti@2.7.0)
       natural-orderby: 5.0.0
     transitivePeerDependencies:
@@ -5618,8 +5771,8 @@ snapshots:
       '@eslint-react/eslint': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
       '@eslint-react/jsx': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
       '@eslint-react/shared': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
-      '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/utils': 8.63.0(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
       compare-versions: 6.1.1
       eslint: 10.7.0(jiti@2.7.0)
       typescript: 6.0.3
@@ -5644,8 +5797,8 @@ snapshots:
       '@eslint-react/eslint': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
       '@eslint-react/jsx': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
       '@eslint-react/shared': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
-      '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/utils': 8.63.0(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
       eslint: 10.7.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -5657,8 +5810,8 @@ snapshots:
       '@eslint-react/core': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
       '@eslint-react/eslint': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
       '@eslint-react/var': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
-      '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/utils': 8.63.0(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
       eslint: 10.7.0(jiti@2.7.0)
       ts-pattern: 5.9.0
       typescript: 6.0.3
@@ -5672,8 +5825,8 @@ snapshots:
       '@eslint-react/eslint': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
       '@eslint-react/shared': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
       '@eslint-react/var': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
-      '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/utils': 8.63.0(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
       eslint: 10.7.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -5686,8 +5839,8 @@ snapshots:
       '@eslint-react/eslint': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
       '@eslint-react/shared': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
       '@eslint-react/var': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
-      '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/utils': 8.63.0(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
       birecord: 0.1.2
       eslint: 10.7.0(jiti@2.7.0)
       ts-pattern: 5.9.0
@@ -5703,11 +5856,11 @@ snapshots:
       '@eslint-react/jsx': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
       '@eslint-react/shared': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
       '@eslint-react/var': 5.13.2(eslint@10.7.0)(typescript@6.0.3)
-      '@typescript-eslint/scope-manager': 8.63.0
+      '@typescript-eslint/scope-manager': 8.64.0
       '@typescript-eslint/type-utils': 8.63.0(eslint@10.7.0)(typescript@6.0.3)
-      '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.63.0(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@6.0.3)
       compare-versions: 6.1.1
       eslint: 10.7.0(jiti@2.7.0)
       string-ts: 2.3.1
@@ -6206,6 +6359,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
 
   longest-streak@3.1.0: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,9 @@
       "path": "./packages/core/tsconfig.json"
     },
     {
+      "path": "./packages/eslint-rules/tsconfig.json"
+    },
+    {
       "path": "./packages/react/tsconfig.json"
     },
     {


### PR DESCRIPTION
Comparing `node.type.name` or `mark.type.name` to a raw string literal is typo-prone: a misspelled name compiles fine and silently never matches. This adds `isNodeOfType(node, name)` and `isMarkOfType(mark, name)` to `@meowdown/core`, typed by the `NodeName` / `MarkName` unions, and migrates every call site. A new private `@meowdown/eslint-rules` package ships a `meowdown/no-type-name-literal` rule that forbids comparing `.type.name` to a string literal (and bare `switch` on `.type.name`), so the unsafe idiom cannot come back.