### PR TITLE
fix(core): render `[text]` and `[text][label]` as plain text

### DIFF
--- a/packages/core/src/extensions/inline-mark-plugin.test.ts
+++ b/packages/core/src/extensions/inline-mark-plugin.test.ts
@@ -314,13 +314,13 @@ describe('inlineMarkPlugin', () => {
 
     const pos = findText(fixture.doc, 'note')
     expect(marksAt(fixture.doc, pos + 1)).toEqual(['mdWikilink'])
-    // Delete one ']': "see [[note] end" is no longer a wikilink. The inner
-    // `[note]` becomes a shortcut reference link, so it loses mdWikilink
-    // but gains the link pack wrapper.
+    // Delete one ']': "see [[note] end" is no longer a wikilink. Lezer parses
+    // the inner `[note]` as a shortcut reference link, which meowdown renders
+    // as plain text, so all marks disappear.
     const firstBracket = findText(fixture.doc, ']')
     fixture.view.dispatch(fixture.state.tr.delete(firstBracket + 1, firstBracket + 2))
     const after = findText(fixture.doc, 'note')
-    expect(marksAt(fixture.doc, after + 1)).toEqual(['mdPack'])
+    expect(marksAt(fixture.doc, after + 1)).toEqual([])
   })
 
   it('removes mdTag when text is glued in front of the #', () => {

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
@@ -338,6 +338,46 @@ describe('link', () => {
       "
     `)
   })
+
+  it('single brackets stay plain text', () => {
+    // meowdown has no link reference definitions, so lezer's shortcut
+    // reference link `[text]` must not render as a link.
+    expect(parse('see [foo] end')).toMatchInlineSnapshot(`
+      "
+      [0, 13]
+      "
+    `)
+  })
+
+  it('full reference stays plain text', () => {
+    expect(parse('[foo][bar]')).toMatchInlineSnapshot(`
+      "
+      [0, 10]
+      "
+    `)
+  })
+
+  it('nested syntax inside plain brackets still renders', () => {
+    expect(parse('[*em*]')).toMatchInlineSnapshot(`
+      "
+      [0, 1]
+      [1, 2] mdPack(key=italic) + mdEm + mdMark
+      [2, 4] mdPack(key=italic) + mdEm
+      [4, 5] mdPack(key=italic) + mdEm + mdMark
+      [5, 6]
+      "
+    `)
+  })
+
+  it('explicit empty destination keeps the link pack', () => {
+    expect(parse('[a]()')).toMatchInlineSnapshot(`
+      "
+      [0, 1] mdPack(key=link,data={"href":"","title":""}) + mdMark
+      [1, 2] mdPack(key=link,data={"href":"","title":""})
+      [2, 5] mdPack(key=link,data={"href":"","title":""}) + mdMark
+      "
+    `)
+  })
 })
 
 describe('image', () => {
@@ -867,13 +907,11 @@ describe('wikilink', () => {
   })
 
   it('unclosed', () => {
-    // The inner `[a]` becomes a shortcut reference link (lezer behavior).
+    // Lezer parses the inner `[a]` as a shortcut reference link, which
+    // meowdown renders as plain text.
     expect(parse('[[a]')).toMatchInlineSnapshot(`
       "
-      [0, 1]
-      [1, 2] mdPack(key=link,data={"href":"","title":""}) + mdMark
-      [2, 3] mdPack(key=link,data={"href":"","title":""})
-      [3, 4] mdPack(key=link,data={"href":"","title":""}) + mdMark
+      [0, 4]
       "
     `)
   })

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.ts
@@ -117,11 +117,22 @@ function walk(
     }
     const type: number = node.type
     if (type === LEZER_NODE_IDS.Link) {
-      const fileMarks = claimFileLink(node, parentMarks, text, marks, options)
-      if (fileMarks) {
-        emit(out, node.from, node.to, fileMarks)
+      if (!hasInlineDestination(node)) {
+        // Lezer also parses reference-style links (`[text]`, `[text][label]`),
+        // but meowdown has no link reference definitions, so those stay plain
+        // text: skip the bracket marks and walk any nested syntax as usual.
+        const children = node.children.filter(
+          (child) =>
+            child.type !== LEZER_NODE_IDS.LinkMark && child.type !== LEZER_NODE_IDS.LinkLabel,
+        )
+        walk(children, parentMarks, node.from, node.to, text, marks, out, options)
       } else {
-        walkLink(node, parentMarks, text, marks, out, options)
+        const fileMarks = claimFileLink(node, parentMarks, text, marks, options)
+        if (fileMarks) {
+          emit(out, node.from, node.to, fileMarks)
+        } else {
+          walkLink(node, parentMarks, text, marks, out, options)
+        }
       }
     } else if (type === LEZER_NODE_IDS.Image) {
       const trailing = takeMagicComment(node, nodes[index + 1], text)
@@ -186,6 +197,19 @@ interface LinkParts {
   labelTo: number
   urlNode: InlineElement | null
   titleNode: InlineElement | null
+}
+
+/**
+ * Whether a `Link` node is an inline link with an explicit `(...)` destination.
+ * Inline links carry at least three `LinkMark` children (`[`, `]`, `(`);
+ * shortcut and reference links (`[text]`, `[text][label]`) stop at two.
+ */
+function hasInlineDestination(node: InlineElement): boolean {
+  let linkMarkCount = 0
+  for (const child of node.children) {
+    if (child.type === LEZER_NODE_IDS.LinkMark) linkMarkCount++
+  }
+  return linkMarkCount >= 3
 }
 
 /**

--- a/packages/markdown/src/inline.test.ts
+++ b/packages/markdown/src/inline.test.ts
@@ -80,6 +80,99 @@ describe('link', () => {
       "
     `)
   })
+
+  // Reference-shaped links have no inline `(...)` destination. Their shared
+  // signature in the tree: only two LinkMark children (`[` and `]`); a
+  // reference label, when present, is a single LinkLabel node, never more
+  // LinkMarks. Inline links carry at least three LinkMarks (`[`, `]`, `(`).
+  // `hasInlineDestination` in `inline-text-to-mark-chunks.ts` relies on this.
+
+  it('parses a shortcut reference link with two LinkMarks', () => {
+    expect(parse('[foo]')).toMatchInlineSnapshot(`
+      "
+      Link [0, 5] "[foo]"
+        LinkMark [0, 1] "["
+        LinkMark [4, 5] "]"
+      "
+    `)
+  })
+
+  it('parses a full reference link with a LinkLabel', () => {
+    expect(parse('[foo][bar]')).toMatchInlineSnapshot(`
+      "
+      Link [0, 10] "[foo][bar]"
+        LinkMark [0, 1] "["
+        LinkMark [4, 5] "]"
+        LinkLabel [5, 10] "[bar]"
+      "
+    `)
+  })
+
+  it('parses a collapsed reference link with an empty LinkLabel', () => {
+    expect(parse('[foo][]')).toMatchInlineSnapshot(`
+      "
+      Link [0, 7] "[foo][]"
+        LinkMark [0, 1] "["
+        LinkMark [4, 5] "]"
+        LinkLabel [5, 7] "[]"
+      "
+    `)
+  })
+
+  it('parses an empty inline destination with four LinkMarks', () => {
+    expect(parse('[a]()')).toMatchInlineSnapshot(`
+      "
+      Link [0, 5] "[a]()"
+        LinkMark [0, 1] "["
+        LinkMark [2, 3] "]"
+        LinkMark [3, 4] "("
+        LinkMark [4, 5] ")"
+      "
+    `)
+  })
+
+  it('does not attach a space-separated paren as a destination', () => {
+    expect(parse('[foo] (bar)')).toMatchInlineSnapshot(`
+      "
+      Link [0, 5] "[foo]"
+        LinkMark [0, 1] "["
+        LinkMark [4, 5] "]"
+      "
+    `)
+  })
+
+  it('parses nested syntax inside a shortcut reference', () => {
+    expect(parse('[*em*]')).toMatchInlineSnapshot(`
+      "
+      Link [0, 6] "[*em*]"
+        LinkMark [0, 1] "["
+        Emphasis [1, 5] "*em*"
+          EmphasisMark [1, 2] "*"
+          EmphasisMark [4, 5] "*"
+        LinkMark [5, 6] "]"
+      "
+    `)
+  })
+
+  it('parses only the inner brackets of nested bracket pairs', () => {
+    expect(parse('[a [b] c]')).toMatchInlineSnapshot(`
+      "
+      Link [3, 6] "[b]"
+        LinkMark [3, 4] "["
+        LinkMark [5, 6] "]"
+      "
+    `)
+  })
+
+  it('parses the inner brackets of an unclosed wikilink as a link', () => {
+    expect(parse('[[a]')).toMatchInlineSnapshot(`
+      "
+      Link [1, 4] "[a]"
+        LinkMark [1, 2] "["
+        LinkMark [3, 4] "]"
+      "
+    `)
+  })
 })
 
 describe('image', () => {
@@ -106,6 +199,17 @@ describe('image', () => {
         URL [7, 10] "url"
         LinkTitle [11, 18] "\\"title\\""
         LinkMark [18, 19] ")"
+      "
+    `)
+  })
+
+  it('parses a reference-style image as an Image with a LinkLabel', () => {
+    expect(parse('![img][ref]')).toMatchInlineSnapshot(`
+      "
+      Image [0, 11] "![img][ref]"
+        LinkMark [0, 2] "!["
+        LinkMark [5, 6] "]"
+        LinkLabel [6, 11] "[ref]"
       "
     `)
   })


### PR DESCRIPTION
Bracket pairs without an inline `(...)` destination (`[text]`, `[text][label]`, `[text][]`) now render as plain text instead of a link pack: meowdown has no link reference definitions, so these shapes can never resolve to a URL.

Split out of https://github.com/prosekit/meowdown/pull/343.