### PR TITLE
feat(markdown): export the `LezerNodeName` type

### DIFF
--- a/packages/markdown/src/index.ts
+++ b/packages/markdown/src/index.ts
@@ -1,6 +1,7 @@
 export { getAutolinkHref } from './autolink-tld.ts'
 export { collectInlineElements, parseInline, type InlineElement } from './inline.ts'
 export { LEZER_NODE_IDS } from './node-ids.ts'
+export type { LezerNodeName } from './node-names.ts'
 export { gfmBlockOnlyParser, gfmParser } from './parser.ts'
 export { isSpaceChar } from './unicode.ts'
 export type { SyntaxNode, Tree, TreeCursor } from '@lezer/common'


### PR DESCRIPTION
Export the `LezerNodeName` union (every node name `gfmParser` can produce) so hosts can type their tree walkers against the grammar instead of bare strings.