### PR TITLE
fix(react): keep Mermaid diagrams legible with host themes

### DIFF
--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -46,9 +46,32 @@
     /* inline and block code background */
     --meowdown-code-bg: light-dark(oklch(0.967 0 0), oklch(0.21 0.006 286));
 
-    /* Mermaid diagram background, foreground, and errors */
+    /* Mermaid diagram palette. The enrichment colors are passed explicitly so
+     * generic host variables such as `--muted` and `--border` cannot leak into
+     * the generated SVG. */
     --meowdown-mermaid-bg: var(--meowdown-code-bg);
     --meowdown-mermaid-fg: var(--meowdown-text);
+    --meowdown-mermaid-line: color-mix(
+      in srgb,
+      var(--meowdown-mermaid-fg) 50%,
+      var(--meowdown-mermaid-bg)
+    );
+    --meowdown-mermaid-accent: var(--meowdown-accent);
+    --meowdown-mermaid-muted: color-mix(
+      in srgb,
+      var(--meowdown-mermaid-fg) 60%,
+      var(--meowdown-mermaid-bg)
+    );
+    --meowdown-mermaid-surface: color-mix(
+      in srgb,
+      var(--meowdown-mermaid-fg) 3%,
+      var(--meowdown-mermaid-bg)
+    );
+    --meowdown-mermaid-border: color-mix(
+      in srgb,
+      var(--meowdown-mermaid-fg) 20%,
+      var(--meowdown-mermaid-bg)
+    );
     --meowdown-mermaid-error: var(--meowdown-danger);
 
     /* placeholder fill while an image loads */

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -130,8 +130,10 @@ the block, then shows source and a live preview while editing it.
 Rendering uses `beautiful-mermaid`, which currently supports Flowchart, State,
 Sequence, Class, ER, and XY Chart diagrams. Unsupported syntax renders an error
 instead of an empty preview. Override `--meowdown-mermaid-bg`,
-`--meowdown-mermaid-fg`, or `--meowdown-mermaid-error` to customize the
-diagram surface.
+`--meowdown-mermaid-fg`, `--meowdown-mermaid-line`,
+`--meowdown-mermaid-accent`, `--meowdown-mermaid-muted`,
+`--meowdown-mermaid-surface`, `--meowdown-mermaid-border`, or
+`--meowdown-mermaid-error` to customize the diagram palette.
 
 ## Styling
 

--- a/packages/react/src/components/mermaid-render.test.tsx
+++ b/packages/react/src/components/mermaid-render.test.tsx
@@ -9,9 +9,9 @@ import type { BeautifulMermaidRender } from '../hooks/use-beautiful-mermaid.ts'
 import { MermaidRender } from './mermaid-render.tsx'
 
 describe('MermaidRender', () => {
-  it('resolves theme changes through CSS without rendering again', async () => {
-    const renderer = vi.fn<BeautifulMermaidRender>(() => {
-      return '<svg xmlns="http://www.w3.org/2000/svg" style="color:var(--meowdown-mermaid-fg)"><text>Diagram</text></svg>'
+  it('isolates its live theme from generic host variables without rendering again', async () => {
+    const renderer = vi.fn<BeautifulMermaidRender>((_source, options) => {
+      return `<svg xmlns="http://www.w3.org/2000/svg" style="color:${options?.muted}"><text>Diagram</text></svg>`
     })
     await render(
       <div data-testid="mermaid-theme-host">
@@ -20,16 +20,23 @@ describe('MermaidRender', () => {
     )
     const host = page.getByTestId('mermaid-theme-host')
     const svg = host.locate('svg')
-    host.element().style.setProperty('--meowdown-mermaid-fg', 'rgb(1, 2, 3)')
+    host.element().style.setProperty('--muted', 'rgb(255, 255, 255)')
+    host.element().style.setProperty('--meowdown-mermaid-muted', 'rgb(1, 2, 3)')
     await expect.element(svg).toHaveStyle({ color: 'rgb(1, 2, 3)' })
 
-    host.element().style.setProperty('--meowdown-mermaid-fg', 'rgb(4, 5, 6)')
+    host.element().style.setProperty('--muted', 'rgb(0, 0, 0)')
+    host.element().style.setProperty('--meowdown-mermaid-muted', 'rgb(4, 5, 6)')
 
     await expect.element(svg).toHaveStyle({ color: 'rgb(4, 5, 6)' })
     expect(renderer).toHaveBeenCalledOnce()
     expect(renderer).toHaveBeenCalledWith('flowchart LR\n  A --> B', {
       bg: 'var(--meowdown-mermaid-bg)',
       fg: 'var(--meowdown-mermaid-fg)',
+      line: 'var(--meowdown-mermaid-line)',
+      accent: 'var(--meowdown-mermaid-accent)',
+      muted: 'var(--meowdown-mermaid-muted)',
+      surface: 'var(--meowdown-mermaid-surface)',
+      border: 'var(--meowdown-mermaid-border)',
       interactive: false,
       transparent: true,
     })

--- a/packages/react/src/components/mermaid-render.tsx
+++ b/packages/react/src/components/mermaid-render.tsx
@@ -14,6 +14,11 @@ interface MermaidRenderProps {
 const MERMAID_OPTIONS = {
   bg: 'var(--meowdown-mermaid-bg)',
   fg: 'var(--meowdown-mermaid-fg)',
+  line: 'var(--meowdown-mermaid-line)',
+  accent: 'var(--meowdown-mermaid-accent)',
+  muted: 'var(--meowdown-mermaid-muted)',
+  surface: 'var(--meowdown-mermaid-surface)',
+  border: 'var(--meowdown-mermaid-border)',
   transparent: true,
   interactive: false,
 } satisfies RenderOptions


### PR DESCRIPTION
## Problem

Mermaid previews currently pass only background and foreground colors to `beautiful-mermaid`. Its remaining SVG palette uses generic CSS custom properties such as `--muted`, `--surface`, `--border`, and `--accent`.

Those names can already exist in a host application. When they do, the generated SVG inherits unrelated host values. In Reflect, that makes edge labels nearly white, node fills white, and node outlines almost invisible.

## Before -> After

| Scenario | Before | After |
| --- | --- | --- |
| Host defines generic theme variables | Mermaid silently inherits them | The SVG receives explicit `--meowdown-mermaid-*` colors |
| Host changes its light/dark palette | Background and foreground update live | The complete diagram palette updates live |
| Consumer customization | Background, foreground, and errors only | Line, accent, muted text, surface, and border are also themeable |

## Changes

1. Pass explicit `line`, `accent`, `muted`, `surface`, and `border` options to `renderMermaidSVG`.
2. Add namespaced defaults that preserve the renderer hierarchy while following the Meowdown accent.
3. Document the complete Mermaid palette.
4. Extend the browser regression test with hostile inherited variables and verify that theme changes still avoid a rerender.

## Tests

- Pins the exact renderer options passed for every Mermaid palette role.
- Verifies a generic host `--muted` value cannot override `--meowdown-mermaid-muted`.
- Retains the existing live theme-switch behavior.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test --run` — 103 files, 1,937 passed, 13 expected failures
- `pnpm build`
- Browser verification in light and dark modes with conflicting generic host variables; the page loaded without an error overlay and the SVG resolved every palette role from the namespaced variables.

## Risk / Rollout

This changes only rendered Mermaid colors. Existing `--meowdown-mermaid-bg`, `--meowdown-mermaid-fg`, and error overrides remain compatible. The new variables give hosts an explicit extension point instead of relying on generic inherited names.