### PR TITLE
docs(website): pin the demo mode via a `mode` URL query

### DIFF
--- a/website/src/use-editor-mode.ts
+++ b/website/src/use-editor-mode.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 
 import type { DemoMode } from './components/demo-editor.tsx'
 
@@ -37,29 +37,40 @@ export const MODES: ModeOption[] = [
 ]
 
 const MODE_STORAGE_KEY = 'meowdown:mode'
+const MODE_QUERY_KEY = 'mode'
 
-function readStoredMode(): DemoMode {
-  const stored = sessionStorage.getItem(MODE_STORAGE_KEY)
-  if (stored) {
-    for (const option of MODES) {
-      if (option.value === stored) {
-        return option.value
-      }
-    }
-  }
-  return 'focus'
+function isDemoMode(value: string | null): value is DemoMode {
+  return MODES.some((option) => option.value === value)
 }
 
-function writeStoredMode(mode: DemoMode): void {
-  sessionStorage.setItem(MODE_STORAGE_KEY, mode)
+// The URL query outranks sessionStorage, so a shared `?mode=` link pins the
+// mode regardless of what the visitor picked before.
+function readInitialMode(): DemoMode {
+  const queryMode = new URLSearchParams(window.location.search).get(MODE_QUERY_KEY)
+  if (queryMode != null) {
+    if (isDemoMode(queryMode)) {
+      return queryMode
+    }
+    console.warn(`[meowdown] Invalid mode in URL query: ${queryMode}`)
+  }
+  const storedMode = sessionStorage.getItem(MODE_STORAGE_KEY)
+  return isDemoMode(storedMode) ? storedMode : 'focus'
+}
+
+function writeModeQuery(mode: DemoMode): void {
+  const url = new URL(window.location.href)
+  url.searchParams.set(MODE_QUERY_KEY, mode)
+  history.replaceState(null, '', url)
 }
 
 export function useEditorMode() {
-  const [mode, setMode] = useState<DemoMode>(readStoredMode)
+  const [mode, setModeState] = useState<DemoMode>(readInitialMode)
 
-  useEffect(() => {
-    writeStoredMode(mode)
-  }, [mode])
+  const setMode = useCallback((nextMode: DemoMode) => {
+    setModeState(nextMode)
+    sessionStorage.setItem(MODE_STORAGE_KEY, nextMode)
+    writeModeQuery(nextMode)
+  }, [])
 
   const activeMode = MODES.find((option) => option.value === mode) ?? MODES[0]
 


### PR DESCRIPTION
Selecting a mode now writes `?mode=` into the URL with `history.replaceState`, and on load the query outranks the sessionStorage memory. This makes a shared link like `/?mode=source` open the demo in that mode.