### PR TITLE
feat: render Mermaid code blocks

### DIFF
--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -607,6 +607,11 @@ describe('code blocks', () => {
     expect(roundtrip('```js\nconst x=1\n```')).toBe('```js\nconst x=1\n```\n')
   })
 
+  it('keeps a Mermaid fence', () => {
+    const markdown = '```mermaid\nflowchart LR\n  A --> B\n```'
+    expect(roundtrip(markdown)).toBe(`${markdown}\n`)
+  })
+
   it('keeps multi-line fenced code', () => {
     expect(roundtrip('```\nl1\nl2\n```')).toBe('```\nl1\nl2\n```\n')
   })

--- a/packages/core/src/extensions/code-block-languages.test.ts
+++ b/packages/core/src/extensions/code-block-languages.test.ts
@@ -239,6 +239,10 @@ describe('codeBlockLanguages', () => {
           "value": "mbox",
         },
         {
+          "label": "Mermaid",
+          "value": "mermaid",
+        },
+        {
           "label": "Modelica",
           "value": "modelica",
         },

--- a/packages/core/src/extensions/code-block-languages.ts
+++ b/packages/core/src/extensions/code-block-languages.ts
@@ -32,6 +32,7 @@ const excludeLanguages = new Set([
 const extraLanguages = [
   { label: 'Plain text', value: '' },
   { label: 'Math', value: 'math' },
+  { label: 'Mermaid', value: 'mermaid' },
 ]
 
 /**

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -46,6 +46,11 @@
     /* inline and block code background */
     --meowdown-code-bg: light-dark(oklch(0.967 0 0), oklch(0.21 0.006 286));
 
+    /* Mermaid diagram background, foreground, and errors */
+    --meowdown-mermaid-bg: var(--meowdown-code-bg);
+    --meowdown-mermaid-fg: var(--meowdown-text);
+    --meowdown-mermaid-error: var(--meowdown-danger);
+
     /* placeholder fill while an image loads */
     --meowdown-image-loading-bg: light-dark(oklch(0.967 0 0), oklch(0.274 0.005 286));
 

--- a/packages/core/src/utils/katex-chunk.ts
+++ b/packages/core/src/utils/katex-chunk.ts
@@ -1,0 +1,5 @@
+import { render } from 'katex'
+
+export type KaTeXRender = typeof render
+
+export { render }

--- a/packages/core/src/utils/katex.ts
+++ b/packages/core/src/utils/katex.ts
@@ -1,6 +1,6 @@
-import type { render } from 'katex'
+import type { KaTeXRender } from './katex-chunk.ts'
 
-export type KaTeXRender = typeof render
+export type { KaTeXRender }
 
 let katexRenderPromise: Promise<KaTeXRender> | undefined
 
@@ -9,7 +9,7 @@ let katexRenderPromise: Promise<KaTeXRender> | undefined
  * contain no math, so the library stays out of the initial bundle.
  */
 export function loadKaTeX(): Promise<KaTeXRender> {
-  katexRenderPromise ??= import('katex').then((module) => module.render)
+  katexRenderPromise ??= import('./katex-chunk.ts').then((module) => module.render)
   return katexRenderPromise
 }
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -119,6 +119,18 @@ resolver that accepts only trusted local image sources.
 <MarkdownView markdown={markdown} interactive={false} resolveImageUrl={resolveLocalImageUrl} />
 ```
 
+### Mermaid code blocks
+
+Fenced `mermaid` code blocks render as diagrams in both `MeowdownEditor` and
+`MarkdownView`. The editor shows only the preview while the caret is outside
+the block, then shows source and a live preview while editing it.
+
+Rendering uses `beautiful-mermaid`, which currently supports Flowchart, State,
+Sequence, Class, ER, and XY Chart diagrams. Unsupported syntax renders an error
+instead of an empty preview. Override `--meowdown-mermaid-bg`,
+`--meowdown-mermaid-fg`, or `--meowdown-mermaid-error` to customize the
+diagram surface.
+
 ## Styling
 
 Import both stylesheets: `@meowdown/core/style.css` (the editor theme and variables) and `@meowdown/react/style.css` (the component layout). The core theme is documented in [`@meowdown/core`](https://www.npmjs.com/package/@meowdown/core).

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,6 +27,7 @@
     "@prosekit/core": "^0.13.0-beta.6",
     "@prosekit/pm": "^0.1.19-beta.3",
     "@prosekit/react": "^0.8.0-beta.21",
+    "beautiful-mermaid": "^1.1.3",
     "clsx": "^2.1.1",
     "github-slugger": "^2.0.0",
     "lucide-react": "^1.24.0",

--- a/packages/react/src/components/code-block-view-loading.test.tsx
+++ b/packages/react/src/components/code-block-view-loading.test.tsx
@@ -1,0 +1,22 @@
+import '../testing/index.ts'
+
+import { describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+import { page } from 'vitest/browser'
+
+vi.mock('../hooks/use-beautiful-mermaid.ts', () => ({
+  useBeautifulMermaid: () => undefined,
+}))
+
+import { ProseKitEditor } from './prosekit-editor.tsx'
+
+describe('code block Mermaid loading', () => {
+  it('keeps the source visible while the renderer loads', async () => {
+    await render(
+      <ProseKitEditor initialMarkdown={'before\n\n```mermaid\nflowchart LR\n  A --> B\n```'} />,
+    )
+
+    await expect.element(page.locate('.ProseMirror pre[data-language="mermaid"]')).toBeVisible()
+    await expect.element(page.getByTestId('code-block-mermaid-preview')).not.toBeInTheDocument()
+  })
+})

--- a/packages/react/src/components/code-block-view.module.css
+++ b/packages/react/src/components/code-block-view.module.css
@@ -2,7 +2,7 @@
   position: relative;
 }
 
-/* Preview-only state: the caret is outside a math block, so the source and
+/* Preview-only state: the caret is outside a rendered block, so the source and
  * its toolbar give way to the rendered formula. The caret can never sit in
  * the hidden source (entering it flips the state back), so the missing box
  * does not disturb caret geometry. */
@@ -23,6 +23,23 @@
 
   -webkit-user-select: none;
   user-select: none;
+}
+
+.MermaidPreview {
+  text-align: initial;
+
+  &[data-error] {
+    color: var(--meowdown-mermaid-error);
+    font-family: var(--meowdown-font-mono);
+    white-space: pre-wrap;
+  }
+
+  svg {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    margin-inline: auto;
+  }
 }
 
 .Toolbar {

--- a/packages/react/src/components/code-block-view.module.d.css.ts
+++ b/packages/react/src/components/code-block-view.module.d.css.ts
@@ -5,6 +5,7 @@ declare const styles = {
   'Root': '' as string,
   'Toolbar': '' as string,
   'Preview': '' as string,
+  'MermaidPreview': '' as string,
   'Toolbar': '' as string,
   'Root': '' as string,
   'Toolbar': '' as string,

--- a/packages/react/src/components/code-block-view.test.tsx
+++ b/packages/react/src/components/code-block-view.test.tsx
@@ -160,3 +160,101 @@ describe('code block math preview', () => {
     })
   })
 })
+
+const mermaidPreview = page.getByTestId('code-block-mermaid-preview')
+const mermaidSource = page.locate('.ProseMirror pre[data-language="mermaid"]')
+
+const MERMAID_BLOCK_MD = 'before\n\n```mermaid\nflowchart LR\n  A[Start] --> B[End]\n```'
+
+describe('code block Mermaid preview', () => {
+  it('shows only a Flowchart preview when the caret is outside', async () => {
+    await render(<ProseKitEditor initialMarkdown={MERMAID_BLOCK_MD} />)
+
+    await expect.element(mermaidPreview.locate('svg'), { timeout: 15000 }).toBeInTheDocument()
+    await expect.element(mermaidPreview).toHaveTextContent('Start')
+    await expect.element(mermaidSource).not.toBeVisible()
+  })
+
+  it('shows the source above the preview once the caret enters', async () => {
+    await render(<ProseKitEditor initialMarkdown={MERMAID_BLOCK_MD} />)
+    await expect.element(mermaidPreview.locate('svg'), { timeout: 15000 }).toBeInTheDocument()
+
+    await mermaidPreview.click()
+
+    await expect.element(mermaidSource).toBeVisible()
+    await expect.element(mermaidPreview).toBeVisible()
+    const source = mermaidSource.element()
+    const preview = mermaidPreview.element()
+    const position = source.compareDocumentPosition(preview)
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('updates the Flowchart preview live while typing', async () => {
+    const ref = createRef<EditorHandle>()
+    await render(<ProseKitEditor ref={ref} initialMarkdown={MERMAID_BLOCK_MD} />)
+    await expect.element(mermaidPreview.locate('svg'), { timeout: 15000 }).toBeInTheDocument()
+    await mermaidPreview.click()
+    ref.current?.setSelection('end')
+    ref.current?.focus()
+    await userEvent.keyboard('{Enter}')
+    await userEvent.keyboard('  B --> Done')
+
+    await expect.element(mermaidPreview).toHaveTextContent('Done')
+  })
+
+  it('renders a Sequence diagram', async () => {
+    const markdown =
+      'before\n\n```mermaid\nsequenceDiagram\n  Alice->>Bob: Hello Bob\n  Bob-->>Alice: Hello Alice\n```'
+    await render(<ProseKitEditor initialMarkdown={markdown} />)
+
+    await expect.element(mermaidPreview.locate('svg'), { timeout: 15000 }).toBeInTheDocument()
+    await expect.element(mermaidPreview).toHaveTextContent('Hello Bob')
+    await expect.element(mermaidPreview).toHaveTextContent('Hello Alice')
+  })
+
+  it('keeps the source visible for an empty Mermaid block', async () => {
+    await render(<ProseKitEditor initialMarkdown={'before\n\n```mermaid\n```'} />)
+
+    await expect.element(mermaidSource).toBeVisible()
+  })
+
+  it('shows an editable error for unsupported syntax', async () => {
+    await render(
+      <ProseKitEditor initialMarkdown={'before\n\n```mermaid\npie\n  "Dogs" : 10\n```'} />,
+    )
+    await expect.element(mermaidPreview, { timeout: 15000 }).toHaveAttribute('data-error')
+    await expect.element(mermaidSource).not.toBeVisible()
+
+    await mermaidPreview.click()
+
+    await expect.element(mermaidSource).toBeVisible()
+  })
+
+  it('drops the preview when the language changes', async () => {
+    const ref = createRef<EditorHandle>()
+    await render(<ProseKitEditor ref={ref} initialMarkdown={MERMAID_BLOCK_MD} />)
+    await expect.element(mermaidPreview.locate('svg'), { timeout: 15000 }).toBeInTheDocument()
+    await mermaidPreview.click()
+
+    await selector.click()
+    await page.getByRole('option', { name: 'TypeScript', exact: true }).click()
+
+    await expect.element(mermaidPreview).not.toBeInTheDocument()
+    await vi.waitFor(() => {
+      expect(ref.current?.getMarkdown()).toContain(
+        '```typescript\nflowchart LR\n  A[Start] --> B[End]\n```',
+      )
+    })
+  })
+
+  it('keeps hostile labels passive', async () => {
+    const markdown =
+      'before\n\n```mermaid\nflowchart LR\n  A[<script>alert(1)</script><img src=x onerror=alert(1)> & safe] --> B\n```'
+    await render(<ProseKitEditor initialMarkdown={markdown} />)
+
+    await expect.element(mermaidPreview.locate('svg'), { timeout: 15000 }).toBeInTheDocument()
+    await expect.element(mermaidPreview.locate('script')).not.toBeInTheDocument()
+    await expect.element(mermaidPreview.locate('img')).not.toBeInTheDocument()
+    await expect.element(mermaidPreview.locate('[onerror]')).not.toBeInTheDocument()
+  })
+})

--- a/packages/react/src/components/code-block-view.tsx
+++ b/packages/react/src/components/code-block-view.tsx
@@ -10,28 +10,33 @@ import type { ReactNodeViewProps } from '@prosekit/react'
 import { CheckIcon, ChevronsUpDownIcon } from 'lucide-react'
 import { useMemo, useState, type MouseEvent } from 'react'
 
+import { useBeautifulMermaid } from '../hooks/use-beautiful-mermaid.ts'
 import { useKaTeX } from '../hooks/use-katex.ts'
 
 import styles from './code-block-view.module.css'
 import { CopyButton } from './copy-button.tsx'
 import { MathRender } from './math-render.tsx'
+import { MermaidRender } from './mermaid-render.tsx'
 
 export function CodeBlockView(props: ReactNodeViewProps) {
   const attrs = props.node.attrs as CodeBlockAttrs
   const language = attrs.language || ''
   const isMath = language === 'math'
+  const isMermaid = language === 'mermaid'
   const code = props.node.textContent
 
   const caretInside = props.decorations.some(isCodeBlockPreviewHiddenDecoration)
 
   const katex = useKaTeX(isMath)
+  const mermaid = useBeautifulMermaid(isMermaid)
   const showMathPreview = isMath && katex != null
+  const showMermaidPreview = isMermaid && mermaid != null
 
   // The preview replaces the source only when the caret is elsewhere; with the
   // caret inside, the source stays on top and the preview updates live below.
   // An empty or not-yet-rendered block keeps its source, so it never turns
   // invisible and unclickable.
-  const previewOnly = showMathPreview && !caretInside && code.trim() !== ''
+  const previewOnly = (showMathPreview || showMermaidPreview) && !caretInside && code.trim() !== ''
 
   const focusSource = (event: MouseEvent) => {
     event.preventDefault()
@@ -137,6 +142,15 @@ export function CodeBlockView(props: ReactNodeViewProps) {
           displayMode
           className={styles.Preview}
           data-testid="code-block-math-preview"
+          onMouseDown={focusSource}
+        />
+      )}
+      {showMermaidPreview && (
+        <MermaidRender
+          renderer={mermaid}
+          source={code}
+          className={`${styles.Preview} ${styles.MermaidPreview}`}
+          data-testid="code-block-mermaid-preview"
           onMouseDown={focusSource}
         />
       )}

--- a/packages/react/src/components/markdown-view-loading.test.tsx
+++ b/packages/react/src/components/markdown-view-loading.test.tsx
@@ -1,0 +1,25 @@
+import '../testing/index.ts'
+
+import { describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+import { page } from 'vitest/browser'
+
+vi.mock('../hooks/use-beautiful-mermaid.ts', () => ({
+  useBeautifulMermaid: () => undefined,
+}))
+
+import { MarkdownView } from './markdown-view.tsx'
+
+describe('MarkdownView Mermaid loading', () => {
+  it('renders the source while the renderer loads', async () => {
+    await render(
+      <div data-testid="markdown-view-loading">
+        <MarkdownView markdown={'```mermaid\nflowchart LR\n  A --> B\n```'} />
+      </div>,
+    )
+
+    const view = page.getByTestId('markdown-view-loading')
+    await expect.element(view.locate('pre[data-language="mermaid"]')).toBeVisible()
+    await expect.element(view.getByTestId('code-block-mermaid-preview')).not.toBeInTheDocument()
+  })
+})

--- a/packages/react/src/components/markdown-view.test.tsx
+++ b/packages/react/src/components/markdown-view.test.tsx
@@ -392,6 +392,44 @@ describe('MarkdownView math', () => {
   })
 })
 
+describe('MarkdownView Mermaid', () => {
+  const mermaidPreview = view.getByTestId('code-block-mermaid-preview')
+
+  it('renders a Flowchart as SVG', async () => {
+    await renderView('```mermaid\nflowchart LR\n  A[Start] --> B[End]\n```')
+
+    await expect.element(mermaidPreview.locate('svg'), { timeout: 15000 }).toBeInTheDocument()
+    await expect.element(mermaidPreview).toHaveTextContent('Start')
+    await expect.element(mermaidPreview).toHaveTextContent('End')
+  })
+
+  it('renders a Sequence diagram as SVG', async () => {
+    await renderView('```mermaid\nsequenceDiagram\n  Alice->>Bob: Hello Bob\n```')
+
+    await expect.element(mermaidPreview.locate('svg'), { timeout: 15000 }).toBeInTheDocument()
+    await expect.element(mermaidPreview).toHaveTextContent('Hello Bob')
+  })
+
+  it('renders unsupported syntax as an error', async () => {
+    await renderView('```mermaid\npie\n  "Dogs" : 10\n```')
+
+    await expect.element(mermaidPreview, { timeout: 15000 }).toHaveAttribute('data-error')
+    await expect.element(mermaidPreview).toHaveTextContent(/Invalid|Unsupported/i)
+  })
+
+  it('renders passive SVG when interaction is disabled', async () => {
+    await renderView('```mermaid\nflowchart LR\n  A --> B\n```', { interactive: false })
+
+    await expect.element(mermaidPreview.locate('svg'), { timeout: 15000 }).toBeInTheDocument()
+    await expect
+      .element(mermaidPreview.locate('a, button, input, select, textarea, [tabindex], [href]'))
+      .not.toBeInTheDocument()
+    await expect
+      .element(mermaidPreview.locate('[onclick], [onmouseover], [onerror], [onload]'))
+      .not.toBeInTheDocument()
+  })
+})
+
 describe('MarkdownView parity with the editor', () => {
   const editorHost = page.getByTestId('parity-editor')
   const staticHost = page.getByTestId('parity-static')
@@ -445,5 +483,25 @@ describe('MarkdownView parity with the editor', () => {
     const editorRoot = editorHost.locate('.ProseMirror').element()
     const staticRoot = staticHost.locate('.ProseMirror').element()
     expect(canonicalize(staticRoot)).toBe(canonicalize(editorRoot))
+  })
+
+  it('matches the editor for a Mermaid diagram', async () => {
+    const markdown = 'before\n\n```mermaid\nflowchart LR\n  A[Start] --> B[End]\n```'
+    await render(
+      <div data-testid="parity-editor">
+        <ProseKitEditor initialMarkdown={markdown} markMode="hide" readOnly />
+      </div>,
+    )
+    await render(
+      <div data-testid="parity-static">
+        <MarkdownView markdown={markdown} />
+      </div>,
+    )
+    const editorPreview = editorHost.getByTestId('code-block-mermaid-preview')
+    const staticPreview = staticHost.getByTestId('code-block-mermaid-preview')
+    await expect.element(editorPreview.locate('svg'), { timeout: 15000 }).toBeInTheDocument()
+    await expect.element(staticPreview.locate('svg'), { timeout: 15000 }).toBeInTheDocument()
+
+    expect(canonicalize(staticPreview.element())).toBe(canonicalize(editorPreview.element()))
   })
 })

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -46,12 +46,14 @@ import {
   type ReactNode,
 } from 'react'
 
+import { useBeautifulMermaid } from '../hooks/use-beautiful-mermaid.ts'
 import { useKaTeX } from '../hooks/use-katex.ts'
 
 import { attributesToProps } from './attributes-to-props.ts'
 import styles from './code-block-view.module.css'
 import { normalizeDOMOutputSpec, type TypedDOMOutputSpec } from './dom-output-spec.tsx'
 import { MathRender } from './math-render.tsx'
+import { MermaidRender } from './mermaid-render.tsx'
 
 /** Payload for {@link TaskClickHandler}. */
 export interface TaskClickPayload {
@@ -441,6 +443,19 @@ function MathCodeBlock({ code }: { code: string }): ReactElement {
   )
 }
 
+function MermaidCodeBlock({ code }: { code: string }): ReactElement {
+  const renderer = useBeautifulMermaid(true)
+  if (!renderer || code.trim() === '') return <CodeBlock code={code} language="mermaid" />
+  return (
+    <MermaidRender
+      renderer={renderer}
+      source={code}
+      className={`${styles.Preview} ${styles.MermaidPreview}`}
+      data-testid="code-block-mermaid-preview"
+    />
+  )
+}
+
 /** Wrap inline `children` in one mark, special-casing the view/link marks. */
 function wrapMark(mark: Mark, children: ReactNode, context: RenderContext): ReactNode {
   const name = mark.type.name as MarkName
@@ -584,6 +599,9 @@ function renderBlock(node: ProseMirrorNode, context: RenderContext): ReactNode {
     const language: string = typeof attrs.language === 'string' ? attrs.language : ''
     if (language === 'math') {
       return <MathCodeBlock key={key} code={node.textContent} />
+    }
+    if (language === 'mermaid') {
+      return <MermaidCodeBlock key={key} code={node.textContent} />
     }
     return <CodeBlock key={key} code={node.textContent} language={language} />
   }

--- a/packages/react/src/components/mermaid-render.test.tsx
+++ b/packages/react/src/components/mermaid-render.test.tsx
@@ -1,0 +1,37 @@
+import '../testing/index.ts'
+
+import { describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+import { page } from 'vitest/browser'
+
+import type { BeautifulMermaidRender } from '../hooks/use-beautiful-mermaid.ts'
+
+import { MermaidRender } from './mermaid-render.tsx'
+
+describe('MermaidRender', () => {
+  it('resolves theme changes through CSS without rendering again', async () => {
+    const renderer = vi.fn<BeautifulMermaidRender>(() => {
+      return '<svg xmlns="http://www.w3.org/2000/svg" style="color:var(--meowdown-mermaid-fg)"><text>Diagram</text></svg>'
+    })
+    await render(
+      <div data-testid="mermaid-theme-host">
+        <MermaidRender renderer={renderer} source={'flowchart LR\n  A --> B'} />
+      </div>,
+    )
+    const host = page.getByTestId('mermaid-theme-host')
+    const svg = host.locate('svg')
+    host.element().style.setProperty('--meowdown-mermaid-fg', 'rgb(1, 2, 3)')
+    await expect.element(svg).toHaveStyle({ color: 'rgb(1, 2, 3)' })
+
+    host.element().style.setProperty('--meowdown-mermaid-fg', 'rgb(4, 5, 6)')
+
+    await expect.element(svg).toHaveStyle({ color: 'rgb(4, 5, 6)' })
+    expect(renderer).toHaveBeenCalledOnce()
+    expect(renderer).toHaveBeenCalledWith('flowchart LR\n  A --> B', {
+      bg: 'var(--meowdown-mermaid-bg)',
+      fg: 'var(--meowdown-mermaid-fg)',
+      interactive: false,
+      transparent: true,
+    })
+  })
+})

--- a/packages/react/src/components/mermaid-render.tsx
+++ b/packages/react/src/components/mermaid-render.tsx
@@ -1,0 +1,78 @@
+import type { RenderOptions } from 'beautiful-mermaid'
+import { useLayoutEffect, useMemo, useRef, type MouseEventHandler, type ReactElement } from 'react'
+
+import type { BeautifulMermaidRender } from '../hooks/use-beautiful-mermaid.ts'
+
+interface MermaidRenderProps {
+  renderer: BeautifulMermaidRender
+  source: string
+  className?: string
+  'data-testid'?: string
+  onMouseDown?: MouseEventHandler
+}
+
+const MERMAID_OPTIONS = {
+  bg: 'var(--meowdown-mermaid-bg)',
+  fg: 'var(--meowdown-mermaid-fg)',
+  transparent: true,
+  interactive: false,
+} satisfies RenderOptions
+
+type MermaidOutput =
+  | { element: Element; error?: undefined }
+  | { element?: undefined; error: string }
+
+function renderMermaid(renderer: BeautifulMermaidRender, source: string): MermaidOutput {
+  try {
+    const svg = renderer(source, MERMAID_OPTIONS)
+    const document = new DOMParser().parseFromString(svg, 'image/svg+xml')
+    const element = document.documentElement
+    if (
+      document.querySelector('parsererror') ||
+      element.localName !== 'svg' ||
+      element.namespaceURI !== 'http://www.w3.org/2000/svg'
+    ) {
+      return { error: 'Invalid SVG output.' }
+    }
+    return { element }
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+export function MermaidRender(props: MermaidRenderProps): ReactElement {
+  const { renderer, source, className, onMouseDown } = props
+  const output = useMemo(() => renderMermaid(renderer, source), [renderer, source])
+  const ref = useRef<HTMLSpanElement>(null)
+  useLayoutEffect(() => {
+    const host = ref.current
+    if (!host || !output.element) return
+    host.replaceChildren(window.document.importNode(output.element, true))
+  }, [output])
+
+  if (output.error) {
+    return (
+      <span
+        key="error"
+        className={className}
+        contentEditable={false}
+        data-error
+        data-testid={props['data-testid']}
+        onMouseDown={onMouseDown}
+      >
+        {output.error}
+      </span>
+    )
+  }
+
+  return (
+    <span
+      key="svg"
+      ref={ref}
+      className={className}
+      contentEditable={false}
+      data-testid={props['data-testid']}
+      onMouseDown={onMouseDown}
+    />
+  )
+}

--- a/packages/react/src/hooks/beautiful-mermaid-chunk.ts
+++ b/packages/react/src/hooks/beautiful-mermaid-chunk.ts
@@ -1,0 +1,5 @@
+import { renderMermaidSVG } from 'beautiful-mermaid'
+
+export type BeautifulMermaidRender = typeof renderMermaidSVG
+
+export { renderMermaidSVG }

--- a/packages/react/src/hooks/use-beautiful-mermaid.ts
+++ b/packages/react/src/hooks/use-beautiful-mermaid.ts
@@ -1,12 +1,12 @@
-import type { renderMermaidSVG } from 'beautiful-mermaid'
 import { useEffect, useState } from 'react'
+import type { BeautifulMermaidRender } from './beautiful-mermaid-chunk.ts'
 
-export type BeautifulMermaidRender = typeof renderMermaidSVG
+export { type BeautifulMermaidRender }
 
 let beautifulMermaidPromise: Promise<BeautifulMermaidRender> | undefined
 
 function loadBeautifulMermaid(): Promise<BeautifulMermaidRender> {
-  beautifulMermaidPromise ??= import('beautiful-mermaid')
+  beautifulMermaidPromise ??= import('./beautiful-mermaid-chunk.ts')
     .then((module) => module.renderMermaidSVG)
     .catch((error) => {
       console.error('[meowdown] Failed to load beautiful-mermaid.', error)

--- a/packages/react/src/hooks/use-beautiful-mermaid.ts
+++ b/packages/react/src/hooks/use-beautiful-mermaid.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+
 import type { BeautifulMermaidRender } from './beautiful-mermaid-chunk.ts'
 
 export { type BeautifulMermaidRender }

--- a/packages/react/src/hooks/use-beautiful-mermaid.ts
+++ b/packages/react/src/hooks/use-beautiful-mermaid.ts
@@ -1,0 +1,33 @@
+import type { renderMermaidSVG } from 'beautiful-mermaid'
+import { useEffect, useState } from 'react'
+
+export type BeautifulMermaidRender = typeof renderMermaidSVG
+
+let beautifulMermaidPromise: Promise<BeautifulMermaidRender> | undefined
+
+export function loadBeautifulMermaid(): Promise<BeautifulMermaidRender> {
+  beautifulMermaidPromise ??= import('beautiful-mermaid')
+    .then((module) => module.renderMermaidSVG)
+    .catch((error) => {
+      console.error('[meowdown] Failed to load beautiful-mermaid.', error)
+      throw error
+    })
+  return beautifulMermaidPromise
+}
+
+export function useBeautifulMermaid(enabled: boolean): BeautifulMermaidRender | undefined {
+  const [renderer, setRenderer] = useState<BeautifulMermaidRender | undefined>(undefined)
+  useEffect(() => {
+    if (!enabled || renderer) return
+    let cancelled = false
+    void loadBeautifulMermaid()
+      .then((loadedRenderer) => {
+        if (!cancelled) setRenderer(() => loadedRenderer)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [enabled, renderer])
+  return renderer
+}

--- a/packages/react/src/hooks/use-beautiful-mermaid.ts
+++ b/packages/react/src/hooks/use-beautiful-mermaid.ts
@@ -5,7 +5,7 @@ export type BeautifulMermaidRender = typeof renderMermaidSVG
 
 let beautifulMermaidPromise: Promise<BeautifulMermaidRender> | undefined
 
-export function loadBeautifulMermaid(): Promise<BeautifulMermaidRender> {
+function loadBeautifulMermaid(): Promise<BeautifulMermaidRender> {
   beautifulMermaidPromise ??= import('beautiful-mermaid')
     .then((module) => module.renderMermaidSVG)
     .catch((error) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,9 @@ importers:
       '@prosekit/react':
         specifier: ^0.8.0-beta.21
         version: 0.8.0-beta.21(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(react-dom@19.2.7)(react@19.2.7)
+      beautiful-mermaid:
+        specifier: ^1.1.3
+        version: 1.1.3
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1837,6 +1840,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  beautiful-mermaid@1.1.3:
+    resolution: {integrity: sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg==}
+
   birecord@0.1.2:
     resolution: {integrity: sha512-5PAPTTmMpMEb+GuMb5DebfBkipRGyIW9+gtwEBSoDA9xkhHILm04+hZQ702pMksu3d8YAuGkmgTzQWcKqTPScA==}
 
@@ -2020,6 +2026,9 @@ packages:
   electron-to-chromium@1.5.389:
     resolution: {integrity: sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==}
 
+  elkjs@0.11.1:
+    resolution: {integrity: sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==}
+
   empathic@2.0.1:
     resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
     engines: {node: '>=14'}
@@ -2034,6 +2043,10 @@ packages:
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   entities@8.0.0:
@@ -5401,6 +5414,11 @@ snapshots:
 
   baseline-browser-mapping@2.10.42: {}
 
+  beautiful-mermaid@1.1.3:
+    dependencies:
+      elkjs: 0.11.1
+      entities: 7.0.1
+
   birecord@0.1.2: {}
 
   boolbase@1.0.0: {}
@@ -5531,6 +5549,8 @@ snapshots:
 
   electron-to-chromium@1.5.389: {}
 
+  elkjs@0.11.1: {}
+
   empathic@2.0.1: {}
 
   enhanced-resolve@5.21.6:
@@ -5541,6 +5561,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   entities@8.0.0: {}
 

--- a/website/src/app.tsx
+++ b/website/src/app.tsx
@@ -185,6 +185,13 @@ function greet(name: string): string {
 }
 \`\`\`
 
+Mermaid diagrams render live too:
+
+\`\`\`mermaid
+flowchart LR
+  Markdown --> Diagram
+\`\`\`
+
 | table | syntax | is | supported |
 | ----- | ------ | -- | --------- |
 | even  | **in** | *tables* too! | :D |


### PR DESCRIPTION
Closes https://github.com/prosekit/meowdown/issues/316 

Renders `mermaid` fenced code blocks with lazy-loaded `beautiful-mermaid` in both the editor and `MarkdownView`.

Previews stay caret-aware and passive, unsupported diagrams show editable errors, and the homepage includes a small Flowchart example. Validated with typecheck, lint, the full Vitest suite, and the website production build.
