### PR TITLE
feat(react): add `expandCollapsed` prop to `MarkdownView`

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -58,6 +58,8 @@ Slash menu host items can include `keywords` to match hidden terms without chang
 
 The caret glides between positions by default; pass `caretGlide={false}` to move it instantly (hosts can also tune the duration via the `--meowdown-caret-glide` CSS variable).
 
+`MarkdownView` folds collapsed (`+`) bullets like the editor; pass `expandCollapsed` to render them expanded at every depth, for views that show slices of a note (e.g. a backlinks panel) where the source's fold state must not hide the content the view exists to show.
+
 ### Wiki embeds
 
 Obsidian-style wiki embeds (`![[path]]`, with optional `|width` or

--- a/packages/react/src/components/markdown-view.test.tsx
+++ b/packages/react/src/components/markdown-view.test.tsx
@@ -255,6 +255,31 @@ describe('MarkdownView', () => {
     await expect.element(view.locate('blockquote')).toHaveTextContent('quote')
   })
 
+  it('folds a collapsed bullet, like the editor', async () => {
+    await renderView('+ parent\n  - child')
+    await expect.element(view.locate('[data-list-collapsed]')).toHaveTextContent('parent')
+    await expect.element(view.getByText('child')).not.toBeVisible()
+  })
+
+  it('renders a collapsed bullet expanded with expandCollapsed', async () => {
+    await renderView('+ parent\n  - child', { expandCollapsed: true })
+    await expect.element(view.getByText('child')).toBeVisible()
+    await expect.element(view.locate('[data-list-collapsed]')).not.toBeInTheDocument()
+  })
+
+  it('expands collapsed bullets at every depth', async () => {
+    await renderView('+ parent\n  + middle\n    - leaf', { expandCollapsed: true })
+    await expect.element(view.getByText('leaf')).toBeVisible()
+    await expect.element(view.locate('[data-list-collapsed]')).not.toBeInTheDocument()
+  })
+
+  it('keeps a circle task round under expandCollapsed', async () => {
+    await renderView('+ [ ] task\n  - child', { expandCollapsed: true })
+    const circleTask = view.locate('[data-list-marker="+"]')
+    await expect.element(circleTask.locate('input[type="checkbox"]')).toBeInTheDocument()
+    await expect.element(view.getByText('child')).toBeVisible()
+  })
+
   it('renders truncated markdown without throwing', async () => {
     await renderView('foo [[Bar and a **bold')
     await expect.element(view).toHaveTextContent('foo')

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -585,10 +585,10 @@ function renderBlock(node: ProseMirrorNode, context: RenderContext): ReactNode {
   let handleTaskClick: ((event: MouseEvent) => void) | undefined
 
   if (typeName === 'list') {
-    const attrs = { ...(node.attrs as MeowdownListAttrs) }
+    let attrs = node.attrs as MeowdownListAttrs
 
     if (context.expandCollapsed && attrs.collapsed) {
-      attrs.collapsed = false
+      attrs = {...attrs, collapsed: false}
     }
 
     const { onTaskClick } = context

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -586,7 +586,6 @@ function renderBlock(node: ProseMirrorNode, context: RenderContext): ReactNode {
 
   if (typeName === 'list') {
     let attrs = node.attrs as MeowdownListAttrs
-
     if (context.expandCollapsed && attrs.collapsed) {
       attrs = {...attrs, collapsed: false}
     }

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -100,6 +100,13 @@ export interface MarkdownViewProps {
    * YouTube embeds are omitted before any image resolver runs.
    */
   interactive?: boolean
+  /**
+   * Render collapsed (`+`) bullets expanded, ignoring their fold state at any
+   * depth. Off by default. For views that show slices of a note (e.g. a
+   * backlinks panel), where the source's fold state must not hide the content
+   * the view exists to show.
+   */
+  expandCollapsed?: boolean
   /** Map an image `src` to a displayable URL, or `undefined` to skip it. */
   resolveImageUrl?: (src: string) => string | undefined
   /**
@@ -127,6 +134,7 @@ export interface MarkdownViewProps {
 
 interface RenderContext {
   interactive: boolean
+  expandCollapsed: boolean
   resolveImageUrl?: (src: string) => string | undefined
   resolveFileLink?: FileLinkResolver
   resolveWikiEmbed?: WikiEmbedResolver
@@ -574,6 +582,16 @@ function renderBlock(node: ProseMirrorNode, context: RenderContext): ReactNode {
   const key = context.keyCounter.value++
   const typeName = node.type.name as NodeName
 
+  // The fold is CSS keyed on the `data-list-collapsed` attribute this node's
+  // `toDOM` would emit; a node without the attr renders expanded.
+  if (
+    typeName === 'list' &&
+    context.expandCollapsed &&
+    (node.attrs as MeowdownListAttrs).collapsed
+  ) {
+    node = node.type.create({ ...node.attrs, collapsed: false }, node.content, node.marks)
+  }
+
   let handleTaskClick: ((event: MouseEvent) => void) | undefined
 
   if (typeName === 'list') {
@@ -653,6 +671,7 @@ export function MarkdownView({
   markMode = 'hide',
   frontmatter = false,
   interactive = true,
+  expandCollapsed = false,
   resolveImageUrl,
   resolveFileLink,
   resolveWikiEmbed,
@@ -668,6 +687,7 @@ export function MarkdownView({
     const doc = markdownToDoc(markdown, { frontmatter })
     const context: RenderContext = {
       interactive,
+      expandCollapsed,
       resolveImageUrl,
       resolveFileLink,
       resolveWikiEmbed,
@@ -685,6 +705,7 @@ export function MarkdownView({
     markdown,
     frontmatter,
     interactive,
+    expandCollapsed,
     resolveImageUrl,
     resolveFileLink,
     resolveWikiEmbed,

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -585,7 +585,7 @@ function renderBlock(node: ProseMirrorNode, context: RenderContext): ReactNode {
   let handleTaskClick: ((event: MouseEvent) => void) | undefined
 
   if (typeName === 'list') {
-    const attrs = { ...node.attrs as MeowdownListAttrs }
+    const attrs = { ...(node.attrs as MeowdownListAttrs) }
 
     if (context.expandCollapsed && attrs.collapsed) {
       attrs.collapsed = false

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -582,20 +582,15 @@ function renderBlock(node: ProseMirrorNode, context: RenderContext): ReactNode {
   const key = context.keyCounter.value++
   const typeName = node.type.name as NodeName
 
-  // The fold is CSS keyed on the `data-list-collapsed` attribute this node's
-  // `toDOM` would emit; a node without the attr renders expanded.
-  if (
-    typeName === 'list' &&
-    context.expandCollapsed &&
-    (node.attrs as MeowdownListAttrs).collapsed
-  ) {
-    node = node.type.create({ ...node.attrs, collapsed: false }, node.content, node.marks)
-  }
-
   let handleTaskClick: ((event: MouseEvent) => void) | undefined
 
   if (typeName === 'list') {
-    const attrs = node.attrs as MeowdownListAttrs
+    const attrs = { ...node.attrs as MeowdownListAttrs }
+
+    if (context.expandCollapsed && attrs.collapsed) {
+      attrs.collapsed = false
+    }
+
     const { onTaskClick } = context
     if (attrs.kind === 'task' && onTaskClick) {
       const index = context.taskCounter.value++

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -587,7 +587,8 @@ function renderBlock(node: ProseMirrorNode, context: RenderContext): ReactNode {
   if (typeName === 'list') {
     let attrs = node.attrs as MeowdownListAttrs
     if (context.expandCollapsed && attrs.collapsed) {
-      attrs = {...attrs, collapsed: false}
+      attrs = { ...attrs, collapsed: false }
+      node = node.type.create(attrs, node.content, node.marks)
     }
 
     const { onTaskClick } = context


### PR DESCRIPTION
`MarkdownView` renders collapsed `+` bullets folded exactly like the editor, so a view that shows a slice of a note (e.g. the backlinks panel in https://github.com/team-reflect/reflect-open/issues/832) can hide the very content it exists to show. This adds an `expandCollapsed` prop that renders list nodes with their fold state cleared, so `data-list-collapsed` (and the CSS that hides descendants) never applies, at any depth. Off by default; the editor and existing views are unchanged.