### PR TITLE
feat(core): support Markdown reference links

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -38,6 +38,7 @@ const markdown = docToMarkdown(editor.state.doc)
   - Thematic breaks (`---`, `***`, `___`)
   - Bold (`**bold**`), italic (`*italic*`), and inline code
   - Links (`[text](url)`), images (`![alt](src)`), and autolinks (`<https://example.com>`)
+  - Reference links (`[text]`, `[text][label]`, `[text][]`) resolved against top-level `[label]: url` definitions
   - Hard line breaks
 - GitHub Flavored Markdown (GFM)
   - Tables, including column alignment (`:--`, `:-:`, `--:`)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,8 @@
     "hast-util-to-mdast": "^10.1.2",
     "katex": "^0.18.1",
     "mdast-util-to-markdown": "^2.1.2",
+    "micromark-util-decode-string": "^2.0.1",
+    "micromark-util-normalize-identifier": "^2.0.1",
     "prosemirror-flat-list": "^0.7.1",
     "prosemirror-highlight": "^0.15.3",
     "rehype-parse": "^9.0.1",

--- a/packages/core/src/converters/md-to-pm.ts
+++ b/packages/core/src/converters/md-to-pm.ts
@@ -157,6 +157,10 @@ function convertBlock(
       return [convertHeading(nodes, cursor, text, 2, true)]
     case LEZER_NODE_IDS.Paragraph:
       return [convertParagraph(nodes, cursor, text)]
+    case LEZER_NODE_IDS.LinkReference:
+      // Definitions remain literal source-backed paragraphs. The inline-mark
+      // layer resolves references document-wide without changing their bytes.
+      return [convertParagraph(nodes, cursor, text)]
     case LEZER_NODE_IDS.CommentBlock:
       // A comment is not rendered output: map it onto the invisible `htmlComment`
       // node so it stays in the document (and round-trips) without reading as

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -225,7 +225,7 @@ describe('inline', () => {
     expect(roundtrip('<?php echo 1; ?>')).toBe('<?php echo 1; ?>\n')
   })
 
-  it.fails('keeps a link reference definition', () => {
+  it('keeps a link reference definition', () => {
     expect(roundtrip('[foo]: /url')).toBe('[foo]: /url\n')
   })
 })

--- a/packages/core/src/extensions/batch-set-mark-step.ts
+++ b/packages/core/src/extensions/batch-set-mark-step.ts
@@ -1,6 +1,6 @@
-import { Mark, type EditorNode, type Schema } from '@prosekit/pm/model'
+import { Fragment, Mark, type EditorNode, type Schema } from '@prosekit/pm/model'
 import type { Mappable } from '@prosekit/pm/transform'
-import { ReplaceStep, Step, StepResult, Transform } from '@prosekit/pm/transform'
+import { ReplaceStep, Step, StepResult } from '@prosekit/pm/transform'
 
 import {
   markChunkFromJSON,
@@ -30,40 +30,94 @@ export class BatchSetMarkStep extends Step {
   apply(doc: EditorNode): StepResult {
     if (this.chunks.length === 0) return StepResult.ok(doc)
     const docSize = doc.content.size
+    const sorted = [...this.chunks]
+      .filter(([from, to]) => from < to && from < docSize)
+      .sort((left, right) => left[0] - right[0])
+    if (sorted.length === 0) return StepResult.ok(doc)
 
-    let tr: Transform | undefined
-    for (const [from, to, expectedUnsorted] of this.chunks) {
-      if (from >= to) continue
+    // Rank-sorted like a node's own mark set; equal-rank marks (nested
+    // mdPack) keep the parser's outer-first emit order, so rewriting a node
+    // whose set merely differs in order keeps same-type marks canonical.
+    const expectedSets = sorted.map(([, , marks]) => Mark.setFrom(marks))
 
-      const safeFrom = Math.max(0, Math.min(from, docSize))
-      const safeTo = Math.max(safeFrom, Math.min(to, docSize))
-      if (safeFrom >= safeTo) continue
+    const first = Math.max(0, sorted[0][0])
+    let last = 0
+    for (const [, to] of sorted) {
+      if (to > last) last = to
+    }
+    last = Math.min(last, docSize)
+    if (first >= last) return StepResult.ok(doc)
 
-      // Rank-sorted like a node's own mark set; equal-rank marks (nested
-      // mdPack) keep the parser's outer-first emit order, so rewriting a node
-      // whose set merely differs in order keeps same-type marks canonical.
-      const expected = Mark.setFrom(expectedUnsorted)
+    // One ordered pass over the document with a moving chunk pointer.
+    // Untouched siblings are reused as-is, so the cost is proportional to
+    // the spanned blocks, never chunks x blocks.
+    let chunkIndex = 0
 
-      doc.nodesBetween(safeFrom, safeTo, (node, pos) => {
-        if (!node.isText) return true
-        const nodeFrom = Math.max(safeFrom, pos)
-        const nodeTo = Math.min(safeTo, pos + node.nodeSize)
-        if (nodeFrom >= nodeTo) return false
-        const current = node.marks
-        if (marksEqual(current, expected)) return false
-
-        tr ??= new Transform(doc)
-        for (const mark of current) {
-          tr.removeMark(nodeFrom, nodeTo, mark)
-        }
-        for (const mark of expected) {
-          tr.addMark(nodeFrom, nodeTo, mark)
-        }
-        return false
+    const rebuildText = (node: EditorNode, nodeFrom: number): EditorNode[] | undefined => {
+      const nodeTo = nodeFrom + node.nodeSize
+      while (chunkIndex < sorted.length && sorted[chunkIndex][1] <= nodeFrom) chunkIndex++
+      interface Piece {
+        from: number
+        to: number
+        marks: readonly Mark[] | undefined
+      }
+      const pieces: Piece[] = []
+      let cursor = nodeFrom
+      let changed = false
+      for (let index = chunkIndex; index < sorted.length; index++) {
+        const [chunkFrom, chunkTo] = sorted[index]
+        if (chunkFrom >= nodeTo) break
+        const from = Math.max(chunkFrom, cursor)
+        const to = Math.min(chunkTo, nodeTo)
+        if (from >= to) continue
+        if (from > cursor) pieces.push({ from: cursor, to: from, marks: undefined })
+        const expected = expectedSets[index]
+        const differs = !marksEqual(node.marks, expected)
+        if (differs) changed = true
+        pieces.push({ from, to, marks: differs ? expected : undefined })
+        cursor = to
+      }
+      if (!changed) return undefined
+      if (cursor < nodeTo) pieces.push({ from: cursor, to: nodeTo, marks: undefined })
+      return pieces.map((piece) => {
+        const cut = node.cut(piece.from - nodeFrom, piece.to - nodeFrom)
+        return piece.marks === undefined ? cut : cut.mark(piece.marks)
       })
     }
 
-    return StepResult.ok(tr ? tr.doc : doc)
+    const rebuildContent = (node: EditorNode, contentFrom: number): Fragment | undefined => {
+      let rebuilt: EditorNode[] | undefined
+      let childFrom = contentFrom
+      for (let index = 0; index < node.childCount; index++) {
+        const child = node.child(index)
+        const childTo = childFrom + child.nodeSize
+        let replacement: EditorNode | EditorNode[] = child
+        if (childTo > first && childFrom < last) {
+          if (child.isText) {
+            replacement = rebuildText(child, childFrom) ?? child
+          } else if (child.childCount > 0) {
+            const content = rebuildContent(child, childFrom + 1)
+            if (content !== undefined) replacement = child.copy(content)
+          }
+        }
+        if (replacement !== child && rebuilt === undefined) {
+          rebuilt = []
+          for (let seen = 0; seen < index; seen++) rebuilt.push(node.child(seen))
+        }
+        if (rebuilt !== undefined) {
+          if (Array.isArray(replacement)) {
+            rebuilt.push(...replacement)
+          } else {
+            rebuilt.push(replacement)
+          }
+        }
+        childFrom = childTo
+      }
+      return rebuilt === undefined ? undefined : Fragment.fromArray(rebuilt)
+    }
+
+    const content = rebuildContent(doc, 0)
+    return StepResult.ok(content === undefined ? doc : doc.copy(content))
   }
 
   invert(doc: EditorNode): Step {

--- a/packages/core/src/extensions/inline-mark-plugin.ts
+++ b/packages/core/src/extensions/inline-mark-plugin.ts
@@ -17,12 +17,14 @@ import { definePlugin } from '@prosekit/core'
 import type { EditorNode, Schema } from '@prosekit/pm/model'
 import type { EditorState, Transaction } from '@prosekit/pm/state'
 import { Plugin, PluginKey } from '@prosekit/pm/state'
+import type { EditorView } from '@prosekit/pm/view'
 
 import type { PositionRange } from '../utils/range.ts'
 
 import { BatchSetMarkStep } from './batch-set-mark-step.ts'
 import { inlineTextToMarkChunks, type InlineMarkOptions } from './inline-text-to-mark-chunks.ts'
 import type { MarkChunk } from './mark-chunk.ts'
+import { isNodeOfType } from './node-names.ts'
 import {
   buildReferenceIndex,
   cachedDefinitionParse,
@@ -86,13 +88,27 @@ function computeAffectedRange(
   }
 }
 
-function createInlineMarkPlugin(options: InlineMarkOptions | undefined): Plugin {
-  interface InlineMarkPluginState {
-    readonly references: ReferenceIndex
+interface InlineMarkPluginState {
+  readonly references: ReferenceIndex
+  /** The definition set changed and untouched citing blocks may be stale. */
+  readonly restyleNeeded: boolean
+}
+
+const inlineMarkPluginKey = new PluginKey<InlineMarkPluginState>('inline-mark')
+
+const RESTYLE_KEY = 'inline-marks-restyle'
+
+/** Quiet period after the last definition edit before the restyle flushes. */
+const RESTYLE_DEBOUNCE_MS = 200
+
+/** @internal only for test */
+export function flushPendingRestyle(view: EditorView): void {
+  if (inlineMarkPluginKey.getState(view.state)?.restyleNeeded === true) {
+    view.dispatch(view.state.tr.setMeta(RESTYLE_KEY, true))
   }
+}
 
-  const pluginKey = new PluginKey<InlineMarkPluginState>('inline-mark')
-
+function createInlineMarkPlugin(options: InlineMarkOptions | undefined): Plugin {
   /** Definition parse results per paragraph node identity. */
   const definitionCache: ReferenceDefinitionCache = new WeakMap()
 
@@ -178,29 +194,29 @@ function createInlineMarkPlugin(options: InlineMarkOptions | undefined): Plugin 
    * containers (blockquote, list, tableCell), so it picks up nested
    * textblocks without each container needing to be listed explicitly.
    *
-   * When the definition set changed, the walk covers the whole document,
-   * but blocks outside the edited `range` whose cached chunks do not
-   * depend on a changed key are skipped without re-parsing or emitting.
+   * With `coverWholeDoc` the walk spans the whole document, but blocks
+   * outside `editedRange` whose cached chunks still match the current
+   * definitions are skipped without re-parsing or emitting.
    */
   function collectChunksForRange(
     state: EditorState,
-    range: PositionRange,
+    editedRange: PositionRange,
     references: ReferenceIndex,
-    definitionsChanged: boolean,
+    coverWholeDoc: boolean,
   ): MarkChunk[] {
     const chunks: MarkChunk[] = []
     const doc = state.doc
-    const scanFrom = definitionsChanged ? 0 : range.from
-    const scanTo = definitionsChanged ? doc.content.size : range.to
+    const scanFrom = coverWholeDoc ? 0 : editedRange.from
+    const scanTo = coverWholeDoc ? doc.content.size : editedRange.to
     doc.nodesBetween(scanFrom, scanTo, (node, pos, parent) => {
       if (node.type.spec.code) return false
       if (!node.isTextblock) return true
       if (node.childCount === 0) return false
       const isDefinition =
         parent === doc &&
-        node.type.name === 'paragraph' &&
+        isNodeOfType(node, 'paragraph') &&
         cachedDefinitionParse(node, definitionCache) !== null
-      if (definitionsChanged && (pos + node.nodeSize <= range.from || pos + 1 > range.to)) {
+      if (coverWholeDoc && (pos + node.nodeSize <= editedRange.from || pos + 1 > editedRange.to)) {
         const cached = chunkCache.get(node)
         if (cached !== undefined && cacheValid(cached, references, isDefinition)) return false
       }
@@ -212,41 +228,80 @@ function createInlineMarkPlugin(options: InlineMarkOptions | undefined): Plugin 
   }
 
   return new Plugin<InlineMarkPluginState>({
-    key: pluginKey,
+    key: inlineMarkPluginKey,
     state: {
       init(_config, state) {
-        return { references: buildReferenceIndex(state.doc, definitionCache) }
+        return { references: buildReferenceIndex(state.doc, definitionCache), restyleNeeded: false }
       },
       apply(transaction, value) {
+        if (transaction.getMeta(RESTYLE_KEY) === true) {
+          return value.restyleNeeded
+            ? { references: value.references, restyleNeeded: false }
+            : value
+        }
         // Our own appended step only rewrites marks, never block text.
         if (!transaction.docChanged || transaction.getMeta(META_KEY)) return value
         if (!transactionTouchesDefinitions(transaction, definitionCache)) return value
         const next = buildReferenceIndex(transaction.doc, definitionCache, value.references)
-        return next === value.references ? value : { references: next }
+        if (next === value.references) return value
+        return { references: next, restyleNeeded: true }
       },
     },
-    appendTransaction(transactions, oldState, newState) {
+    appendTransaction(transactions, _oldState, newState) {
       // Drop transactions we appended ourselves to avoid recursing.
       for (const tr of transactions) {
         if (tr.getMeta(META_KEY)) return null
       }
-      const references = pluginKey.getState(newState)?.references ?? EMPTY_REFERENCE_INDEX
-      const oldReferences = pluginKey.getState(oldState)?.references ?? references
-      const definitionsChanged = references !== oldReferences
-      const range = computeAffectedRange(transactions, newState)
-      const chunks = collectChunksForRange(newState, range, references, definitionsChanged)
+      const pluginState = inlineMarkPluginKey.getState(newState)
+      const references = pluginState?.references ?? EMPTY_REFERENCE_INDEX
+      const restyle = transactions.some((tr) => tr.getMeta(RESTYLE_KEY) === true)
+      // The flush walks the whole doc with an empty edited range, so only
+      // blocks whose cached chunks went stale are re-parsed and re-marked.
+      const editedRange = restyle
+        ? { from: 0, to: 0 }
+        : computeAffectedRange(transactions, newState)
+      const chunks = collectChunksForRange(newState, editedRange, references, restyle)
       if (chunks.length === 0) return null
       const tr = newState.tr.step(new BatchSetMarkStep(chunks))
       tr.setMeta(META_KEY, true)
       tr.setMeta('addToHistory', false)
       return tr
     },
-    view(view) {
+    view(editorView) {
       // `EditorState.create` does NOT fire `appendTransaction`, so the
       // initial document never gets processed via the normal path. Dispatch
       // a no-op tr on mount to wake the plugin up.
-      view.dispatch(triggerInlineMarks(view.state))
-      return {}
+      editorView.dispatch(triggerInlineMarks(editorView.state))
+
+      let timer: ReturnType<typeof setTimeout> | undefined
+
+      const flush = (view: EditorView): void => {
+        timer = undefined
+        if (view.isDestroyed) return
+        if (inlineMarkPluginKey.getState(view.state)?.restyleNeeded !== true) return
+        view.dispatch(view.state.tr.setMeta(RESTYLE_KEY, true))
+      }
+
+      return {
+        update(view, prevState) {
+          const current = inlineMarkPluginKey.getState(view.state)
+          if (current?.restyleNeeded !== true) {
+            if (timer !== undefined) clearTimeout(timer)
+            timer = undefined
+            return
+          }
+          // Plugin-state identity changes exactly when the definition set
+          // changed, so unrelated edits and selection moves leave the
+          // pending timer alone instead of pushing the flush out.
+          if (timer === undefined || inlineMarkPluginKey.getState(prevState) !== current) {
+            if (timer !== undefined) clearTimeout(timer)
+            timer = setTimeout(() => flush(view), RESTYLE_DEBOUNCE_MS)
+          }
+        },
+        destroy() {
+          if (timer !== undefined) clearTimeout(timer)
+        },
+      }
     },
   })
 }

--- a/packages/core/src/extensions/inline-mark-plugin.ts
+++ b/packages/core/src/extensions/inline-mark-plugin.ts
@@ -23,6 +23,15 @@ import type { PositionRange } from '../utils/range.ts'
 import { BatchSetMarkStep } from './batch-set-mark-step.ts'
 import { inlineTextToMarkChunks, type InlineMarkOptions } from './inline-text-to-mark-chunks.ts'
 import type { MarkChunk } from './mark-chunk.ts'
+import {
+  buildReferenceIndex,
+  cachedDefinitionParse,
+  EMPTY_REFERENCE_INDEX,
+  transactionTouchesDefinitions,
+  type ReferenceDefinition,
+  type ReferenceDefinitionCache,
+  type ReferenceIndex,
+} from './reference-links.ts'
 import { getMarkBuildersForSchema } from './schema.ts'
 
 const META_KEY = 'inline-marks-applied'
@@ -78,6 +87,15 @@ function computeAffectedRange(
 }
 
 function createInlineMarkPlugin(options: InlineMarkOptions | undefined): Plugin {
+  interface InlineMarkPluginState {
+    readonly references: ReferenceIndex
+  }
+
+  const pluginKey = new PluginKey<InlineMarkPluginState>('inline-mark')
+
+  /** Definition parse results per paragraph node identity. */
+  const definitionCache: ReferenceDefinitionCache = new WeakMap()
+
   /**
    * Cache of chunks per textblock node, keyed by the immutable
    * `ProseMirrorNode` instance. Stored chunks are baseOffset-relative
@@ -86,20 +104,63 @@ function createInlineMarkPlugin(options: InlineMarkOptions | undefined): Plugin 
    * the doc (a paragraph below it was inserted or deleted). Scoped to the
    * plugin instance because the chunks depend on this editor's `options`.
    */
-  const chunkCache = new WeakMap<EditorNode, readonly MarkChunk[]>()
+  interface CachedChunks {
+    readonly chunks: readonly MarkChunk[]
+    /** Reference keys this block looked up and what each resolved to. */
+    readonly resolved: ReadonlyMap<string, ReferenceDefinition | null> | undefined
+    readonly isDefinition: boolean
+  }
+
+  const chunkCache = new WeakMap<EditorNode, CachedChunks>()
+
+  function cacheValid(
+    entry: CachedChunks,
+    references: ReferenceIndex,
+    isDefinition: boolean,
+  ): boolean {
+    if (entry.isDefinition !== isDefinition) return false
+    if (entry.resolved === undefined) return true
+    for (const [key, definition] of entry.resolved) {
+      const current = references.definitions.get(key) ?? null
+      if (current === definition) continue
+      if (
+        current === null ||
+        definition === null ||
+        current.href !== definition.href ||
+        current.title !== definition.title
+      ) {
+        return false
+      }
+    }
+    return true
+  }
 
   function chunksForTextblock(
     node: EditorNode,
     baseOffset: number,
     schema: Schema,
+    references: ReferenceIndex,
+    isDefinition: boolean,
   ): readonly MarkChunk[] {
-    let relative = chunkCache.get(node)
-    if (relative) {
+    const cached = chunkCache.get(node)
+    let relative: readonly MarkChunk[]
+    if (cached !== undefined && cacheValid(cached, references, isDefinition)) {
       chunkCacheHits++
+      relative = cached.chunks
     } else {
       chunkCacheParses++
-      relative = inlineTextToMarkChunks(getMarkBuildersForSchema(schema), node.textContent, options)
-      chunkCache.set(node, relative)
+      const usedReferences = new Map<string, ReferenceDefinition | null>()
+      relative = inlineTextToMarkChunks(getMarkBuildersForSchema(schema), node.textContent, {
+        ...options,
+        referenceDefinitions: references.definitions,
+        isReferenceDefinition: isDefinition,
+        usedReferences,
+      })
+      chunkCache.set(node, {
+        chunks: relative,
+        resolved: usedReferences.size > 0 ? usedReferences : undefined,
+        isDefinition,
+      })
     }
     if (baseOffset === 0) return relative
     const shifted: MarkChunk[] = []
@@ -116,29 +177,64 @@ function createInlineMarkPlugin(options: InlineMarkOptions | undefined): Plugin 
    * The walker uses `nodesBetween` which naturally recurses into
    * containers (blockquote, list, tableCell), so it picks up nested
    * textblocks without each container needing to be listed explicitly.
+   *
+   * When the definition set changed, the walk covers the whole document,
+   * but blocks outside the edited `range` whose cached chunks do not
+   * depend on a changed key are skipped without re-parsing or emitting.
    */
-  function collectChunksForRange(state: EditorState, range: PositionRange): MarkChunk[] {
+  function collectChunksForRange(
+    state: EditorState,
+    range: PositionRange,
+    references: ReferenceIndex,
+    definitionsChanged: boolean,
+  ): MarkChunk[] {
     const chunks: MarkChunk[] = []
-    state.doc.nodesBetween(range.from, range.to, (node, pos) => {
+    const doc = state.doc
+    const scanFrom = definitionsChanged ? 0 : range.from
+    const scanTo = definitionsChanged ? doc.content.size : range.to
+    doc.nodesBetween(scanFrom, scanTo, (node, pos, parent) => {
       if (node.type.spec.code) return false
       if (!node.isTextblock) return true
       if (node.childCount === 0) return false
-      const nodeChunks = chunksForTextblock(node, pos + 1, state.schema)
+      const isDefinition =
+        parent === doc &&
+        node.type.name === 'paragraph' &&
+        cachedDefinitionParse(node, definitionCache) !== null
+      if (definitionsChanged && (pos + node.nodeSize <= range.from || pos + 1 > range.to)) {
+        const cached = chunkCache.get(node)
+        if (cached !== undefined && cacheValid(cached, references, isDefinition)) return false
+      }
+      const nodeChunks = chunksForTextblock(node, pos + 1, state.schema, references, isDefinition)
       if (nodeChunks.length > 0) chunks.push(...nodeChunks)
       return false
     })
     return chunks
   }
 
-  return new Plugin({
-    key: new PluginKey('inline-mark'),
-    appendTransaction(transactions, _oldState, newState) {
+  return new Plugin<InlineMarkPluginState>({
+    key: pluginKey,
+    state: {
+      init(_config, state) {
+        return { references: buildReferenceIndex(state.doc, definitionCache) }
+      },
+      apply(transaction, value) {
+        // Our own appended step only rewrites marks, never block text.
+        if (!transaction.docChanged || transaction.getMeta(META_KEY)) return value
+        if (!transactionTouchesDefinitions(transaction, definitionCache)) return value
+        const next = buildReferenceIndex(transaction.doc, definitionCache, value.references)
+        return next === value.references ? value : { references: next }
+      },
+    },
+    appendTransaction(transactions, oldState, newState) {
       // Drop transactions we appended ourselves to avoid recursing.
       for (const tr of transactions) {
         if (tr.getMeta(META_KEY)) return null
       }
+      const references = pluginKey.getState(newState)?.references ?? EMPTY_REFERENCE_INDEX
+      const oldReferences = pluginKey.getState(oldState)?.references ?? references
+      const definitionsChanged = references !== oldReferences
       const range = computeAffectedRange(transactions, newState)
-      const chunks = collectChunksForRange(newState, range)
+      const chunks = collectChunksForRange(newState, range, references, definitionsChanged)
       if (chunks.length === 0) return null
       const tr = newState.tr.step(new BatchSetMarkStep(chunks))
       tr.setMeta(META_KEY, true)

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.ts
@@ -17,6 +17,11 @@ import { parseMagicComment, type MagicComment } from './magic-comment.ts'
 import type { MarkChunk } from './mark-chunk.ts'
 import type { MarkName } from './mark-names.ts'
 import { marksEqual } from './marks-equal.ts'
+import {
+  normalizeReferenceLabel,
+  type ReferenceDefinition,
+  type ReferenceDefinitions,
+} from './reference-links.ts'
 import type { TypedMarkBuilders } from './schema.ts'
 import { parseWikiEmbed, wikiEmbedBasename, type WikiEmbedOptions } from './wiki-embed.ts'
 import { parseWikilink } from './wikilink.ts'
@@ -72,8 +77,19 @@ export interface FileLinkOptions {
   resolveFileLink?: FileLinkResolver
 }
 
-/** Host options that influence source-backed inline atom parsing. */
-export type InlineMarkOptions = FileLinkOptions & WikiEmbedOptions
+/** Host options and document context that influence inline parsing. */
+export type InlineMarkOptions = FileLinkOptions &
+  WikiEmbedOptions & {
+    /** Document-wide definitions used to resolve reference links. */
+    referenceDefinitions?: ReferenceDefinitions
+    /** This textblock is itself a reference definition; disables resolution. */
+    isReferenceDefinition?: boolean
+    /**
+     * Collector for every reference key this block looked up, resolved or
+     * not, so callers can invalidate cached results when a key changes.
+     */
+    usedReferences?: Map<string, ReferenceDefinition | null>
+  }
 
 /**
  * Walk a textblock's inline content and produce a list of mark chunks
@@ -118,14 +134,18 @@ function walk(
     const type: number = node.type
     if (type === LEZER_NODE_IDS.Link) {
       if (!hasInlineDestination(node)) {
-        // Lezer also parses reference-style links (`[text]`, `[text][label]`),
-        // but meowdown has no link reference definitions, so those stay plain
-        // text: skip the bracket marks and walk any nested syntax as usual.
-        const children = node.children.filter(
-          (child) =>
-            child.type !== LEZER_NODE_IDS.LinkMark && child.type !== LEZER_NODE_IDS.LinkLabel,
-        )
-        walk(children, parentMarks, node.from, node.to, text, marks, out, options)
+        const definition = resolveReference(node, text, options)
+        if (definition) {
+          walkLink(node, parentMarks, text, marks, out, options, definition)
+        } else {
+          // An unresolved reference shape (`[text]`, `[text][label]`) stays
+          // plain text: skip the bracket marks and walk any nested syntax.
+          const children = node.children.filter(
+            (child) =>
+              child.type !== LEZER_NODE_IDS.LinkMark && child.type !== LEZER_NODE_IDS.LinkLabel,
+          )
+          walk(children, parentMarks, node.from, node.to, text, marks, out, options)
+        }
       } else {
         const fileMarks = claimFileLink(node, parentMarks, text, marks, options)
         if (fileMarks) {
@@ -136,7 +156,7 @@ function walk(
       }
     } else if (type === LEZER_NODE_IDS.Image) {
       const trailing = takeMagicComment(node, nodes[index + 1], text)
-      walkImage(node, parentMarks, text, marks, out, trailing)
+      walkImage(node, parentMarks, text, marks, out, options, trailing)
       if (trailing) index++ // skip the folded comment
       pos = trailing ? trailing.to : node.to
       continue
@@ -197,6 +217,8 @@ interface LinkParts {
   labelTo: number
   urlNode: InlineElement | null
   titleNode: InlineElement | null
+  /** The `[label]` of a full reference, brackets included, or null. */
+  referenceLabelNode: InlineElement | null
 }
 
 /**
@@ -222,6 +244,7 @@ function scanLinkParts(node: InlineElement): LinkParts {
   let labelTo = -1
   let urlNode: InlineElement | null = null
   let titleNode: InlineElement | null = null
+  let referenceLabelNode: InlineElement | null = null
   let bracketCount = 0
   for (const child of node.children) {
     const childType = child.type
@@ -233,9 +256,45 @@ function scanLinkParts(node: InlineElement): LinkParts {
       urlNode = child
     } else if (titleNode == null && childType === LEZER_NODE_IDS.LinkTitle) {
       titleNode = child
+    } else if (referenceLabelNode == null && childType === LEZER_NODE_IDS.LinkLabel) {
+      referenceLabelNode = child
     }
   }
-  return { labelFrom, labelTo, urlNode, titleNode }
+  return { labelFrom, labelTo, urlNode, titleNode, referenceLabelNode }
+}
+
+/**
+ * The normalized reference key of a `[text]` / `[text][label]` / `[text][]`
+ * shape, or undefined when the label never closes or normalizes to nothing.
+ */
+function referenceKeyOf(node: InlineElement, text: string): string | undefined {
+  const { labelFrom, labelTo, referenceLabelNode } = scanLinkParts(node)
+  if (labelFrom < 0 || labelTo < 0) return undefined
+  const label = text.slice(labelFrom, labelTo)
+  const authored = referenceLabelNode
+    ? text.slice(referenceLabelNode.from + 1, referenceLabelNode.to - 1) || label
+    : label
+  const key = normalizeReferenceLabel(authored)
+  return key === '' ? undefined : key
+}
+
+/**
+ * Resolve a reference-shaped `Link` / `Image` against the document's
+ * definitions, recording the lookup (hit or miss) in `usedReferences`.
+ */
+function resolveReference(
+  node: InlineElement,
+  text: string,
+  options: InlineMarkOptions | undefined,
+): ReferenceDefinition | undefined {
+  if (options?.referenceDefinitions === undefined || options.isReferenceDefinition === true) {
+    return undefined
+  }
+  const key = referenceKeyOf(node, text)
+  if (key === undefined) return undefined
+  const definition = options.referenceDefinitions.get(key) ?? null
+  options.usedReferences?.set(key, definition)
+  return definition ?? undefined
 }
 
 /** The last path segment of `href` (query/hash stripped), decoded when possible. */
@@ -299,11 +358,17 @@ function walkLink(
   marks: TypedMarkBuilders,
   out: MarkChunk[],
   options: InlineMarkOptions | undefined,
+  reference?: ReferenceDefinition,
 ): void {
   const { labelTo: labelEnd, urlNode, titleNode } = scanLinkParts(node)
-  const href = urlNode ? text.slice(urlNode.from, urlNode.to) : ''
-  const title = titleNode ? unquoteTitle(text.slice(titleNode.from, titleNode.to)) : ''
-  const linkTextMark = href ? marks.mdLinkText.create({ href } satisfies MdLinkTextAttrs) : null
+  const href = reference ? reference.href : urlNode ? text.slice(urlNode.from, urlNode.to) : ''
+  const title = reference
+    ? reference.title
+    : titleNode
+      ? unquoteTitle(text.slice(titleNode.from, titleNode.to))
+      : ''
+  const linkTextMark =
+    href || reference ? marks.mdLinkText.create({ href } satisfies MdLinkTextAttrs) : null
   const inLabel = (pos: number): boolean => labelEnd >= 0 && pos < labelEnd && linkTextMark !== null
 
   const pack = marks.mdPack.create({ key: 'link', data: { href, title } } satisfies MdPackAttrs)
@@ -328,7 +393,10 @@ function walkLink(
       pos = child.to
       continue
     }
-    const maybeMarkName = MARK_NAME_BY_TYPE_ID.get(child.type)
+    const maybeMarkName =
+      reference && child.type === LEZER_NODE_IDS.LinkLabel
+        ? 'mdMark'
+        : MARK_NAME_BY_TYPE_ID.get(child.type)
     const childMarks = maybeMarkName
       ? [...baseForChild, marks[maybeMarkName].create()]
       : baseForChild
@@ -376,12 +444,14 @@ function walkImage(
   text: string,
   marks: TypedMarkBuilders,
   out: MarkChunk[],
+  options: InlineMarkOptions | undefined,
   trailing?: AdjacentMagicComment,
 ): void {
   const urlNode = node.children.find((child) => child.type === LEZER_NODE_IDS.URL)
-  if (!urlNode) {
-    // A reference image `![alt][id]` has no `URL` child; fall back to the link
-    // walk, which renders nothing yet.
+  const reference = urlNode ? undefined : resolveReference(node, text, options)
+  if (!urlNode && !reference) {
+    // An unresolved reference image `![alt][id]` has no `URL` child; fall back
+    // to the link walk, which renders nothing yet.
     walkLink(node, parentMarks, text, marks, out, undefined)
     return
   }
@@ -389,10 +459,18 @@ function walkImage(
   const bracketNodes = node.children.filter((child) => child.type === LEZER_NODE_IDS.LinkMark)
   const titleNode = node.children.find((child) => child.type === LEZER_NODE_IDS.LinkTitle)
 
-  const src: string = text.slice(urlNode.from, urlNode.to)
+  const src: string = reference
+    ? reference.href
+    : urlNode
+      ? text.slice(urlNode.from, urlNode.to)
+      : ''
   const alt: string =
     bracketNodes.length >= 2 ? text.slice(bracketNodes[0].to, bracketNodes[1].from) : ''
-  const title: string = titleNode ? unquoteTitle(text.slice(titleNode.from, titleNode.to)) : ''
+  const title: string = reference
+    ? reference.title
+    : titleNode
+      ? unquoteTitle(text.slice(titleNode.from, titleNode.to))
+      : ''
   const width = trailing?.magic.width ?? null
   const height = trailing?.magic.height ?? null
   const to = trailing?.to ?? node.to

--- a/packages/core/src/extensions/reference-links.test.ts
+++ b/packages/core/src/extensions/reference-links.test.ts
@@ -1,0 +1,127 @@
+import { getMarkType } from '@prosekit/core'
+import type { EditorNode } from '@prosekit/pm/model'
+import { describe, expect, it } from 'vitest'
+
+import { findText } from '../testing/find-text.ts'
+import { setupFixture, type Fixture } from '../testing/index.ts'
+
+function hrefAt(doc: EditorNode, needle: string): string | undefined {
+  const node = doc.nodeAt(findText(doc, needle))
+  const mark = node?.marks.find((candidate) => candidate.type.name === 'mdLinkText')
+  return mark?.attrs.href
+}
+
+describe('reference links', () => {
+  function setupDoc(...paragraphTexts: string[]): Fixture {
+    const fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(...paragraphTexts.map((text) => n.paragraph(text))))
+    return fixture
+  }
+
+  it('resolves a shortcut reference', () => {
+    using fixture = setupDoc('Read [alpha] here.', '[alpha]: https://a.test')
+    expect(hrefAt(fixture.doc, 'alpha')).toBe('https://a.test')
+  })
+
+  it('resolves a full reference', () => {
+    using fixture = setupDoc('See [text here][alpha] now.', '[alpha]: https://a.test')
+    expect(hrefAt(fixture.doc, 'text here')).toBe('https://a.test')
+  })
+
+  it('resolves a collapsed reference', () => {
+    using fixture = setupDoc('See [beta][] now.', '[beta]: https://b.test')
+    expect(hrefAt(fixture.doc, 'beta')).toBe('https://b.test')
+  })
+
+  it('matches labels case-insensitively', () => {
+    using fixture = setupDoc('Read [Alpha] here.', '[alpha]: https://a.test')
+    expect(hrefAt(fixture.doc, 'Alpha')).toBe('https://a.test')
+  })
+
+  it('marks the full reference label as syntax', () => {
+    using fixture = setupDoc('See [text here][alpha] now.', '[alpha]: https://a.test')
+    const labelNode = fixture.doc.nodeAt(findText(fixture.doc, '[alpha]'))
+    const names = labelNode?.marks.map((mark) => mark.type.name).sort()
+    expect(names).toEqual(['mdMark', 'mdPack'])
+  })
+
+  it('keeps an unresolved reference as plain text', () => {
+    using fixture = setupDoc('Read [gamma] and [delta][nope].')
+    expect(hrefAt(fixture.doc, 'gamma')).toBeUndefined()
+    expect(hrefAt(fixture.doc, 'delta')).toBeUndefined()
+  })
+
+  it('keeps the definition label unlinked', () => {
+    using fixture = setupDoc('Read [alpha] here.', '[alpha]: https://a.test')
+    expect(hrefAt(fixture.doc, '[alpha]:')).toBeUndefined()
+  })
+
+  it('lets the first definition win', () => {
+    using fixture = setupDoc(
+      'Read [alpha].',
+      '[alpha]: https://first.test',
+      '[alpha]: https://second.test',
+    )
+    expect(hrefAt(fixture.doc, 'alpha')).toBe('https://first.test')
+  })
+
+  it('resolves an empty destination', () => {
+    using fixture = setupDoc('Read [foo] here.', '[foo]: <>')
+    expect(hrefAt(fixture.doc, 'foo')).toBe('')
+  })
+
+  it('renders a reference image', () => {
+    using fixture = setupDoc('See ![moon pic][moon].', '[moon]: https://img.test/moon.jpg')
+    const imageNode = fixture.doc.nodeAt(findText(fixture.doc, 'moon pic'))
+    const imageMark = imageNode?.marks.find((mark) => mark.type.name === 'mdImage')
+    expect(imageMark?.attrs.src).toBe('https://img.test/moon.jpg')
+  })
+
+  it('ignores a definition inside a blockquote', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(
+      n.doc(n.paragraph('Read [alpha].'), n.blockquote(n.paragraph('[alpha]: https://quoted.test'))),
+    )
+    expect(hrefAt(fixture.doc, 'alpha')).toBeUndefined()
+  })
+
+  it('updates citing links when the definition URL changes', () => {
+    using fixture = setupDoc('Read [alpha] here.', '[alpha]: https://a.test')
+    const { editor } = fixture
+    const urlEnd = findText(fixture.doc, 'https://a.test') + 'https://a.test'.length
+    editor.view.dispatch(editor.state.tr.insertText('x', urlEnd))
+    expect(hrefAt(fixture.doc, 'alpha')).toBe('https://a.testx')
+  })
+
+  it('unresolves citing links when the definition is deleted', () => {
+    using fixture = setupDoc('Read [alpha] here.', '[alpha]: https://a.test')
+    const { editor } = fixture
+    const definition = fixture.doc.child(fixture.doc.childCount - 1)
+    const definitionStart = fixture.doc.content.size - definition.nodeSize
+    editor.view.dispatch(editor.state.tr.delete(definitionStart, fixture.doc.content.size))
+    expect(hrefAt(fixture.doc, 'alpha')).toBeUndefined()
+  })
+
+  it('resolves after a definition is created later', () => {
+    using fixture = setupDoc('Read [alpha] here.')
+    const { editor, n } = fixture
+    expect(hrefAt(fixture.doc, 'alpha')).toBeUndefined()
+    const definition = n.paragraph('[alpha]: https://late.test')
+    editor.view.dispatch(editor.state.tr.insert(editor.state.doc.content.size, definition))
+    expect(hrefAt(fixture.doc, 'alpha')).toBe('https://late.test')
+  })
+
+  it('survives an external AddMarkStep across the definition', () => {
+    using fixture = setupDoc('Read [alpha] here.', '[alpha]: https://a.test')
+    const { editor } = fixture
+    const definitionStart = findText(fixture.doc, '[alpha]:')
+    const strong = getMarkType(fixture.schema, 'mdStrong').create()
+    editor.view.dispatch(editor.state.tr.addMark(definitionStart, definitionStart + 7, strong))
+    expect(hrefAt(fixture.doc, 'alpha')).toBe('https://a.test')
+    const sentenceEnd = findText(fixture.doc, 'here.') + 'here.'.length
+    editor.view.dispatch(editor.state.tr.insertText('!', sentenceEnd))
+    expect(hrefAt(fixture.doc, 'alpha')).toBe('https://a.test')
+  })
+})

--- a/packages/core/src/extensions/reference-links.test.ts
+++ b/packages/core/src/extensions/reference-links.test.ts
@@ -5,10 +5,14 @@ import { describe, expect, it } from 'vitest'
 import { findText } from '../testing/find-text.ts'
 import { setupFixture, type Fixture } from '../testing/index.ts'
 
+import { flushPendingRestyle } from './inline-mark-plugin.ts'
+import type { MdImageAttrs, MdLinkTextAttrs } from './inline-marks.ts'
+import { isMarkOfType } from './mark-names.ts'
+
 function hrefAt(doc: EditorNode, needle: string): string | undefined {
   const node = doc.nodeAt(findText(doc, needle))
-  const mark = node?.marks.find((candidate) => candidate.type.name === 'mdLinkText')
-  return mark?.attrs.href
+  const mark = node?.marks.find((candidate) => isMarkOfType(candidate, 'mdLinkText'))
+  return (mark?.attrs as MdLinkTextAttrs | undefined)?.href
 }
 
 describe('reference links', () => {
@@ -74,15 +78,18 @@ describe('reference links', () => {
   it('renders a reference image', () => {
     using fixture = setupDoc('See ![moon pic][moon].', '[moon]: https://img.test/moon.jpg')
     const imageNode = fixture.doc.nodeAt(findText(fixture.doc, 'moon pic'))
-    const imageMark = imageNode?.marks.find((mark) => mark.type.name === 'mdImage')
-    expect(imageMark?.attrs.src).toBe('https://img.test/moon.jpg')
+    const imageMark = imageNode?.marks.find((mark) => isMarkOfType(mark, 'mdImage'))
+    expect((imageMark?.attrs as MdImageAttrs | undefined)?.src).toBe('https://img.test/moon.jpg')
   })
 
   it('ignores a definition inside a blockquote', () => {
     using fixture = setupFixture()
     const { n } = fixture
     fixture.set(
-      n.doc(n.paragraph('Read [alpha].'), n.blockquote(n.paragraph('[alpha]: https://quoted.test'))),
+      n.doc(
+        n.paragraph('Read [alpha].'),
+        n.blockquote(n.paragraph('[alpha]: https://quoted.test')),
+      ),
     )
     expect(hrefAt(fixture.doc, 'alpha')).toBeUndefined()
   })
@@ -92,6 +99,7 @@ describe('reference links', () => {
     const { editor } = fixture
     const urlEnd = findText(fixture.doc, 'https://a.test') + 'https://a.test'.length
     editor.view.dispatch(editor.state.tr.insertText('x', urlEnd))
+    flushPendingRestyle(editor.view)
     expect(hrefAt(fixture.doc, 'alpha')).toBe('https://a.testx')
   })
 
@@ -101,6 +109,7 @@ describe('reference links', () => {
     const definition = fixture.doc.child(fixture.doc.childCount - 1)
     const definitionStart = fixture.doc.content.size - definition.nodeSize
     editor.view.dispatch(editor.state.tr.delete(definitionStart, fixture.doc.content.size))
+    flushPendingRestyle(editor.view)
     expect(hrefAt(fixture.doc, 'alpha')).toBeUndefined()
   })
 
@@ -110,6 +119,7 @@ describe('reference links', () => {
     expect(hrefAt(fixture.doc, 'alpha')).toBeUndefined()
     const definition = n.paragraph('[alpha]: https://late.test')
     editor.view.dispatch(editor.state.tr.insert(editor.state.doc.content.size, definition))
+    flushPendingRestyle(editor.view)
     expect(hrefAt(fixture.doc, 'alpha')).toBe('https://late.test')
   })
 

--- a/packages/core/src/extensions/reference-links.ts
+++ b/packages/core/src/extensions/reference-links.ts
@@ -1,0 +1,183 @@
+import { gfmParser, LEZER_NODE_IDS, type SyntaxNode } from '@meowdown/markdown'
+import type { EditorNode } from '@prosekit/pm/model'
+import type { Transaction } from '@prosekit/pm/state'
+import { decodeString } from 'micromark-util-decode-string'
+import { normalizeIdentifier } from 'micromark-util-normalize-identifier'
+
+/** One CommonMark link-reference definition resolved for rendering. */
+export interface ReferenceDefinition {
+  /** Normalized label key used by full, collapsed, and shortcut references. */
+  key: string
+  /** Destination value with optional angle brackets removed. */
+  href: string
+  /** Unquoted definition title, or an empty string. */
+  title: string
+}
+
+/** First-definition-wins lookup, matching CommonMark reference semantics. */
+export type ReferenceDefinitions = ReadonlyMap<string, ReferenceDefinition>
+
+/** Parse results per textblock node identity; `null` marks a non-definition. */
+export type ReferenceDefinitionCache = WeakMap<EditorNode, ReferenceDefinition | null>
+
+/** Document-wide definitions; rebuilt only when a definition-shaped block changes. */
+export interface ReferenceIndex {
+  definitions: ReferenceDefinitions
+}
+
+const EMPTY_DEFINITIONS: ReferenceDefinitions = new Map()
+
+export const EMPTY_REFERENCE_INDEX: ReferenceIndex = { definitions: EMPTY_DEFINITIONS }
+
+/**
+ * A definition block is one line; longer blocks are prose that merely starts
+ * like a definition, and parsing them on every keystroke is wasted work.
+ */
+const MAX_DEFINITION_LENGTH = 1024
+
+/** CommonMark label normalization: collapse whitespace and Unicode case-fold. */
+export function normalizeReferenceLabel(label: string): string {
+  return normalizeIdentifier(label)
+}
+
+function destinationValue(raw: string): string {
+  const unwrapped = raw.startsWith('<') && raw.endsWith('>') ? raw.slice(1, -1) : raw
+  return decodeString(unwrapped)
+}
+
+function titleValue(raw: string): string {
+  return raw.length >= 2 ? decodeString(raw.slice(1, -1)) : ''
+}
+
+/** `text` could open a definition: `[` after at most 3 spaces, with a `]:`. */
+function isDefinitionShaped(text: string): boolean {
+  if (text.length > MAX_DEFINITION_LENGTH) return false
+  const first = text.search(/\S/)
+  return first >= 0 && first <= 3 && text[first] === '[' && text.includes(']:')
+}
+
+/** Parse one textblock's text as a complete CommonMark link-reference definition. */
+function parseReferenceDefinition(text: string): ReferenceDefinition | null {
+  if (!isDefinitionShaped(text)) return null
+  let reference: SyntaxNode | null = null
+  gfmParser.parse(text).iterate({
+    enter(node) {
+      if (node.type.id !== LEZER_NODE_IDS.LinkReference) return true
+      reference = node.node
+      return false
+    },
+  })
+  if (reference === null) return null
+  const found: SyntaxNode = reference
+  const labelNode = found.getChild('LinkLabel')
+  const urlNode = found.getChild('URL')
+  if (labelNode === null || urlNode === null) return null
+  const key = normalizeReferenceLabel(text.slice(labelNode.from + 1, labelNode.to - 1))
+  if (key === '') return null
+  const titleNode = found.getChild('LinkTitle')
+  return {
+    key,
+    href: destinationValue(text.slice(urlNode.from, urlNode.to)),
+    title: titleNode === null ? '' : titleValue(text.slice(titleNode.from, titleNode.to)),
+  }
+}
+
+/** Definition parse for one textblock, memoized on the immutable node identity. */
+export function cachedDefinitionParse(
+  node: EditorNode,
+  cache: ReferenceDefinitionCache,
+): ReferenceDefinition | null {
+  const hit = cache.get(node)
+  if (hit !== undefined) return hit
+  const parsed = parseReferenceDefinition(node.textContent)
+  cache.set(node, parsed)
+  return parsed
+}
+
+function definitionsEqual(left: ReferenceDefinitions, right: ReferenceDefinitions): boolean {
+  if (left.size !== right.size) return false
+  for (const [key, definition] of right) {
+    const other = left.get(key)
+    if (
+      other !== definition &&
+      (other === undefined || other.href !== definition.href || other.title !== definition.title)
+    ) {
+      return false
+    }
+  }
+  return true
+}
+
+/**
+ * Scan the document's top-level paragraphs for definitions. Definitions are
+ * deliberately top-level only: performance is preferred over CommonMark's
+ * container support, and unchanged blocks hit `cache` by node identity.
+ * Returns `previous` unchanged when the collected definitions are identical,
+ * so callers can compare indexes by object identity.
+ */
+export function buildReferenceIndex(
+  doc: EditorNode,
+  cache: ReferenceDefinitionCache,
+  previous?: ReferenceIndex,
+): ReferenceIndex {
+  let definitions: Map<string, ReferenceDefinition> | undefined
+  doc.forEach((child) => {
+    if (child.type.name !== 'paragraph' || child.childCount === 0) return
+    const definition = cachedDefinitionParse(child, cache)
+    if (definition === null) return
+    definitions ??= new Map()
+    if (!definitions.has(definition.key)) definitions.set(definition.key, definition)
+  })
+  const next = definitions ?? EMPTY_DEFINITIONS
+  if (previous !== undefined && definitionsEqual(previous.definitions, next)) return previous
+  if (previous === undefined && next === EMPTY_DEFINITIONS) return EMPTY_REFERENCE_INDEX
+  return { definitions: next }
+}
+
+function rangeHasDefinitionShapedBlock(
+  doc: EditorNode,
+  from: number,
+  to: number,
+  cache: ReferenceDefinitionCache,
+): boolean {
+  const docSize = doc.content.size
+  let found = false
+  doc.nodesBetween(Math.max(0, from - 1), Math.min(docSize, to + 1), (node, _pos, parent) => {
+    if (found || parent !== doc) return false
+    if (node.type.name === 'paragraph') {
+      const cached = cache.get(node)
+      if (cached !== undefined ? cached !== null : isDefinitionShaped(node.textContent)) {
+        found = true
+      }
+    }
+    return false
+  })
+  return found
+}
+
+/**
+ * Whether a transaction could have added, removed, or altered a definition
+ * block. Checks the blocks around every step's ranges on both the before and
+ * after documents, so a plain-paragraph keystroke costs one textblock guard
+ * and steps without ranges (mark and attr steps, which cannot change any
+ * block's text) never trigger an index rebuild.
+ */
+export function transactionTouchesDefinitions(
+  transaction: Transaction,
+  cache: ReferenceDefinitionCache,
+): boolean {
+  for (const [index, map] of transaction.mapping.maps.entries()) {
+    const before = transaction.docs[index]
+    const after =
+      index + 1 < transaction.docs.length ? transaction.docs[index + 1] : transaction.doc
+    let touched = false
+    map.forEach((oldStart, oldEnd, newStart, newEnd) => {
+      if (touched) return
+      touched =
+        rangeHasDefinitionShapedBlock(before, oldStart, oldEnd, cache) ||
+        rangeHasDefinitionShapedBlock(after, newStart, newEnd, cache)
+    })
+    if (touched) return true
+  }
+  return false
+}

--- a/packages/core/src/extensions/reference-links.ts
+++ b/packages/core/src/extensions/reference-links.ts
@@ -4,6 +4,8 @@ import type { Transaction } from '@prosekit/pm/state'
 import { decodeString } from 'micromark-util-decode-string'
 import { normalizeIdentifier } from 'micromark-util-normalize-identifier'
 
+import { isNodeOfType } from './node-names.ts'
+
 /** One CommonMark link-reference definition resolved for rendering. */
 export interface ReferenceDefinition {
   /** Normalized label key used by full, collapsed, and shortcut references. */
@@ -122,7 +124,7 @@ export function buildReferenceIndex(
 ): ReferenceIndex {
   let definitions: Map<string, ReferenceDefinition> | undefined
   doc.forEach((child) => {
-    if (child.type.name !== 'paragraph' || child.childCount === 0) return
+    if (!isNodeOfType(child, 'paragraph') || child.childCount === 0) return
     const definition = cachedDefinitionParse(child, cache)
     if (definition === null) return
     definitions ??= new Map()
@@ -144,7 +146,7 @@ function rangeHasDefinitionShapedBlock(
   let found = false
   doc.nodesBetween(Math.max(0, from - 1), Math.min(docSize, to + 1), (node, _pos, parent) => {
     if (found || parent !== doc) return false
-    if (node.type.name === 'paragraph') {
+    if (isNodeOfType(node, 'paragraph')) {
       const cached = cache.get(node)
       if (cached !== undefined ? cached !== null : isDefinitionShaped(node.textContent)) {
         found = true

--- a/packages/core/src/extensions/reference-restyle.test.ts
+++ b/packages/core/src/extensions/reference-restyle.test.ts
@@ -1,0 +1,85 @@
+import type { EditorNode } from '@prosekit/pm/model'
+import { describe, expect, it, vi } from 'vitest'
+
+import { findText } from '../testing/find-text.ts'
+import { setupFixture, type Fixture } from '../testing/index.ts'
+
+import { flushPendingRestyle, getCacheStats, resetCacheStats } from './inline-mark-plugin.ts'
+import type { MdLinkTextAttrs } from './inline-marks.ts'
+import { isMarkOfType } from './mark-names.ts'
+
+function hrefAt(doc: EditorNode, needle: string): string | undefined {
+  const node = doc.nodeAt(findText(doc, needle))
+  const mark = node?.marks.find((candidate) => isMarkOfType(candidate, 'mdLinkText'))
+  return (mark?.attrs as MdLinkTextAttrs | undefined)?.href
+}
+
+describe('deferred reference restyle', () => {
+  function typeAt(fixture: Fixture, pos: number, text: string): void {
+    const { editor } = fixture
+    editor.view.dispatch(editor.state.tr.insertText(text, pos))
+  }
+
+  function setupCitingDoc(citingCount: number): Fixture {
+    const fixture = setupFixture()
+    const { n } = fixture
+    const citing = Array.from({ length: citingCount }, (_, index) =>
+      n.paragraph(`Cited ${index} points at [alpha] mid-sentence.`),
+    )
+    fixture.set(n.doc(...citing, n.paragraph('[alpha]: https://a.test')))
+    return fixture
+  }
+
+  it('resolves references synchronously in the mount pass', () => {
+    using fixture = setupCitingDoc(1)
+    expect(hrefAt(fixture.doc, 'alpha')).toBe('https://a.test')
+  })
+
+  it('keeps citing blocks on the old href until the flush', async () => {
+    using fixture = setupCitingDoc(1)
+    const urlEnd = findText(fixture.doc, 'https://a.test') + 'https://a.test'.length
+    typeAt(fixture, urlEnd, 'x')
+    // The keystroke itself must not restyle the citing block.
+    expect(hrefAt(fixture.doc, 'alpha')).toBe('https://a.test')
+    await vi.waitFor(() => {
+      expect(hrefAt(fixture.doc, 'alpha')).toBe('https://a.testx')
+    })
+  })
+
+  it('coalesces a keystroke burst into one restyle pass', async () => {
+    using fixture = setupCitingDoc(5)
+    let pos = findText(fixture.doc, 'https://a.test') + 'https://a.test'.length
+    resetCacheStats()
+    for (let i = 0; i < 10; i++) {
+      typeAt(fixture, pos, 'x')
+      pos += 1
+    }
+    await vi.waitFor(() => {
+      expect(hrefAt(fixture.doc, 'alpha')).toBe('https://a.test' + 'x'.repeat(10))
+    })
+    // 10 keystrokes re-parse the edited definition block once each; the
+    // single flush re-parses the 5 citing blocks and the definition block
+    // once. A synchronous restyle would have paid 10 x 5 citing parses.
+    expect(getCacheStats().parses).toBeLessThanOrEqual(10 + 5 + 2)
+  })
+
+  it('flushes deterministically through the test helper', () => {
+    using fixture = setupCitingDoc(1)
+    const urlEnd = findText(fixture.doc, 'https://a.test') + 'https://a.test'.length
+    typeAt(fixture, urlEnd, 'x')
+    flushPendingRestyle(fixture.editor.view)
+    expect(hrefAt(fixture.doc, 'alpha')).toBe('https://a.testx')
+  })
+
+  it('defers linkifying when a definition is created', async () => {
+    using fixture = setupFixture()
+    const { n, editor } = fixture
+    fixture.set(n.doc(n.paragraph('Read [alpha] here.')))
+    const definition = n.paragraph('[alpha]: https://late.test')
+    editor.view.dispatch(editor.state.tr.insert(editor.state.doc.content.size, definition))
+    expect(hrefAt(fixture.doc, 'alpha')).toBeUndefined()
+    await vi.waitFor(() => {
+      expect(hrefAt(fixture.doc, 'alpha')).toBe('https://late.test')
+    })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,12 @@ importers:
       mdast-util-to-markdown:
         specifier: ^2.1.2
         version: 2.1.2
+      micromark-util-decode-string:
+        specifier: ^2.0.1
+        version: 2.0.1
+      micromark-util-normalize-identifier:
+        specifier: ^2.0.1
+        version: 2.0.1
       prosemirror-flat-list:
         specifier: ^0.7.1
         version: 0.7.1


### PR DESCRIPTION
Resolve CommonMark reference links (`[text]`, `[text][label]`, `[text][]`) and reference images against top-level `[label]: url` definition blocks, which stay literal source paragraphs and round-trip byte-exact. Unlike #314, the definition index is rebuilt by a guarded full rescan with per-block key-dependency caching, definition edits restyle citing blocks through a debounced flush instead of on every keystroke, and `BatchSetMarkStep.apply` applies all chunks in one document pass, so typing cost stays flat relative to master at every measured document size, definition count, and citation count.