### PR TITLE
fix(core): preserve parent list item type when parsing HTML

### DIFF
--- a/packages/core/src/converters/html-to-md.test.ts
+++ b/packages/core/src/converters/html-to-md.test.ts
@@ -64,6 +64,11 @@ describe('htmlToMarkdown', () => {
     expect(htmlToMarkdown(html).trim()).toBe('- [ ] one\n- [x] two')
   })
 
+  it('does not promote a parent of a nested task item', () => {
+    const html = '<ul><li>parent<ul><li><input type="checkbox" checked> child</li></ul></li></ul>'
+    expect(htmlToMarkdown(html).trim()).toBe('- parent\n  - [x] child')
+  })
+
   it('converts a tiptap-style task list', () => {
     // Tiptap nests the checkbox in a <label> and the body in a <div>, a shape
     // the stock `li` handler misses (the item would lose its checkbox).

--- a/packages/core/src/converters/html-to-md.ts
+++ b/packages/core/src/converters/html-to-md.ts
@@ -66,11 +66,12 @@ function isCheckboxInput(node: Element): boolean {
   return node.tagName === 'input' && node.properties.type === 'checkbox'
 }
 
-/** The first checkbox `<input>` in `node`'s subtree, if any. */
+/** The first checkbox `<input>` before any nested list, if any. */
 function findCheckbox(node: Element): Element | undefined {
   for (const child of node.children) {
     if (child.type !== 'element') continue
     if (isCheckboxInput(child)) return child
+    if (child.tagName === 'ul' || child.tagName === 'ol') continue
     const nested = findCheckbox(child)
     if (nested) return nested
   }


### PR DESCRIPTION
Task item detection now stops at nested lists, so a checkbox in a child item cannot promote its ordinary parent to a task item. A regression test covers a plain parent containing a checked child task. Converter and paste tests, typecheck, and lint pass.
