### PR TITLE
fix(core): keep heading list items tight

### DIFF
--- a/packages/core/src/converters/pm-to-md.test.ts
+++ b/packages/core/src/converters/pm-to-md.test.ts
@@ -92,6 +92,17 @@ describe('docToMarkdown', () => {
     expect(markdown).toBe('- one\n- two\n')
   })
 
+  it('keeps a heading item in a tight bullet list', () => {
+    const doc = n.doc(
+      n.list({ kind: 'bullet' }, n.paragraph('one')),
+      n.list({ kind: 'bullet' }, n.heading({ level: 2 }, 'Section')),
+      n.list({ kind: 'bullet' }, n.paragraph('two')),
+    )
+    const markdown = docToMarkdown(doc)
+    expect(markdown).toBe('- one\n- ## Section\n- two\n')
+    expect(docToMarkdown(markdownToDoc(markdown))).toBe(markdown)
+  })
+
   it('keeps an ordered start number', () => {
     const doc = n.doc(
       n.list({ kind: 'ordered', order: 5 }, n.paragraph('five')),

--- a/packages/core/src/converters/pm-to-md.ts
+++ b/packages/core/src/converters/pm-to-md.ts
@@ -309,7 +309,7 @@ function emitBlockChildren(node: ProseMirrorNode, out: MdOut, tightItem = false)
 
 /**
  * A run of sibling `list` nodes serializes tight iff every item is "simple":
- * at most one leading paragraph, then only nested lists. Any other shape
+ * at most one leading paragraph or heading, then only nested lists. Any other shape
  * (multiple paragraphs, a blockquote, a code block, …) needs blank-line
  * separation inside the item, which per CommonMark makes the whole list
  * loose.
@@ -327,7 +327,12 @@ function isTightItem(item: ProseMirrorNode): boolean {
     const child = item.child(i)
     const typeName = child.type.name
     if (typeName === ('list' satisfies NodeName)) continue
-    if (typeName === ('paragraph' satisfies NodeName) && i === 0) continue
+    if (
+      i === 0 &&
+      (typeName === ('paragraph' satisfies NodeName) || typeName === ('heading' satisfies NodeName))
+    ) {
+      continue
+    }
     return false
   }
   return true


### PR DESCRIPTION
## Summary

- treat a single heading block as a tight list item
- avoid adding blank lines to every sibling when one list item is a heading
- cover compact serialization and markdown round-tripping

## Verification

- pnpm test --run packages/core/src/converters/pm-to-md.test.ts
- pnpm typecheck
- pnpm lint
- pnpm build