### PR TITLE
fix: remove an empty code block with Backspace instead of lifting it out of its list

### DIFF
--- a/packages/core/src/extensions/code-block.test.ts
+++ b/packages/core/src/extensions/code-block.test.ts
@@ -4,6 +4,8 @@ import { page, userEvent } from 'vitest/browser'
 
 import { setupFixture } from '../testing/index.ts'
 
+import { isNodeOfType } from './node-names.ts'
+
 describe('codeBlock attrs', () => {
   it('keeps `fenceStyle` and `fenceLength` through a DOM round-trip', () => {
     using fixture = setupFixture()
@@ -125,5 +127,56 @@ describe('typing over code block selections', () => {
     await vi.waitFor(() => {
       expect(fixture.doc.eq(expected)).toBe(true)
     })
+  })
+})
+
+describe('backspace in an empty code block', () => {
+  it('removes an empty top-level code block', async () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('before'), n.codeBlock({ language: '' }, '<a>')))
+    fixture.view.focus()
+    await userEvent.keyboard('{Backspace}')
+    const expected = n.doc(n.paragraph('before'), n.paragraph())
+    expect(fixture.doc.eq(expected)).toBe(true)
+  })
+
+  it('removes an empty code block inside a list item instead of lifting it', async () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(
+      n.doc(
+        n.list({ kind: 'bullet' }, n.paragraph('item'), n.codeBlock({ language: '' }, '<a>')),
+        n.list({ kind: 'bullet' }, n.paragraph('next')),
+      ),
+    )
+    fixture.view.focus()
+    await userEvent.keyboard('{Backspace}')
+    const expected = n.doc(
+      n.list({ kind: 'bullet' }, n.paragraph('item'), n.paragraph()),
+      n.list({ kind: 'bullet' }, n.paragraph('next')),
+    )
+    expect(fixture.doc.eq(expected)).toBe(true)
+  })
+
+  it('leaves a non-empty code block alone at its start', async () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(
+      n.doc(
+        n.list({ kind: 'bullet' }, n.paragraph('item'), n.codeBlock({ language: '' }, '<a>ab')),
+      ),
+    )
+    fixture.view.focus()
+    await userEvent.keyboard('{Backspace}')
+    // The block survives as a code block; the key falls through to the
+    // existing chain (the list lift), which must not be affected.
+    let codeBlocks = 0
+    fixture.doc.descendants((node) => {
+      if (isNodeOfType(node, 'codeBlock')) codeBlocks += 1
+      return true
+    })
+    expect(codeBlocks).toBe(1)
+    expect(fixture.doc.textContent).toContain('ab')
   })
 })

--- a/packages/core/src/extensions/code-block.ts
+++ b/packages/core/src/extensions/code-block.ts
@@ -1,14 +1,25 @@
-import { defineNodeAttr, union, type Extension, type PlainExtension } from '@prosekit/core'
+import {
+  defineKeymap,
+  defineNodeAttr,
+  isAtBlockStart,
+  Priority,
+  union,
+  unsetBlockType,
+  withPriority,
+  type Extension,
+  type PlainExtension,
+} from '@prosekit/core'
 import {
   defineCodeBlock as defineBaseCodeBlock,
   type CodeBlockAttrs,
 } from '@prosekit/extensions/code-block'
 import { defineTextBlockEnterRule } from '@prosekit/extensions/enter-rule'
 import { defineTextBlockInputRule } from '@prosekit/extensions/input-rule'
+import type { Command } from '@prosekit/pm/state'
 
 import { parseInteger } from '../utils/parse-integer.ts'
 
-import type { NodeName } from './node-names.ts'
+import { isNodeOfType, type NodeName } from './node-names.ts'
 
 export type CodeBlockFenceStyle = 'tilde' | 'indented' | 'dollar'
 
@@ -95,6 +106,23 @@ function defineDollarFenceEnterRule(): PlainExtension {
   })
 }
 
+// Backspace in an empty code block removes the block, like Backspace at the
+// start of a heading. Registered above the list keymap: its `joinListUp`
+// would otherwise consume the key to lift the block out of its list item — a
+// visually undetectable change that costs an extra keypress to delete the
+// block and rebuilds the node view for nothing.
+const backspaceUnsetEmptyCodeBlock: Command = (state, dispatch, view) => {
+  const $pos = isAtBlockStart(state, view)
+  if ($pos == null) return false
+  if (!isNodeOfType($pos.parent, 'codeBlock')) return false
+  if ($pos.parent.content.size > 0) return false
+  return unsetBlockType()(state, dispatch, view)
+}
+
+function defineCodeBlockKeymap(): PlainExtension {
+  return withPriority(defineKeymap({ Backspace: backspaceUnsetEmptyCodeBlock }), Priority.high)
+}
+
 export function defineCodeBlock() {
   return union(
     defineBaseCodeBlock(),
@@ -103,5 +131,6 @@ export function defineCodeBlock() {
     defineTildeFenceInputRule(),
     defineTildeFenceEnterRule(),
     defineDollarFenceEnterRule(),
+    defineCodeBlockKeymap(),
   )
 }


### PR DESCRIPTION
## Problem

Type some text in a code block that lives inside a list item (in DayJot every daily-note block does, via the default bullet), delete all of it, then press Backspace once more. Expected: the empty code block is removed. Actual: nothing visible happens, and only a second press removes the block.

The first press is consumed by the list keymap's `joinListUp`, which lifts the code block out of its list item — a change with no visual feedback (only the serialized indentation changes):

```
- item              - item

  ```        →      ```
  ```                ```
```

Worse, the lift destroys and recreates the code block's node view for nothing. In a real WKWebView (DayJot desktop) that rebuild races the DOM observer against React's asynchronous node-view teardown, and the last deleted character can get read back out of the stale DOM and resurrected inside the block — the user sees a stray character (e.g. `d`) appear in the code block instead of the block being deleted.

## Fix

Handle Backspace in the code block extension, registered above the list keymap: when the caret sits in an **empty** code block, unset it back to a paragraph — mirroring how Backspace at the start of a heading unsets it (`backspaceUnsetHeading`). A non-empty code block declines the key, so the existing chain (list lift, join) is untouched.

This makes the empty-block deletion a single, visible step in every context, and removes the pointless node-view rebuild that triggered the WebKit resurrection race.

## Tests

- `removes an empty top-level code block`
- `removes an empty code block inside a list item instead of lifting it`
- `leaves a non-empty code block alone at its start`

All of `code-block.test.ts` passes on chromium, webkit, and firefox; `list.test.ts`, `heading.test.ts`, `hidden-run-caret.test.ts`, and the react `code-block-view` suites pass; `pnpm typecheck` and `pnpm lint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)