### PR TITLE
fix(react): stop wikilink hover card side flip loop near the viewport bottom

### DIFF
--- a/packages/react/src/components/wikilink-hover-card.module.css
+++ b/packages/react/src/components/wikilink-hover-card.module.css
@@ -1,7 +1,7 @@
 .Positioner {
   z-index: 50;
-  max-width: calc(100vw - 1rem);
-  max-height: calc(100vh - 1rem);
+  width: var(--positioner-width);
+  height: var(--positioner-height);
   pointer-events: none;
   transition-property: top, left, right, bottom, transform;
   transition-timing-function: cubic-bezier(0.22, 1, 0.36, 1);

--- a/packages/react/src/components/wikilink-hover-card.test.tsx
+++ b/packages/react/src/components/wikilink-hover-card.test.tsx
@@ -13,7 +13,6 @@ import { WikilinkHoverCard } from './wikilink-hover-card.tsx'
 
 const pmRoot = page.locate('.ProseMirror')
 const card = page.getByTestId('wikilink-hover-card')
-const positioner = page.getByTestId('wikilink-hover-positioner')
 
 function HostPreviewCard() {
   return (
@@ -250,35 +249,6 @@ describe('WikilinkHoverCard', () => {
     expect(document.activeElement).toBe(activeElement)
     expect(handleRef.current?.getSelection()).toEqual(selection)
     await expect.element(card).toHaveAttribute('inert')
-  })
-
-  it('keeps one side when the link has partial space below', async () => {
-    await unhover()
-    await render(
-      <div style={{ position: 'fixed', left: 0, top: 470, width: 400 }}>
-        <MeowdownEditor initialMarkdown="[[Edge]]" blockHandle={false}>
-          <WikilinkHoverCard>
-            {(hit) => <div style={{ height: 150 }}>Preview: {hit.target}</div>}
-          </WikilinkHoverCard>
-        </MeowdownEditor>
-      </div>,
-    )
-
-    await hover(pmRoot.getByTestId('wikilink'))
-    await expect.element(card, { timeout: 1000 }).toBeInTheDocument()
-    await expect.element(positioner).toHaveAttribute('data-side', 'top')
-
-    const positionerElement = positioner.element()
-    const sides = new Set<string | null>()
-    const start = performance.now()
-    while (performance.now() - start < 500) {
-      sides.add(positionerElement.getAttribute('data-side'))
-      await new Promise((resolve) => requestAnimationFrame(resolve))
-    }
-    expect([...sides]).toEqual(['top'])
-    await vi.waitFor(() => {
-      expect(positionerElement.getBoundingClientRect().height).toBeGreaterThan(0)
-    })
   })
 
   it('keeps the popup inside an 8px viewport margin near the bottom-right edge', async () => {

--- a/packages/react/src/components/wikilink-hover-card.test.tsx
+++ b/packages/react/src/components/wikilink-hover-card.test.tsx
@@ -13,6 +13,7 @@ import { WikilinkHoverCard } from './wikilink-hover-card.tsx'
 
 const pmRoot = page.locate('.ProseMirror')
 const card = page.getByTestId('wikilink-hover-card')
+const positioner = page.getByTestId('wikilink-hover-positioner')
 
 function HostPreviewCard() {
   return (
@@ -249,6 +250,35 @@ describe('WikilinkHoverCard', () => {
     expect(document.activeElement).toBe(activeElement)
     expect(handleRef.current?.getSelection()).toEqual(selection)
     await expect.element(card).toHaveAttribute('inert')
+  })
+
+  it('keeps one side when the link has partial space below', async () => {
+    await unhover()
+    await render(
+      <div style={{ position: 'fixed', left: 0, top: 470, width: 400 }}>
+        <MeowdownEditor initialMarkdown="[[Edge]]" blockHandle={false}>
+          <WikilinkHoverCard>
+            {(hit) => <div style={{ height: 150 }}>Preview: {hit.target}</div>}
+          </WikilinkHoverCard>
+        </MeowdownEditor>
+      </div>,
+    )
+
+    await hover(pmRoot.getByTestId('wikilink'))
+    await expect.element(card, { timeout: 1000 }).toBeInTheDocument()
+    await expect.element(positioner).toHaveAttribute('data-side', 'top')
+
+    const positionerElement = positioner.element()
+    const sides = new Set<string | null>()
+    const start = performance.now()
+    while (performance.now() - start < 500) {
+      sides.add(positionerElement.getAttribute('data-side'))
+      await new Promise((resolve) => requestAnimationFrame(resolve))
+    }
+    expect([...sides]).toEqual(['top'])
+    await vi.waitFor(() => {
+      expect(positionerElement.getBoundingClientRect().height).toBeGreaterThan(0)
+    })
   })
 
   it('keeps the popup inside an 8px viewport margin near the bottom-right edge', async () => {


### PR DESCRIPTION
Near the viewport bottom, the hover card flipped between top and bottom every frame: Base UI's viewport machinery bottom-anchors the popup with `position: absolute` when the card is on the top side, the unsized positioner then collapsed to 0x0, and `flip` saw a popup that fits below again. Size the positioner with Base UI's `--positioner-width`/`--positioner-height` variables so it keeps its size, and add a regression test.

https://github.com/user-attachments/assets/377c58d8-9755-4c78-b323-9e637aa184b3

