### PR TITLE
fix(core): treat table pipe layout as normalizing in `checkRoundTrip`

### DIFF
--- a/packages/core/src/converters/check-roundtrip.test.ts
+++ b/packages/core/src/converters/check-roundtrip.test.ts
@@ -77,12 +77,20 @@ describe('checkRoundTrip', () => {
     '- [ ] todo\neen voorlopig idee', // a lazy continuation gains the canonical item indent
     '- item\nlazy line', // same, on a plain bullet
     '#  Journal', // a double space after the ATX marker collapses to one
+    '| a | b |\n| --- | ----------- |\n| c | d |', // delimiter dash counts are layout
+    '| a | b |\n| - | - |\n| c | d |', // same, shorter than canonical
+    '| a |\n| :---: |\n| b |', // alignment colons survive; only the dash count normalizes
+    '| a | b |\n| :--- | ---: |\n| c | d |', // same, for left / right alignment
+    '|a|b|\n|---|---|\n|c|d|', // spacing around pipes is layout
+    '| a    | b  |\n| ---- | -- |\n| c    | d  |', // pretty-printed cell padding is layout
+    'a | b\n--- | ---\nc | d', // outer pipes are layout
+    '> a | b\n> --- | ---', // same, inside a blockquote
   ])('reports normalizing for %j', (markdown) => {
     expect(checkRoundTrip(markdown)).toBe('normalizing')
   })
 
   it.each([
-    '| a |\n| :---: |\n| b |', // table column alignment is dropped: same line count, content differs
+    '| a |\n| --- |\n| b | c |', // a cell beyond the delimiter's column count is dropped
   ])('reports lossy for %j', (markdown) => {
     expect(checkRoundTrip(markdown)).toBe('lossy')
   })

--- a/packages/core/src/converters/check-roundtrip.ts
+++ b/packages/core/src/converters/check-roundtrip.ts
@@ -6,7 +6,8 @@ import { docToMarkdown } from './pm-to-md.ts'
  * - `exact`: byte-identical (modulo the trailing newline).
  * - `normalizing`: bytes differ, but only as layout the parser collapses back -
  *   no non-blank line content is lost and re-parsing the output yields the same
- *   doc (e.g. a lazy continuation re-indented to its canonical column).
+ *   doc (e.g. a lazy continuation re-indented to its canonical column, or a
+ *   table delimiter row rewritten to canonical dashes).
  * - `lossy`: content changed - a non-blank line differs, or the re-parsed doc does.
  */
 export type RoundTripFidelity = 'exact' | 'normalizing' | 'lossy'
@@ -35,6 +36,42 @@ function collapseWhitespace(line: string): string {
   return line.trim().replaceAll(/\s+/gu, ' ')
 }
 
+// A GFM delimiter cell is optional colons around a run of dashes. The dash
+// count is layout; only the colon positions carry content (column alignment).
+const DELIMITER_CELL_RE = /^:?-+:?$/u
+
+function canonicalizeDelimiterCell(cell: string): string {
+  const alignsLeft = cell.startsWith(':')
+  const alignsRight = cell.endsWith(':')
+  if (alignsLeft && alignsRight) return ':-:'
+  if (alignsLeft) return ':--'
+  if (alignsRight) return '--:'
+  return '---'
+}
+
+// Rebuild a pipe-bearing line into the serializer's `| a | b |` form. Outer
+// pipes, spacing around pipes, and delimiter dash counts are table layout the
+// parser reads through, so two rows that differ only there carry the same
+// content. Lines the serializer never restructures (a paragraph or code line
+// holding pipes) canonicalize the same way on both sides, so equal lines stay
+// equal; the leading `[\s>]*` prefix is kept so rows inside a blockquote
+// compare within their blockquote.
+function canonicalizeTableRow(line: string): string | undefined {
+  if (!line.includes('|')) return undefined
+  const prefix = /^[\s>]*/u.exec(line)?.[0] ?? ''
+  const row = line.slice(prefix.length).trim()
+  const inner = row.replace(/^\|/u, '').replace(/\|$/u, '')
+  const cells = inner.split('|').map((cell) => collapseWhitespace(cell))
+  const rendered = cells.every((cell) => DELIMITER_CELL_RE.test(cell))
+    ? cells.map(canonicalizeDelimiterCell)
+    : cells
+  return collapseWhitespace(`${prefix} | ${rendered.join(' | ')} |`)
+}
+
+function normalizeLine(line: string): string {
+  return canonicalizeTableRow(line) ?? collapseWhitespace(line)
+}
+
 /** Options for {@link checkRoundTrip}. */
 export interface CheckRoundTripOptions {
   /** Whether to handle a leading `---` frontmatter block. Off by default. */
@@ -54,7 +91,7 @@ export function checkRoundTrip(
   const after = nonBlankLines(serialized)
   const textMatches =
     before.length === after.length &&
-    before.every((line, i) => collapseWhitespace(line) === collapseWhitespace(after[i]))
+    before.every((line, i) => normalizeLine(line) === normalizeLine(after[i]))
 
   return textMatches ? 'normalizing' : 'lossy'
 }


### PR DESCRIPTION
`checkRoundTrip` reported `lossy` for any table whose pipe layout differs from the serializer's canonical form: delimiter rows with extra dashes (`| --- | ----------- |`), wider alignment markers (`:---`), pretty-printed cell padding, or missing outer pipes. Per GFM these are pure layout (only colon positions and cell text carry content), so consumers gating editability on the fidelity fell back to read-only for common real-world tables (https://github.com/team-reflect/reflect-open/issues/817). The line comparison now rebuilds pipe-bearing lines into the serializer's canonical row form before comparing, so such tables classify as `normalizing`.