### PR TITLE
fix: move a block between editors instead of duplicating it

### DIFF
--- a/packages/core/src/extensions/cross-editor-drag.test.ts
+++ b/packages/core/src/extensions/cross-editor-drag.test.ts
@@ -1,0 +1,130 @@
+import { dropAt, startBlockDrag, startTextDrag } from '@meowdown/vitest/drag-events'
+import { isApple } from '@prosekit/core'
+import { describe, expect, it, vi } from 'vitest'
+
+import { markdownToDoc } from '../converters/md-to-pm.ts'
+import { docToMarkdown } from '../converters/pm-to-md.ts'
+import { setupFixture, type Fixture } from '../testing/index.ts'
+
+function setupEditor(markdown: string, containerId: string): Fixture {
+  const fixture = setupFixture({ containerId })
+  fixture.set(markdownToDoc(markdown, { nodes: fixture.editor.nodes }))
+  return fixture
+}
+
+function setupSource(markdown = 'Alpha\n\nBravo'): Fixture {
+  return setupEditor(markdown, 'test-container')
+}
+
+function setupTarget(markdown = 'Charlie'): Fixture {
+  return setupEditor(markdown, 'test-container-target')
+}
+
+// Aims at the end of the last text block, where `dropPoint` inserts after it.
+function endOfDoc(fixture: Fixture): number {
+  return fixture.doc.content.size - 1
+}
+
+const copyModifier: DragEventInit = isApple ? { altKey: true } : { ctrlKey: true }
+
+describe('cross editor drag', () => {
+  it('removes the block from the source editor after it lands', async () => {
+    using source = setupSource()
+    using target = setupTarget()
+
+    dropAt(target.view, startBlockDrag(source.view, 0), endOfDoc(target))
+
+    await vi.waitFor(() => {
+      expect(docToMarkdown(source.doc)).toBe('Bravo\n')
+    })
+    expect(docToMarkdown(target.doc)).toBe('Charlie\n\nAlpha\n')
+  })
+
+  it('keeps list marker fidelity while moving', async () => {
+    using source = setupSource('+ [ ] Task\n\nBravo')
+    using target = setupTarget()
+
+    dropAt(target.view, startBlockDrag(source.view, 0), endOfDoc(target))
+
+    await vi.waitFor(() => {
+      expect(docToMarkdown(source.doc)).toBe('Bravo\n')
+    })
+    expect(docToMarkdown(target.doc)).toBe('Charlie\n\n+ [ ] Task\n')
+  })
+
+  it('moves a dragged text selection out of the source editor', async () => {
+    using source = setupSource('Alpha Bravo')
+    using target = setupTarget()
+
+    // "Alpha " carries no `dragging.node`, so the source delete goes through
+    // `deleteSelection`.
+    dropAt(target.view, startTextDrag(source.view, 1, 7), endOfDoc(target))
+
+    await vi.waitFor(() => {
+      expect(docToMarkdown(source.doc)).toBe('Bravo\n')
+    })
+    expect(target.doc.textContent).toContain('Alpha')
+  })
+
+  it('copies instead of moving when the copy modifier is held', async () => {
+    using source = setupSource()
+    using target = setupTarget()
+
+    dropAt(target.view, startBlockDrag(source.view, 0), endOfDoc(target), copyModifier)
+
+    await vi.waitFor(() => {
+      expect(docToMarkdown(target.doc)).toBe('Charlie\n\nAlpha\n')
+    })
+    expect(docToMarkdown(source.doc)).toBe('Alpha\n\nBravo\n')
+  })
+
+  it('leaves the source alone when the drop carries nothing', async () => {
+    using source = setupSource()
+    using target = setupTarget()
+
+    startBlockDrag(source.view, 0)
+    // An empty transfer parses to an empty slice, so nothing lands.
+    dropAt(target.view, new DataTransfer(), endOfDoc(target))
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(docToMarkdown(source.doc)).toBe('Alpha\n\nBravo\n')
+    expect(docToMarkdown(target.doc)).toBe('Charlie\n')
+  })
+
+  it('ignores a drop that did not start in another meowdown editor', async () => {
+    using source = setupSource()
+    using target = setupTarget()
+
+    const dataTransfer = new DataTransfer()
+    dataTransfer.setData('text/plain', 'Delta')
+    dropAt(target.view, dataTransfer, endOfDoc(target))
+
+    await vi.waitFor(() => {
+      expect(target.doc.textContent).toContain('Delta')
+    })
+    expect(docToMarkdown(source.doc)).toBe('Alpha\n\nBravo\n')
+  })
+
+  it('does not touch a third editor that is not the drag source', async () => {
+    using source = setupSource()
+    using target = setupTarget()
+    using bystander = setupEditor('Echo', 'test-container-bystander')
+
+    dropAt(target.view, startBlockDrag(source.view, 0), endOfDoc(target))
+
+    await vi.waitFor(() => {
+      expect(docToMarkdown(source.doc)).toBe('Bravo\n')
+    })
+    expect(docToMarkdown(bystander.doc)).toBe('Echo\n')
+  })
+
+  it('keeps a same editor drag on the ProseMirror move path', async () => {
+    using fixture = setupSource()
+
+    dropAt(fixture.view, startBlockDrag(fixture.view, 0), endOfDoc(fixture))
+
+    await vi.waitFor(() => {
+      expect(docToMarkdown(fixture.doc)).toBe('Bravo\n\nAlpha\n')
+    })
+  })
+})

--- a/packages/core/src/extensions/cross-editor-drag.test.ts
+++ b/packages/core/src/extensions/cross-editor-drag.test.ts
@@ -91,6 +91,21 @@ describe('cross editor drag', () => {
     expect(docToMarkdown(target.doc)).toBe('Charlie\n')
   })
 
+  it('leaves the source alone when its doc changed during the drag', async () => {
+    using source = setupSource()
+    using target = setupTarget()
+
+    const dataTransfer = startBlockDrag(source.view, 0)
+    // Editing the dragged block makes the dragstart-time positions stale.
+    source.view.dispatch(source.view.state.tr.insertText('Zulu ', 1))
+    dropAt(target.view, dataTransfer, endOfDoc(target))
+
+    await vi.waitFor(() => {
+      expect(docToMarkdown(target.doc)).toBe('Charlie\n\nAlpha\n')
+    })
+    expect(docToMarkdown(source.doc)).toBe('Zulu Alpha\n\nBravo\n')
+  })
+
   it('ignores a drop that did not start in another meowdown editor', async () => {
     using source = setupSource()
     using target = setupTarget()

--- a/packages/core/src/extensions/cross-editor-drag.ts
+++ b/packages/core/src/extensions/cross-editor-drag.ts
@@ -1,0 +1,106 @@
+import { definePlugin, isApple, Priority, withPriority, type PlainExtension } from '@prosekit/core'
+import type { ViewDragging } from '@prosekit/extensions/drop-indicator'
+import type { Slice } from '@prosekit/pm/model'
+import { Plugin, PluginKey } from '@prosekit/pm/state'
+import type { EditorView } from '@prosekit/pm/view'
+
+// Every mounted meowdown view on the page. A drag that starts in one of them
+// and lands in another one moves content between two documents; ProseMirror's
+// own move handling only ever covers a single view.
+const mountedViews = new Set<EditorView>()
+
+// Mirrors prosemirror-view's `dragMoves`: once any view prop defines
+// `dragCopies`, it replaces the modifier key instead of adding to it.
+// https://code.haverbeke.berlin/prosemirror/prosemirror-view/src/tag/1.42.2/src/input.ts#L729
+function dragCopies(view: EditorView, event: DragEvent): boolean {
+  let copy: boolean | undefined
+  view.someProp('dragCopies', (test) => {
+    copy = copy || test(event)
+  })
+  if (copy != null) return copy
+  return isApple ? event.altKey : event.ctrlKey
+}
+
+function findDragSource(target: EditorView): EditorView | undefined {
+  for (const view of mountedViews) {
+    if (view !== target && !view.isDestroyed && view.editable && view.dragging) {
+      return view
+    }
+  }
+  return undefined
+}
+
+function deleteDraggedContent(view: EditorView, dragging: ViewDragging): void {
+  const tr = view.state.tr
+  if (dragging.node) {
+    dragging.node.replace(tr)
+  } else {
+    // A text selection drag carries no `node`; the source selection is still
+    // the dragged text.
+    tr.deleteSelection()
+  }
+  if (!tr.docChanged) return
+  view.dispatch(tr.setMeta('uiEvent', 'drop'))
+}
+
+function handleCrossEditorDrop(
+  target: EditorView,
+  event: DragEvent,
+  slice: Slice,
+  move: boolean,
+): boolean {
+  // `move` is true only when the drag started in this same view, where
+  // ProseMirror removes the dragged content itself.
+  if (move || slice.size === 0) return false
+
+  const source = findDragSource(target)
+  if (!source) return false
+  const dragging = source.dragging as ViewDragging | null
+  if (!dragging) return false
+  if (dragCopies(target, event)) return false
+
+  // Claim the drag, so a second drop cannot delete the same block twice.
+  source.dragging = null
+
+  // The insertion happens later in this same drop event, either in the drop
+  // indicator plugin (at the position the indicator line showed) or in
+  // ProseMirror itself. A transaction without steps keeps the same doc object,
+  // so an unchanged reference means nothing landed and the source block stays.
+  const docBeforeDrop = target.state.doc
+  queueMicrotask(() => {
+    if (source.isDestroyed || target.isDestroyed) return
+    if (target.state.doc === docBeforeDrop) return
+    deleteDraggedContent(source, dragging)
+  })
+
+  // Never consume the drop: inserting is still someone else's job.
+  return false
+}
+
+function createCrossEditorDragPlugin(): Plugin {
+  return new Plugin({
+    key: new PluginKey('meowdown-cross-editor-drag'),
+    view: (view) => {
+      mountedViews.add(view)
+      return {
+        destroy: () => {
+          mountedViews.delete(view)
+        },
+      }
+    },
+    props: {
+      handleDrop: handleCrossEditorDrop,
+    },
+  })
+}
+
+/**
+ * Dragging a block from one meowdown editor into another one on the same page
+ * moves it: the block leaves the source document once it lands in the target.
+ * Hold Alt (Ctrl on Windows and Linux) to copy instead.
+ */
+export function defineCrossEditorDrag(): PlainExtension {
+  // High priority so this runs before the drop indicator plugin, which
+  // consumes the drop and would keep any later `handleDrop` from seeing it.
+  return withPriority(definePlugin(createCrossEditorDragPlugin()), Priority.high)
+}

--- a/packages/core/src/extensions/cross-editor-drag.ts
+++ b/packages/core/src/extensions/cross-editor-drag.ts
@@ -23,7 +23,7 @@ function dragCopies(view: EditorView, event: DragEvent): boolean {
 
 function findDragSource(target: EditorView): EditorView | undefined {
   for (const view of mountedViews) {
-    if (view !== target && !view.isDestroyed && view.editable && view.dragging) {
+    if (view !== target && view.editable && view.dragging) {
       return view
     }
   }

--- a/packages/core/src/extensions/cross-editor-drag.ts
+++ b/packages/core/src/extensions/cross-editor-drag.ts
@@ -9,25 +9,12 @@ import type { EditorView } from '@prosekit/pm/view'
 // own move handling only ever covers a single view.
 const mountedViews = new Set<EditorView>()
 
-// Mirrors prosemirror-view's `dragMoves`: once any view prop defines
-// `dragCopies`, it replaces the modifier key instead of adding to it.
-// https://code.haverbeke.berlin/prosemirror/prosemirror-view/src/tag/1.42.2/src/input.ts#L729
-function dragCopies(view: EditorView, event: DragEvent): boolean {
-  let copy: boolean | undefined
-  view.someProp('dragCopies', (test) => {
-    copy = copy || test(event)
-  })
-  if (copy != null) return copy
-  return isApple ? event.altKey : event.ctrlKey
-}
-
 function findDragSource(target: EditorView): EditorView | undefined {
   for (const view of mountedViews) {
-    if (view !== target && view.editable && view.dragging) {
+    if (view !== target && !view.isDestroyed && view.editable && view.dragging) {
       return view
     }
   }
-  return undefined
 }
 
 function deleteDraggedContent(view: EditorView, dragging: ViewDragging): void {
@@ -59,9 +46,12 @@ function handleCrossEditorDrop(
 
   const source = findDragSource(target)
   if (!source) return false
+
   const dragging = source.dragging
   if (!dragging) return false
-  if (dragCopies(target, event)) return false
+
+  const shouldCopy = isApple ? event.altKey : event.ctrlKey
+  if (shouldCopy) return false
 
   // Claim the drag, so a second drop cannot delete the same block twice.
   source.dragging = null

--- a/packages/core/src/extensions/cross-editor-drag.ts
+++ b/packages/core/src/extensions/cross-editor-drag.ts
@@ -33,6 +33,10 @@ function findDragSource(target: EditorView): EditorView | undefined {
 function deleteDraggedContent(view: EditorView, dragging: ViewDragging): void {
   const tr = view.state.tr
   if (dragging.node) {
+    // `dragging.node` holds dragstart-time positions. If the doc changed
+    // during the drag, deleting there would hit the wrong range; keep the
+    // block and let the drop degrade to a copy.
+    if (view.state.doc.nodeAt(dragging.node.from) !== dragging.node.node) return
     dragging.node.replace(tr)
   } else {
     // A text selection drag carries no `node`; the source selection is still

--- a/packages/core/src/extensions/cross-editor-drag.ts
+++ b/packages/core/src/extensions/cross-editor-drag.ts
@@ -55,7 +55,7 @@ function handleCrossEditorDrop(
 
   const source = findDragSource(target)
   if (!source) return false
-  const dragging = source.dragging as ViewDragging | null
+  const dragging = source.dragging
   if (!dragging) return false
   if (dragCopies(target, event)) return false
 

--- a/packages/core/src/extensions/extension.ts
+++ b/packages/core/src/extensions/extension.ts
@@ -17,6 +17,7 @@ import { defineClipboard } from './clipboard/clipboard.ts'
 import { defineCodeBlockSyntaxHighlight } from './code-block-highlight.ts'
 import { defineCodeBlock } from './code-block.ts'
 import { defineEditorCommands } from './commands.ts'
+import { defineCrossEditorDrag } from './cross-editor-drag.ts'
 import { defineEscapeCollapse } from './escape-collapse.ts'
 import { defineDocFrontmatterAttr } from './frontmatter.ts'
 import { defineHeading } from './heading.ts'
@@ -62,6 +63,7 @@ function defineEditorExtensionImpl(options: EditorExtensionOptions) {
     // plugins
     defineViewAttributes({ class: 'meowdown-content' }),
     defineCodeBlockSyntaxHighlight(),
+    defineCrossEditorDrag(),
     defineEscapeCollapse(),
     defineMoveBlock(),
     defineSelectDocBoundary(),

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -23,15 +23,21 @@ export interface SetupFixtureOptions {
   mount?: boolean
   /** Creation-time options for `defineEditorExtension` (e.g. `resolveFileLink`). */
   extensionOptions?: EditorExtensionOptions
+  /** The container's DOM id. Two fixtures need two ids to stay mounted at once. */
+  containerId?: string
 }
 
-export function setupFixture({ mount = true, extensionOptions }: SetupFixtureOptions = {}) {
+export function setupFixture({
+  mount = true,
+  extensionOptions,
+  containerId = 'test-container',
+}: SetupFixtureOptions = {}) {
   const extension = defineEditorExtension(extensionOptions)
   const editor = createTestEditor({ extension })
   const n = editor.nodes
   const m = editor.marks
 
-  const div = getTestContainer()
+  const div = getTestContainer(containerId)
 
   if (mount) {
     editor.mount(div)
@@ -41,6 +47,7 @@ export function setupFixture({ mount = true, extensionOptions }: SetupFixtureOpt
     if (mount) {
       editor.unmount()
     }
+    div.remove()
   }
 
   return {
@@ -90,8 +97,7 @@ export function setupFixture({ mount = true, extensionOptions }: SetupFixtureOpt
 
 export type Fixture = ReturnType<typeof setupFixture>
 
-function getTestContainer(): HTMLDivElement {
-  const id = 'test-container'
+function getTestContainer(id: string): HTMLDivElement {
   const existing = document.getElementById(id)
   if (existing) existing.remove()
   const div = document.createElement('div')

--- a/packages/react/src/components/cross-editor-drag.test.tsx
+++ b/packages/react/src/components/cross-editor-drag.test.tsx
@@ -1,0 +1,57 @@
+import '../testing/index.ts'
+
+import { createRef, type Ref } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { mouse } from 'vitest-browser-commands/playwright'
+import { render } from 'vitest-browser-react'
+import { page } from 'vitest/browser'
+
+import { hover, unhover } from '../testing/mouse.ts'
+
+import { ProseKitEditor } from './prosekit-editor.tsx'
+import type { EditorHandle } from './types.ts'
+
+const yesterday = page.getByTestId('editor-yesterday')
+const today = page.getByTestId('editor-today')
+
+async function renderTwoEditors(refs: { yesterday: Ref<EditorHandle>; today: Ref<EditorHandle> }) {
+  await unhover()
+  return await render(
+    <>
+      <div data-testid="editor-yesterday">
+        <ProseKitEditor ref={refs.yesterday} initialMarkdown={'Alpha\n\nBravo'} />
+      </div>
+      <div data-testid="editor-today">
+        <ProseKitEditor ref={refs.today} initialMarkdown="Charlie" />
+      </div>
+    </>,
+  )
+}
+
+describe('cross editor block drag', () => {
+  it('moves the block into the other editor', async () => {
+    const from = createRef<EditorHandle>()
+    const to = createRef<EditorHandle>()
+    await renderTwoEditors({ yesterday: from, today: to })
+
+    await hover(yesterday.getByText('Alpha'))
+    const start = await hover(yesterday.getByTestId('block-handle-drag'))
+    await mouse.down()
+    // Move a bit to fire dragstart before targeting the drop position.
+    await mouse.move(start.x - 5, start.y - 5)
+
+    // Drop near the top-left corner of "Charlie", i.e. before it.
+    const target = await hover(today.getByText('Charlie'), { position: { x: 5, y: 5 } })
+    // A move that changes the drag target dispatches only dragenter/dragleave;
+    // nudge once more so the target receives the dragover that shows the
+    // drop indicator.
+    await mouse.move(target.x + 1, target.y)
+    await expect.element(today.getByTestId('drop-indicator')).toBeVisible()
+    await mouse.up()
+
+    await vi.waitFor(() => {
+      expect(from.current?.getMarkdown()).toBe('Bravo\n')
+    })
+    expect(to.current?.getMarkdown()).toBe('Alpha\n\nCharlie\n')
+  })
+})

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -7,6 +7,7 @@
     "./clipboard": "./src/clipboard.ts",
     "./config": "./src/config.ts",
     "./custom-string-serializer": "./src/custom-string-serializer.ts",
+    "./drag-events": "./src/drag-events.ts",
     "./file-events": "./src/file-events.ts",
     "./helpers": "./src/helpers.ts",
     "./setup-console": "./src/setup-console.ts",

--- a/packages/vitest/src/drag-events.ts
+++ b/packages/vitest/src/drag-events.ts
@@ -1,0 +1,62 @@
+import { Fragment, Slice } from '@prosekit/pm/model'
+import { NodeSelection, TextSelection } from '@prosekit/pm/state'
+import type { EditorView } from '@prosekit/pm/view'
+
+/**
+ * Serialize `slice` onto a real `DataTransfer` and leave `view.dragging` on the
+ * source view, the way `handlers.dragstart` does. Returns the transfer for
+ * `dropAt`.
+ */
+function startDrag(view: EditorView, slice: Slice, node?: NodeSelection): DataTransfer {
+  const serialized = view.serializeForClipboard(slice)
+
+  const dataTransfer = new DataTransfer()
+  dataTransfer.setData('text/html', serialized.dom.innerHTML)
+  dataTransfer.setData('text/plain', serialized.text)
+  dataTransfer.effectAllowed = 'copyMove'
+
+  // Not annotated: `EditorView['dragging']` omits `node`, and an inline object
+  // literal would trip the excess property check.
+  const dragging = { slice: serialized.slice, move: true, node }
+  view.dragging = dragging
+
+  return dataTransfer
+}
+
+/** Drag the block at `pos`, the way ProseKit's block handle does. */
+export function startBlockDrag(view: EditorView, pos: number): DataTransfer {
+  const node = view.state.doc.nodeAt(pos)
+  if (!node) throw new Error(`[meowdown] no node at position ${pos}`)
+
+  return startDrag(
+    view,
+    new Slice(Fragment.from(node), 0, 0),
+    NodeSelection.create(view.state.doc, pos),
+  )
+}
+
+/** Drag the text between `from` and `to`, which carries no `dragging.node`. */
+export function startTextDrag(view: EditorView, from: number, to: number): DataTransfer {
+  view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, from, to)))
+  return startDrag(view, view.state.selection.content())
+}
+
+/** Dispatch a `drop` carrying `dataTransfer` at the document position `pos`. */
+export function dropAt(
+  view: EditorView,
+  dataTransfer: DataTransfer,
+  pos: number,
+  init: DragEventInit = {},
+): DragEvent {
+  const coords = view.coordsAtPos(pos)
+  const event = new DragEvent('drop', {
+    dataTransfer,
+    clientX: coords.left,
+    clientY: (coords.top + coords.bottom) / 2,
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  })
+  view.dom.dispatchEvent(event)
+  return event
+}


### PR DESCRIPTION
Dragging a block from one meowdown editor into another one on the same page left the block in both documents, because `view.dragging` is per-view state and ProseMirror's move handling only ever deletes from the view the drag started in. A new `defineCrossEditorDrag` extension tracks the mounted views, and once the dropped content lands in the target it removes it from the source; hold Alt (Ctrl on Windows and Linux) to copy instead.