### PR TITLE
fix(react): preserve edge blocks on markdown echo

### DIFF
--- a/packages/react/src/components/prosekit-editor.test.tsx
+++ b/packages/react/src/components/prosekit-editor.test.tsx
@@ -151,6 +151,38 @@ describe('ProseKitEditor', () => {
     await expect.element(screen.getByText('Hello')).toBeInTheDocument()
   })
 
+  it('keeps a leading empty block when the host echoes unchanged Markdown', async () => {
+    const ref = createRef<EditorHandle>()
+    await render(
+      <ProseKitEditor ref={ref} markMode="hide" initialMarkdown={'**Links**\n\n- aiforui.dev'} />,
+    )
+
+    const handle = ref.current
+    const editor = handle?.editor
+    if (!handle || !editor) throw new Error('editor not mounted')
+    handle.setSelection('start')
+    handle.focus()
+    await userEvent.keyboard('{Enter}')
+    expect(editor.state.doc.child(0).type.name).toBe('paragraph')
+    expect(editor.state.doc.child(0).content.size).toBe(0)
+    expect(editor.state.doc.child(1).textContent).toBe('**Links**')
+    expect(editor.state.selection.$from.parent).toBe(editor.state.doc.child(1))
+    expect(editor.state.selection.$from.parentOffset).toBe(0)
+
+    // A controlled host commonly persists getMarkdown() and echoes it through
+    // setMarkdown(). Edge-only blank blocks have no Markdown representation,
+    // so replacing the whole document here would drop the block and map its
+    // caret to the end of the note.
+    const markdown = handle.getMarkdown().trimEnd()
+    handle.setMarkdown(markdown)
+
+    expect(editor.state.doc.child(0).type.name).toBe('paragraph')
+    expect(editor.state.doc.child(0).content.size).toBe(0)
+    expect(editor.state.doc.child(1).textContent).toBe('**Links**')
+    expect(editor.state.selection.$from.parent).toBe(editor.state.doc.child(1))
+    expect(editor.state.selection.$from.parentOffset).toBe(0)
+  })
+
   it('fires onDocChange for insertMarkdown, unlike setMarkdown', async () => {
     const onDocChange = vi.fn()
     const ref = createRef<EditorHandle>()

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -346,12 +346,27 @@ export function ProseKitEditor({
     function getState(): EditorStateSnapshot {
       return [getMarkdown(), getSelection()]
     }
-    function replaceState(markdown?: string, selection?: SelectionHint, addToHistory = true): void {
+    function replaceState(
+      markdown?: string,
+      selection?: SelectionHint,
+      addToHistory = true,
+      forceMarkdown = false,
+    ): void {
       if (markdown == null && !selection) return
       const transaction = editor.state.tr
       if (markdown != null) {
         const doc = markdownToDoc(markdown, { nodes: editor.nodes, frontmatter })
-        transaction.replaceWith(0, transaction.doc.content.size, doc.content)
+        const currentMarkdown = docToMarkdown(transaction.doc, { frontmatter })
+        const nextMarkdown = docToMarkdown(doc, { frontmatter })
+        // Edge-only blank blocks intentionally normalize away in Markdown. An
+        // equivalent host echo must not replace the document and erase that
+        // transient editor structure; refreshMarkdownRendering forces the
+        // replacement when a caller explicitly needs one.
+        if (forceMarkdown || currentMarkdown !== nextMarkdown) {
+          transaction.replaceWith(0, transaction.doc.content.size, doc.content)
+        } else if (!selection) {
+          return
+        }
       }
       if (selection) {
         transaction.setSelection(resolveSelection(transaction.doc, selection)).scrollIntoView()
@@ -374,7 +389,7 @@ export function ProseKitEditor({
     }
     function refreshMarkdownRendering(): void {
       const [markdown, selection] = getState()
-      replaceState(markdown, selection, false)
+      replaceState(markdown, selection, false, true)
     }
     function insertMarkdown(markdown: string): void {
       editor.commands.insertMarkdown(markdown)


### PR DESCRIPTION
## Problem

A host can persist editor changes by reading `getMarkdown()` and echoing the value through `setMarkdown()`. Pressing Enter before the first block creates a leading empty ProseMirror paragraph, but edge-only blank blocks intentionally have no Markdown representation. The echo therefore reparsed a document without that paragraph, replaced the whole editor document, and mapped the caret to the end of the note.

This is especially visible on mobile: Return before a heading such as **Links** leaves the content in place and sends the caret below the final list item.

## Before -> After

| Scenario | Before | After |
| --- | --- | --- |
| Equivalent Markdown echo | Replaces the whole document, drops transient edge blocks, and remaps the caret | Leaves the editor document and caret untouched |
| Explicit `setState` selection | Applied during replacement | Still applied, even when the Markdown itself is equivalent |
| `refreshMarkdownRendering()` | Forces a reparse | Still forces a reparse |
| Different Markdown | Replaces editor content | Unchanged |

## Changes

1. Normalize the incoming document and compare its serialized Markdown with the current editor document before replacing content.
2. Skip only the document replacement for equivalent Markdown; explicit selection hints still run.
3. Keep `refreshMarkdownRendering()` as the intentional force-reparse path.
4. Add a hide-mode regression covering Return before a bold **Links** block followed by an autolink bullet, including a host-normalized echo without the final newline.

## Tests

The regression pins that the leading empty block, **Links** block, and caret position survive the Markdown echo in both Chromium and WebKit.

## Verification

- `pnpm test --run packages/react/src` — 262 passed in Chromium
- `MEOWDOWN_TEST_BROWSER=webkit pnpm test --run packages/react/src` — 261 passed, 1 existing skip
- `pnpm typecheck` — passed
- `pnpm lint` — passed

## Risk / Rollout

No Markdown format, schema, or persistence behavior changes. The only behavioral change is that Markdown-equivalent `setMarkdown()` calls are now idempotent. Callers that need to rebuild rendering from the same Markdown retain the dedicated `refreshMarkdownRendering()` API.
