### PR TITLE
fix(core): make Mod-Shift-V paste without formatting in shells without a native shortcut

### DIFF
--- a/packages/core/src/extensions/clipboard/clipboard.ts
+++ b/packages/core/src/extensions/clipboard/clipboard.ts
@@ -4,6 +4,7 @@ import { defineHTMLPaste } from '../html-paste.ts'
 
 import { defineClipboardParser } from './clipboard-parser.ts'
 import { defineSemanticClipboardSerializer } from './clipboard-serializer.ts'
+import { definePlainPasteFallback } from './plain-paste-fallback.ts'
 import { definePlainTextPaste } from './plain-paste.ts'
 import { definePlainTextSerializer } from './plain-text.ts'
 
@@ -20,5 +21,6 @@ export function defineClipboard(): PlainExtension {
     defineClipboardParser(),
     defineHTMLPaste(),
     definePlainTextPaste(),
+    definePlainPasteFallback(),
   )
 }

--- a/packages/core/src/extensions/clipboard/plain-paste-fallback.test.ts
+++ b/packages/core/src/extensions/clipboard/plain-paste-fallback.test.ts
@@ -1,0 +1,135 @@
+import type { EditorView } from '@prosekit/pm/view'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { docToMarkdown } from '../../converters/pm-to-md.ts'
+import { setupFixture } from '../../testing/index.ts'
+
+/**
+ * Dispatch the bare Mod-Shift-V keydown a desktop shell without a "Paste and
+ * Match Style" menu item delivers: the keystroke reaches the page, but no
+ * paste event follows. A synthetic event never triggers the browser's own
+ * paste, so this reproduces that environment on every engine.
+ */
+function pressPlainPasteShortcut(view: EditorView): void {
+  const isApple = /Mac|iP(?:hone|[oa]d)/.test(navigator.platform)
+  const event = new KeyboardEvent('keydown', {
+    key: 'V',
+    code: 'KeyV',
+    shiftKey: true,
+    metaKey: isApple,
+    ctrlKey: !isApple,
+    bubbles: true,
+    cancelable: true,
+  })
+  // prosemirror-keymap matches `Shift-` bindings through the keyCode-derived
+  // base key name, and constructor-created events carry `keyCode: 0`.
+  Object.defineProperty(event, 'keyCode', { value: 86 })
+  view.dom.dispatchEvent(event)
+}
+
+function fireNativePlainPaste(view: EditorView, text: string): void {
+  const clipboardData = new DataTransfer()
+  clipboardData.setData('text/plain', text)
+  const event = new ClipboardEvent('paste', { clipboardData, cancelable: true })
+  // Firefox discards the DataTransfer passed to the ClipboardEvent
+  // constructor; shadow the getter with the real object when it did not survive.
+  if (event.clipboardData?.getData('text/plain') !== text) {
+    Object.defineProperty(event, 'clipboardData', { value: clipboardData })
+  }
+  view.dom.dispatchEvent(event)
+}
+
+function stubClipboardReadText(text: string | Error) {
+  return vi
+    .spyOn(navigator.clipboard, 'readText')
+    .mockImplementation(() =>
+      text instanceof Error ? Promise.reject(text) : Promise.resolve(text),
+    )
+}
+
+async function waitPastNativePasteWindow(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 300))
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('plain paste fallback', () => {
+  it('pastes the clipboard text when no native paste follows the shortcut', async () => {
+    using fixture = setupFixture()
+    const { n, view } = fixture
+    fixture.set(n.doc(n.paragraph('a<a>b')))
+    const before = docToMarkdown(view.state.doc)
+    const readText = stubClipboardReadText('xxx\nyyy')
+
+    pressPlainPasteShortcut(view)
+    await vi.waitFor(() => {
+      expect(docToMarkdown(view.state.doc)).not.toBe(before)
+    })
+    // The Shift-paste semantics: every newline run becomes a paragraph break.
+    expect(docToMarkdown(view.state.doc)).toMatchInlineSnapshot(`
+      """
+      axxx
+
+      yyyb
+
+      """
+    `)
+    expect(readText).toHaveBeenCalledOnce()
+  })
+
+  it('stays out of the way when a native paste event follows the keydown', async () => {
+    using fixture = setupFixture()
+    const { n, view } = fixture
+    fixture.set(n.doc(n.paragraph()))
+    const readText = stubClipboardReadText('from the fallback')
+
+    pressPlainPasteShortcut(view)
+    fireNativePlainPaste(view, 'from the native paste')
+    await waitPastNativePasteWindow()
+
+    expect(docToMarkdown(view.state.doc)).toMatchInlineSnapshot(`
+      """
+      from the native paste
+
+      """
+    `)
+    expect(readText).not.toHaveBeenCalled()
+  })
+
+  it('does not paste stale text after the document changed while waiting', async () => {
+    using fixture = setupFixture()
+    const { n, view } = fixture
+    fixture.set(n.doc(n.paragraph('a<a>')))
+    stubClipboardReadText('pasted')
+
+    pressPlainPasteShortcut(view)
+    view.dispatch(view.state.tr.insertText('typed'))
+    await waitPastNativePasteWindow()
+
+    expect(docToMarkdown(view.state.doc)).toMatchInlineSnapshot(`
+      """
+      atyped
+
+      """
+    `)
+  })
+
+  it('keeps the keystroke inert when the clipboard read is refused', async () => {
+    using fixture = setupFixture()
+    const { n, view } = fixture
+    fixture.set(n.doc(n.paragraph('untouched')))
+    stubClipboardReadText(new Error('denied'))
+
+    pressPlainPasteShortcut(view)
+    await waitPastNativePasteWindow()
+
+    expect(docToMarkdown(view.state.doc)).toMatchInlineSnapshot(`
+      """
+      untouched
+
+      """
+    `)
+  })
+})

--- a/packages/core/src/extensions/clipboard/plain-paste-fallback.ts
+++ b/packages/core/src/extensions/clipboard/plain-paste-fallback.ts
@@ -1,0 +1,84 @@
+import { defineKeymap, definePlugin, union, type PlainExtension } from '@prosekit/core'
+import type { ProseMirrorNode } from '@prosekit/pm/model'
+import { Plugin, PluginKey, type Command } from '@prosekit/pm/state'
+import type { EditorView } from '@prosekit/pm/view'
+
+/**
+ * How long to wait after a Mod-Shift-V keydown for the environment's own
+ * paste event. Where the shortcut is native (a browser's "paste without
+ * formatting" menu shortcut, an Electron `pasteAndMatchStyle` accelerator),
+ * the paste event follows the keydown within a few milliseconds, so a short
+ * pause is enough to tell "a native paste is coming" apart from "this
+ * keystroke has no default action here".
+ */
+const NATIVE_PASTE_WAIT = 150
+
+async function pastePlainClipboardText(view: EditorView, docAtArm: ProseMirrorNode) {
+  let text: string
+  try {
+    text = await navigator.clipboard.readText()
+  } catch {
+    // The environment refused clipboard access; keep the status quo (the
+    // keystroke does nothing) rather than fail loudly.
+    return
+  }
+  // A changed doc means something else handled the keystroke after all (or
+  // the user kept typing); pasting on top of it would double-insert.
+  if (!text || view.isDestroyed || view.state.doc !== docAtArm) return
+  view.pasteText(text)
+}
+
+/**
+ * Make Mod-Shift-V (paste without formatting) work in environments where the
+ * shortcut has no native paste behind it. Browsers bind it themselves and
+ * ProseMirror's Shift-tracking turns the resulting paste event into a plain
+ * paste, but desktop shells (a Tauri or Electron webview without a "Paste and
+ * Match Style" menu item) deliver only the bare keydown — the user presses
+ * the shortcut and nothing happens.
+ *
+ * The keydown is never consumed: where a native paste does exist it must keep
+ * winning, since it needs no clipboard-read permission. Instead the keystroke
+ * arms a short timer that a native paste event disarms; only when no paste
+ * arrives does the fallback read the clipboard itself and run the text
+ * through {@link EditorView.pasteText}, the exact code path of a Shift-paste.
+ */
+export function definePlainPasteFallback(): PlainExtension {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+
+  const disarm = () => {
+    if (timeout !== undefined) {
+      clearTimeout(timeout)
+      timeout = undefined
+    }
+  }
+
+  const arm: Command = (state, dispatch, view) => {
+    disarm()
+    if (!view || !view.editable) return false
+    if (typeof navigator === 'undefined' || !navigator.clipboard) return false
+    const docAtArm = state.doc
+    timeout = setTimeout(() => {
+      timeout = undefined
+      void pastePlainClipboardText(view, docAtArm)
+    }, NATIVE_PASTE_WAIT)
+    return false
+  }
+
+  return union(
+    defineKeymap({ 'Mod-Shift-v': arm }),
+    definePlugin(
+      new Plugin({
+        key: new PluginKey('meowdown-plain-paste-fallback'),
+        props: {
+          handleDOMEvents: {
+            paste: () => {
+              disarm()
+              return false
+            },
+          },
+        },
+        view: () => ({ destroy: disarm }),
+      }),
+    ),
+  )
+}

--- a/packages/core/src/extensions/commands.test.ts
+++ b/packages/core/src/extensions/commands.test.ts
@@ -221,6 +221,55 @@ describe('insertTrigger', () => {
   })
 })
 
+describe('pastePlainText', () => {
+  it('pastes text with Shift-paste semantics: every newline is a paragraph break', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(n.doc(n.paragraph('a<a>b')))
+
+    expect(editor.commands.pastePlainText('xxx\nyyy')).toBe(true)
+
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      axxx
+
+      yyyb
+
+      """
+    `)
+  })
+
+  it('keeps pasted markdown syntax as literal text', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>')))
+
+    expect(editor.commands.pastePlainText('**bold** and <b>html</b>')).toBe(true)
+
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      **bold** and <b>html</b>
+
+      """
+    `)
+  })
+
+  it('ignores empty text', () => {
+    using fixture = setupFixture()
+    const { editor, n } = fixture
+    fixture.set(n.doc(n.paragraph('Hello<a>')))
+
+    expect(editor.commands.pastePlainText('')).toBe(false)
+
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      Hello
+
+      """
+    `)
+  })
+})
+
 describe('turnIntoText', () => {
   it('turns a heading into a paragraph', () => {
     using fixture = setupFixture()

--- a/packages/core/src/extensions/commands.ts
+++ b/packages/core/src/extensions/commands.ts
@@ -84,6 +84,22 @@ function insertTrigger(text: string): Command {
 }
 
 /**
+ * Pastes `text` as plain text, through the exact code path of a Shift-paste
+ * ("paste without formatting"): every newline run becomes a paragraph break,
+ * and the paste-handling plugins (link paste, embeds) still get a look. Made
+ * for host apps whose shell owns the Mod-Shift-V shortcut — a desktop menu
+ * accelerator swallows the keystroke before the webview sees it, so the shell
+ * must read the clipboard itself and hand the text to this command.
+ */
+function pastePlainText(text: string): Command {
+  return (state, dispatch, view) => {
+    if (!text || !view) return false
+    if (!dispatch) return true
+    return view.pasteText(text)
+  }
+}
+
+/**
  * Turns the current block into plain text, peeling one layer per call: a
  * non-paragraph textblock becomes a paragraph, then a paragraph in a list
  * loses its marker, then a paragraph in a blockquote lifts out of it.
@@ -105,6 +121,7 @@ export function defineEditorCommands() {
   return defineCommands({
     insertMarkdown,
     insertTrigger,
+    pastePlainText,
     scrollIntoView,
     selectText,
     selectTextBetween,

--- a/packages/core/src/extensions/key-bindings.test.ts
+++ b/packages/core/src/extensions/key-bindings.test.ts
@@ -25,6 +25,7 @@ describe('EDITOR_KEY_BINDINGS', () => {
         "Mod-Shift-Enter": "Cycle a circle checkbox task",
         "Mod-Shift-h": "Highlight",
         "Mod-Shift-k": "Insert a wikilink",
+        "Mod-Shift-v": "Paste without formatting",
         "Mod-Shift-x": "Strikethrough",
         "Mod-b": "Bold",
         "Mod-e": "Inline code",

--- a/packages/core/src/extensions/key-bindings.ts
+++ b/packages/core/src/extensions/key-bindings.ts
@@ -7,6 +7,7 @@ export const EDITOR_KEY_BINDINGS = {
   'Mod-Shift-h': 'Highlight',
   'Mod-k': 'Link',
   'Mod-Shift-k': 'Insert a wikilink',
+  'Mod-Shift-v': 'Paste without formatting',
   'Mod-1': 'Heading 1',
   'Mod-2': 'Heading 2',
   'Mod-3': 'Heading 3',


### PR DESCRIPTION
## Problem

`Cmd+Shift+V` (paste without formatting) does nothing in the Reflect Beta mac app (0.7.0-beta.12), while it works in traditional Reflect.

In browsers the shortcut is backed by the browser itself: the keydown reaches the page (ProseMirror tracks the Shift state), then a native paste event follows and gets parsed as a plain paste. The traditional Reflect Electron app reproduces this with a `Paste and Match Style` menu item (`pasteAndMatchStyle:` selector). The beta app is a Tauri/WKWebView shell with no such menu item, so the webview receives only the bare keydown — no paste event ever fires, and the keystroke does nothing.

## Changes

- **New `definePlainPasteFallback()`** in the clipboard pipeline: `Mod-Shift-V` arms a short (150ms) fallback timer *without consuming the keydown*. Where a native paste exists it still wins (no clipboard-read permission involved) and its paste event disarms the timer. Only when no paste arrives does the fallback read `navigator.clipboard.readText()` and run the text through `view.pasteText` — the exact Shift-paste code path, including the `handlePaste` plugins. A doc-identity guard prevents double-insertion or stale pastes; a refused clipboard read keeps the status quo.
- **New `pastePlainText(text)` command** for hosts whose shell owns the shortcut outright (a menu accelerator swallows the keystroke before the webview sees it): the shell reads the clipboard and hands the text to this command. This is the guaranteed path for the Reflect beta menu, mirroring how `insertTrigger` serves toolbar inserts.
- `Mod-Shift-v` added to `EDITOR_KEY_BINDINGS`.

## Testing

- New browser-mode tests for the fallback (fires when no paste follows, stays inert when a native paste event or a doc change intervenes, swallows refused clipboard reads) — passing on chromium, webkit, and firefox.
- New `pastePlainText` command tests; full `@meowdown/core` suite, lint, and typecheck pass.

## Follow-up (Reflect side)

The beta app should also add a `Paste and Match Style` menu item that reads the clipboard and calls `editor.commands.pastePlainText(text)` — that covers the case where WKWebView refuses `navigator.clipboard.readText()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)