### PR TITLE
feat(markdown): re-export some types from `@lezer/common`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,6 @@
     "@codemirror/language": "^6.12.4",
     "@codemirror/language-data": "^6.5.2",
     "@floating-ui/dom": "^1.8.0",
-    "@lezer/common": "^1.5.2",
     "@lezer/highlight": "^1.2.3",
     "@meowdown/markdown": "workspace:^",
     "@ocavue/utils": "^1.7.0",

--- a/packages/core/src/converters/md-to-pm.ts
+++ b/packages/core/src/converters/md-to-pm.ts
@@ -1,5 +1,9 @@
-import type { TreeCursor } from '@lezer/common'
-import { gfmBlockOnlyParser, isSpaceChar, LEZER_NODE_IDS } from '@meowdown/markdown'
+import {
+  gfmBlockOnlyParser,
+  isSpaceChar,
+  LEZER_NODE_IDS,
+  type TreeCursor,
+} from '@meowdown/markdown'
 import type { ProseMirrorNode } from '@prosekit/pm/model'
 
 import type { CodeBlockFenceStyle } from '../extensions/code-block.ts'

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,3 +1,6 @@
 import { defineSharedConfig } from '@meowdown/vitest/config'
 
-export default defineSharedConfig()
+export default defineSharedConfig({
+  env: 'browser',
+  groupOrder: 1000,
+})

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -20,6 +20,7 @@
     "build": "tsdown"
   },
   "dependencies": {
+    "@lezer/common": "^1.5.2",
     "@lezer/markdown": "^1.7.1"
   },
   "devDependencies": {

--- a/packages/markdown/src/index.ts
+++ b/packages/markdown/src/index.ts
@@ -3,5 +3,5 @@ export { collectInlineElements, parseInline, type InlineElement } from './inline
 export { LEZER_NODE_IDS } from './node-ids.ts'
 export { gfmBlockOnlyParser, gfmParser } from './parser.ts'
 export { isSpaceChar } from './unicode.ts'
-export type { SyntaxNode, Tree } from '@lezer/common'
+export type { SyntaxNode, Tree, TreeCursor } from '@lezer/common'
 export type { MarkdownParser } from './parser.ts'

--- a/packages/markdown/src/index.ts
+++ b/packages/markdown/src/index.ts
@@ -3,4 +3,5 @@ export { collectInlineElements, parseInline, type InlineElement } from './inline
 export { LEZER_NODE_IDS } from './node-ids.ts'
 export { gfmBlockOnlyParser, gfmParser } from './parser.ts'
 export { isSpaceChar } from './unicode.ts'
+export type { SyntaxNode, Tree } from '@lezer/common'
 export type { MarkdownParser } from './parser.ts'

--- a/packages/markdown/vitest.config.ts
+++ b/packages/markdown/vitest.config.ts
@@ -1,9 +1,6 @@
-import { defineProject } from 'vitest/config'
+import { defineSharedConfig } from '@meowdown/vitest/config'
 
-export default defineProject({
-  test: {
-    environment: 'node',
-    setupFiles: ['@meowdown/vitest/setup-console'],
-    snapshotSerializers: ['@meowdown/vitest/custom-string-serializer'],
-  },
+export default defineSharedConfig({
+  env: 'node',
+  groupOrder: 500,
 })

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -1,3 +1,6 @@
 import { defineSharedConfig } from '@meowdown/vitest/config'
 
-export default defineSharedConfig()
+export default defineSharedConfig({
+  env: 'browser',
+  groupOrder: 2000,
+})

--- a/packages/vitest/src/config.ts
+++ b/packages/vitest/src/config.ts
@@ -5,7 +5,13 @@ import { defineProject } from 'vitest/config'
 const IS_BOT = !!(process.env.AI_AGENT || process.env.CI)
 const IS_DEBUG = !!process.env.DEBUG
 
-export function defineSharedConfig() {
+export function defineSharedConfig({
+  groupOrder,
+  env,
+}: {
+  groupOrder: number
+  env: 'browser' | 'node'
+}) {
   const browserName = (() => {
     if (process.env.MEOWDOWN_TEST_BROWSER === 'webkit') {
       return 'webkit'
@@ -20,24 +26,27 @@ export function defineSharedConfig() {
   })()
 
   const setupFiles = ['@meowdown/vitest/setup-console']
-  if (browserName === 'webkit') {
+  if (env === 'browser' && browserName === 'webkit') {
     setupFiles.push('@meowdown/vitest/setup-webkit')
   }
 
   return defineProject({
     plugins: [playwrightCommands()],
     oxc:
-      browserName === 'webkit'
+      env === 'browser' && browserName === 'webkit'
         ? // WebKit's JavaScriptCore can't parse `using` declarations; lower them
           { target: 'es2025' }
         : undefined,
     test: {
       setupFiles,
       snapshotSerializers: ['@meowdown/vitest/custom-string-serializer'],
+      sequence: {
+        groupOrder,
+      },
       retry: IS_BOT ? 3 : 0,
       fileParallelism: false,
       browser: {
-        enabled: true,
+        enabled: env === 'browser',
         viewport: {
           width: 900,
           height: 600,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,9 +72,6 @@ importers:
       '@floating-ui/dom':
         specifier: ^1.8.0
         version: 1.8.0
-      '@lezer/common':
-        specifier: ^1.5.2
-        version: 1.5.2
       '@lezer/highlight':
         specifier: ^1.2.3
         version: 1.2.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
 
   packages/markdown:
     dependencies:
+      '@lezer/common':
+        specifier: ^1.5.2
+        version: 1.5.2
       '@lezer/markdown':
         specifier: ^1.7.1
         version: 1.7.1


### PR DESCRIPTION
Re-export the lezer tree types from `@lezer/common` so consumers (including `@meowdown/core` itself) can type their parse-tree walkers without a direct `@lezer/common` dependency.