### PR TITLE
fix: place virtual caret after code-block newline

### DIFF
--- a/packages/core/src/extensions/caret-rect.ts
+++ b/packages/core/src/extensions/caret-rect.ts
@@ -36,7 +36,11 @@ export function findCoordsCaretRect(view: EditorView): CaretRect | undefined {
   const head = state.selection.head
   const runBefore = getHiddenRunBefore(state, head)
   const runAfter = getHiddenRunAfter(state, head)
-  const preferredBeforeSide: boolean = runBefore == null
+  const $head = state.doc.resolve(head)
+  const afterLineBreak =
+    $head.parentOffset > 0 &&
+    $head.parent.textBetween($head.parentOffset - 1, $head.parentOffset) === '\n'
+  const preferredBeforeSide: boolean = runBefore == null && !afterLineBreak
   // `side` picks which neighbor to measure: -1 the character before the
   // position, 1 the character after it.
   const probes: [pos: number, beforeSide: boolean][] = [

--- a/packages/core/src/extensions/virtual-caret.test.ts
+++ b/packages/core/src/extensions/virtual-caret.test.ts
@@ -126,7 +126,7 @@ describe('virtual caret rendering', () => {
     const top3 = getCaretElement().getBoundingClientRect().top
 
     expect(top2 - top1).toBeGreaterThan(10)
-    expect(top3).toBeCloseTo(top2)
+    expect(Math.abs(top3 - top2)).toBeLessThan(5)
   })
 })
 

--- a/packages/core/src/extensions/virtual-caret.test.ts
+++ b/packages/core/src/extensions/virtual-caret.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 
 import { setupFixture, type Fixture } from '../testing/index.ts'
@@ -91,21 +91,42 @@ describe('virtual caret rendering', () => {
   it('moves to the new code-block line immediately after Enter', async () => {
     using fixture = setupFixture()
     const { n } = fixture
-    fixture.set(n.doc(n.codeBlock('foo<a>')))
     fixture.view.focus()
+
+    fixture.set(n.doc(n.codeBlock('line1\nline2<a>')))
     await expect.element(caret).toBeVisible()
+    expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`
+      "
+      line1
+      line2┃
+      "
+    `)
+    const top1 = getCaretElement().getBoundingClientRect().top
 
-    expect(fixture.selectionSnapshot).toBe('foo┃')
     await userEvent.keyboard('{Enter}')
-    expect(fixture.selectionSnapshot).toBe('\nfoo\n┃\n')
-    const afterEnterTop = getCaretElement().getBoundingClientRect().top
+    await expect.element(caret).toBeVisible()
+    expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`
+      "
+      line1
+      line2
+      ┃
+      "
+    `)
+    const top2 = getCaretElement().getBoundingClientRect().top
 
-    await userEvent.keyboard('A')
-    expect(fixture.selectionSnapshot).toBe('\nfoo\nA┃\n')
-    await vi.waitFor(() => {
-      const afterTypingTop = getCaretElement().getBoundingClientRect().top
-      expect(Math.abs(afterEnterTop - afterTypingTop)).toBeLessThanOrEqual(3)
-    })
+    await userEvent.keyboard('a')
+    await expect.element(caret).toBeVisible()
+    expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`
+      "
+      line1
+      line2
+      a┃
+      "
+    `)
+    const top3 = getCaretElement().getBoundingClientRect().top
+
+    expect(top2 - top1).toBeGreaterThan(10)
+    expect(top3).toBeCloseTo(top2)
   })
 })
 

--- a/packages/core/src/extensions/virtual-caret.test.ts
+++ b/packages/core/src/extensions/virtual-caret.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 
 import { setupFixture, type Fixture } from '../testing/index.ts'
@@ -86,6 +86,26 @@ describe('virtual caret rendering', () => {
     using fixture = setupMode('hide', 'hello <a>world')
     await userEvent.keyboard('x')
     expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`"hello x┃world"`)
+  })
+
+  it('moves to the new code-block line immediately after Enter', async () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.codeBlock('foo<a>')))
+    fixture.view.focus()
+    await expect.element(caret).toBeVisible()
+
+    expect(fixture.selectionSnapshot).toBe('foo┃')
+    await userEvent.keyboard('{Enter}')
+    expect(fixture.selectionSnapshot).toBe('\nfoo\n┃\n')
+    const afterEnterTop = getCaretElement().getBoundingClientRect().top
+
+    await userEvent.keyboard('A')
+    expect(fixture.selectionSnapshot).toBe('\nfoo\nA┃\n')
+    await vi.waitFor(() => {
+      const afterTypingTop = getCaretElement().getBoundingClientRect().top
+      expect(Math.abs(afterEnterTop - afterTypingTop)).toBeLessThanOrEqual(3)
+    })
   })
 })
 


### PR DESCRIPTION
Prefer the forward `coordsAtPos` probe when the selection follows a newline, so an empty code-block line uses its own geometry instead of the end of the preceding text. Add a browser regression test covering Enter followed by typing.

Validated with targeted Chromium, Firefox, and WebKit tests, `pnpm typecheck`, `pnpm lint`, and the full Chromium suite.
