### PR TITLE
ci: create one git tag and one GitHub release per version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,37 +18,6 @@ jobs:
         id: release-please
         with:
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
-
-      # release-please titles the grouped release PR "chore: release master": the
-      # merge plugin fills ${version} only from a root-path package, which this repo
-      # does not have (https://github.com/googleapis/release-please/issues/2386), and
-      # the linked-versions plugin hardcodes its own title
-      # (https://github.com/googleapis/release-please/issues/2305). This step
-      # retitles the PR with the version from the manifest on the PR branch.
-      #
-      # The title must keep the exact shape "chore: release X.Y.Z": release-please
-      # re-parses the title when the PR merges, and a shape it cannot parse skips
-      # tagging and publish (https://github.com/googleapis/release-please/issues/2712).
-      # Component versions still come from the PR body, not the title
-      # (https://github.com/googleapis/release-please/issues/2101), so the rewrite is
-      # safe. Delete this step once the grouped title becomes configurable upstream
-      # (https://github.com/googleapis/release-please/pull/2617).
-      - name: Add version to release PR title
-        if: ${{ steps.release-please.outputs.prs_created == 'true' }}
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
-          PRS: ${{ steps.release-please.outputs.prs }}
-        run: |
-          number=$(jq -r '.[0].number' <<< "$PRS")
-          branch=$(jq -r '.[0].headBranchName' <<< "$PRS")
-          version=$(gh api "repos/${{ github.repository }}/contents/.release-please-manifest.json?ref=$branch" \
-            -H 'Accept: application/vnd.github.raw+json' | jq -r '.["packages/core"]')
-          if [ -z "$version" ] || [ "$version" = "null" ]; then
-            echo "could not resolve version from manifest on $branch" >&2
-            exit 1
-          fi
-          gh pr edit "$number" --repo "${{ github.repository }}" --title "chore: release $version"
     outputs:
       releases_created: ${{ steps.release-please.outputs.releases_created }}
 

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,3 @@
 {
-  "packages/core": "0.54.0",
-  "packages/markdown": "0.54.0",
-  "packages/react": "0.54.0"
+  ".": "0.54.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meowdown-monorepo",
   "type": "module",
-  "version": "0.0.0",
+  "version": "0.54.0",
   "private": true,
   "packageManager": "pnpm@11.13.0",
   "scripts": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,21 +3,16 @@
   "bump-minor-pre-major": true,
   "always-update": true,
   "packages": {
-    "packages/core": {
-      "component": "core"
-    },
-    "packages/markdown": {
-      "component": "markdown"
-    },
-    "packages/react": {
-      "component": "react"
+    ".": {
+      "release-type": "node",
+      "include-component-in-tag": false,
+      "pull-request-title-pattern": "chore: release ${version}",
+      "exclude-paths": ["website", "packages/vitest", "packages/eslint-rules", ".github"],
+      "extra-files": [
+        { "type": "json", "path": "packages/core/package.json", "jsonpath": "$.version" },
+        { "type": "json", "path": "packages/markdown/package.json", "jsonpath": "$.version" },
+        { "type": "json", "path": "packages/react/package.json", "jsonpath": "$.version" }
+      ]
     }
-  },
-  "plugins": [
-    {
-      "type": "linked-versions",
-      "groupName": "meowdown",
-      "components": ["core", "markdown", "react"]
-    }
-  ]
+  }
 }


### PR DESCRIPTION
Collapse the release-please config to a single root package: each version now produces one `vX.Y.Z` tag and one GitHub release instead of three per-component ones, with the three `package.json` versions bumped via `extra-files`. With a single package the release PR title renders correctly on its own, so the retitle workaround step and the `linked-versions` plugin are removed. The baseline tag `v0.54.0` is pushed alongside this PR so the first run after merge can locate the previous release.