### PR TITLE
feat: persist tweet embed height to avoid layout shift

### DIFF
--- a/packages/core/src/extensions/atom-mark-navigation.test.ts
+++ b/packages/core/src/extensions/atom-mark-navigation.test.ts
@@ -26,7 +26,9 @@ function getSVGImageURL(width: number, height: number): string {
 function setup(mode: MarkMode, paragraphs: string[]): Fixture {
   const fixture = setupFixture({ extensionOptions: { markMode: mode } })
   const { editor, n } = fixture
-  editor.use(defineImage({ resolveImageUrl: () => getSVGImageURL(24, 24) }))
+  editor.use(
+    defineImage({ resolveImageUrl: () => getSVGImageURL(24, 24), persistTweetHeight: false }),
+  )
   fixture.set(n.doc(...paragraphs.map((text) => n.paragraph(text))))
   fixture.view.focus()
   return fixture

--- a/packages/core/src/extensions/embed-paste.test.ts
+++ b/packages/core/src/extensions/embed-paste.test.ts
@@ -17,7 +17,7 @@ const EMBED = `![](${YT})`
 
 function useEmbedPaste(fixture: Fixture): void {
   const { editor } = fixture
-  editor.use(defineImage({ resolveImageUrl: (src) => src }))
+  editor.use(defineImage({ resolveImageUrl: (src) => src, persistTweetHeight: false }))
   editor.use(defineEmbedPaste())
 }
 

--- a/packages/core/src/extensions/image.ts
+++ b/packages/core/src/extensions/image.ts
@@ -69,7 +69,7 @@ function applyTweetHeight(iframe: HTMLIFrameElement, height: number | null): voi
 function buildEmbedIframe(
   embed: EmbedDescriptor,
   height: number | null,
-  onHeight: ((height: number) => void) | undefined,
+  onHeight: (height: number) => void,
 ): HTMLIFrameElement {
   const iframe = document.createElement('iframe')
   iframe.src = embed.src
@@ -209,8 +209,9 @@ function commitTweetHeight(view: EditorView, content: HTMLElement, height: numbe
 class ImageMarkView implements MarkView {
   readonly #dom: HTMLElement
   readonly #contentDOM: HTMLElement
-  readonly #options: ImageOptions
   readonly #view: EditorView
+  readonly #resolveImageUrl: ImageUrlResolver | undefined
+  readonly #persistTweetHeight: boolean
   #attrs: MdImageAttrs
   #resizableRoot: HTMLElement | undefined
   #image: HTMLImageElement | undefined
@@ -218,8 +219,9 @@ class ImageMarkView implements MarkView {
 
   constructor(mark: Mark, view: EditorView, options: ImageOptions) {
     this.#attrs = mark.attrs as MdImageAttrs
-    this.#options = options
     this.#view = view
+    this.#resolveImageUrl = options.resolveImageUrl
+    this.#persistTweetHeight = options.persistTweetHeight ?? true
 
     this.#dom = document.createElement('span')
     this.#dom.className = 'md-image-view md-atom-view'
@@ -277,17 +279,19 @@ class ImageMarkView implements MarkView {
     if (embed) {
       const wrapper = document.createElement('span')
       wrapper.className = 'md-image-view-preview md-atom-view-preview'
-      const onHeight =
-        (this.#options.persistTweetHeight ?? true)
-          ? (height: number) => commitTweetHeight(this.#view, this.#contentDOM, height)
-          : undefined
+      const onHeight = (height: number) => {
+        applyTweetHeight(iframe, height)
+        if (this.#persistTweetHeight) {
+          commitTweetHeight(this.#view, this.#contentDOM, height)
+        }
+      }
       const iframe = buildEmbedIframe(embed, this.#attrs.height, onHeight)
       if (embed.kind === 'tweet') this.#tweetIframe = iframe
       wrapper.appendChild(embed.kind === 'youtube' ? this.#buildResizableEmbed(iframe) : iframe)
       return wrapper
     }
 
-    const url = (this.#options.resolveImageUrl ?? defaultResolveImageUrl)(src)
+    const url = (this.#resolveImageUrl ?? defaultResolveImageUrl)(src)
     if (!url) return undefined
 
     const wrapper = document.createElement('span')

--- a/packages/core/src/extensions/image.ts
+++ b/packages/core/src/extensions/image.ts
@@ -28,6 +28,13 @@ export interface ImageOptions {
    * that image. Defaults to `defaultResolveImageUrl`.
    */
   resolveImageUrl?: ImageUrlResolver
+  /**
+   * Whether to write the height a tweet embed reports back into the trailing
+   * size comment, so the next load can seed the iframe at its final height.
+   * Defaults to `true`; disable when the document must never change without a
+   * user edit (e.g. deterministic tests).
+   */
+  persistTweetHeight?: boolean
 }
 
 /** Show an `src` as-is when it is an http(s) URL, otherwise skip rendering it. */
@@ -62,7 +69,7 @@ function applyTweetHeight(iframe: HTMLIFrameElement, height: number | null): voi
 function buildEmbedIframe(
   embed: EmbedDescriptor,
   height: number | null,
-  onHeight: (height: number) => void,
+  onHeight: ((height: number) => void) | undefined,
 ): HTMLIFrameElement {
   const iframe = document.createElement('iframe')
   iframe.src = embed.src
@@ -270,9 +277,11 @@ class ImageMarkView implements MarkView {
     if (embed) {
       const wrapper = document.createElement('span')
       wrapper.className = 'md-image-view-preview md-atom-view-preview'
-      const iframe = buildEmbedIframe(embed, this.#attrs.height, (height) =>
-        commitTweetHeight(this.#view, this.#contentDOM, height),
-      )
+      const onHeight =
+        (this.#options.persistTweetHeight ?? true)
+          ? (height: number) => commitTweetHeight(this.#view, this.#contentDOM, height)
+          : undefined
+      const iframe = buildEmbedIframe(embed, this.#attrs.height, onHeight)
       if (embed.kind === 'tweet') this.#tweetIframe = iframe
       wrapper.appendChild(embed.kind === 'youtube' ? this.#buildResizableEmbed(iframe) : iframe)
       return wrapper

--- a/packages/core/src/extensions/image.ts
+++ b/packages/core/src/extensions/image.ts
@@ -10,7 +10,12 @@ import {
 import { listenForTweetHeight, matchEmbed, type EmbedDescriptor } from './embed.ts'
 import { getMarkRangeAt } from './get-mark-range-at.ts'
 import type { MdImageAttrs } from './inline-marks.ts'
-import { formatMagicComment, parseMagicComment, stripMagicComment } from './magic-comment.ts'
+import {
+  formatMagicComment,
+  parseMagicComment,
+  stripMagicComment,
+  type MagicComment,
+} from './magic-comment.ts'
 import type { MarkName } from './mark-names.ts'
 import { formatSizedWikiEmbed, parseWikiEmbed } from './wiki-embed.ts'
 
@@ -54,7 +59,11 @@ function applyTweetHeight(iframe: HTMLIFrameElement, height: number | null): voi
  * A persisted tweet height seeds the iframe before `Tweet.html` reports the
  * real one, so a revisited tweet keeps its space instead of shifting layout.
  */
-function buildEmbedIframe(embed: EmbedDescriptor, height: number | null): HTMLIFrameElement {
+function buildEmbedIframe(
+  embed: EmbedDescriptor,
+  height: number | null,
+  onHeight: (height: number) => void,
+): HTMLIFrameElement {
   const iframe = document.createElement('iframe')
   iframe.src = embed.src
   iframe.title = embed.title
@@ -67,7 +76,7 @@ function buildEmbedIframe(embed: EmbedDescriptor, height: number | null): HTMLIF
   if (embed.allowFullscreen) iframe.allowFullscreen = true
   if (embed.kind === 'tweet') {
     if (height != null) applyTweetHeight(iframe, height)
-    listenForTweetHeight(iframe)
+    listenForTweetHeight(iframe, onHeight)
   }
   return iframe
 }
@@ -108,29 +117,18 @@ function applyImageDisplaySize(
 }
 
 /**
- * Persist a resized width and height by rewriting only the trailing magic
- * comment, leaving the `![alt](url)` source untouched. The inline-mark plugin
- * re-derives the `width`/`height` attributes from the new text.
+ * Rewrite only the trailing magic comment of the image source at `range`,
+ * merging `patch` into the existing metadata and leaving the `![alt](url)`
+ * source untouched. The inline-mark plugin re-derives the `width`/`height`
+ * attributes from the new text.
  */
-function commitImageSize(
+function rewriteMagicComment(
   view: EditorView,
-  content: HTMLElement,
-  rawWidth: number,
-  rawHeight: number,
+  range: { from: number; to: number },
+  patch: MagicComment,
+  addToHistory: boolean,
 ): void {
-  const pos = view.posAtDOM(content, 0)
-  const range = getMarkRangeAt(view.state, pos, 'mdImage')
-  if (!range) return
   const current = view.state.doc.textBetween(range.from, range.to)
-  const attrs = range.mark.attrs as MdImageAttrs
-
-  if (attrs.syntax === 'wikiEmbed') {
-    const target = attrs.wikiTarget || parseWikiEmbed(current).target
-    if (!target) return
-    const next = formatSizedWikiEmbed(target, rawWidth, rawHeight)
-    if (next !== current) view.dispatch(view.state.tr.insertText(next, range.from, range.to))
-    return
-  }
 
   // Split the range into the `![alt](url)` source and its optional comment;
   // positions in a textblock are 1:1 with characters, so `from + base.length` is
@@ -141,12 +139,64 @@ function commitImageSize(
 
   const nextComment = formatMagicComment({
     ...parseMagicComment(currentComment),
-    width: Math.round(rawWidth),
-    height: Math.round(rawHeight),
+    ...patch,
   })
   if (nextComment === currentComment) return
 
-  view.dispatch(view.state.tr.insertText(nextComment, commentFrom, range.to))
+  const transaction = view.state.tr.insertText(nextComment, commentFrom, range.to)
+  if (!addToHistory) transaction.setMeta('addToHistory', false)
+  view.dispatch(transaction)
+}
+
+/** Persist a resized width and height into the trailing magic comment. */
+function commitImageSize(
+  view: EditorView,
+  content: HTMLElement,
+  rawWidth: number,
+  rawHeight: number,
+): void {
+  const pos = view.posAtDOM(content, 0)
+  const range = getMarkRangeAt(view.state, pos, 'mdImage')
+  if (!range) return
+  const attrs = range.mark.attrs as MdImageAttrs
+
+  if (attrs.syntax === 'wikiEmbed') {
+    const current = view.state.doc.textBetween(range.from, range.to)
+    const target = attrs.wikiTarget || parseWikiEmbed(current).target
+    if (!target) return
+    const next = formatSizedWikiEmbed(target, rawWidth, rawHeight)
+    if (next !== current) view.dispatch(view.state.tr.insertText(next, range.from, range.to))
+    return
+  }
+
+  rewriteMagicComment(
+    view,
+    range,
+    { width: Math.round(rawWidth), height: Math.round(rawHeight) },
+    true,
+  )
+}
+
+/**
+ * Ignore reported tweet heights this close to the persisted one. Fonts, theme,
+ * and container width nudge the rendered height by a few pixels per device;
+ * writing those back would churn the document on every open.
+ */
+const TWEET_HEIGHT_TOLERANCE = 8
+
+/**
+ * Persist the height a tweet embed reported, so the next load can seed the
+ * iframe before the tweet renders. A passive metadata write: outside undo
+ * history, skipped in read-only views, and skipped inside the tolerance.
+ */
+function commitTweetHeight(view: EditorView, content: HTMLElement, height: number): void {
+  if (!view.editable || !content.isConnected) return
+  const pos = view.posAtDOM(content, 0)
+  const range = getMarkRangeAt(view.state, pos, 'mdImage')
+  if (!range) return
+  const attrs = range.mark.attrs as MdImageAttrs
+  if (attrs.height != null && Math.abs(height - attrs.height) <= TWEET_HEIGHT_TOLERANCE) return
+  rewriteMagicComment(view, range, { height: Math.round(height) }, false)
 }
 
 class ImageMarkView implements MarkView {
@@ -220,7 +270,9 @@ class ImageMarkView implements MarkView {
     if (embed) {
       const wrapper = document.createElement('span')
       wrapper.className = 'md-image-view-preview md-atom-view-preview'
-      const iframe = buildEmbedIframe(embed, this.#attrs.height)
+      const iframe = buildEmbedIframe(embed, this.#attrs.height, (height) =>
+        commitTweetHeight(this.#view, this.#contentDOM, height),
+      )
       if (embed.kind === 'tweet') this.#tweetIframe = iframe
       wrapper.appendChild(embed.kind === 'youtube' ? this.#buildResizableEmbed(iframe) : iframe)
       return wrapper

--- a/packages/core/src/extensions/image.ts
+++ b/packages/core/src/extensions/image.ts
@@ -35,8 +35,26 @@ export function defaultResolveImageUrl(src: string): string | undefined {
  */
 const MAX_DISPLAY_HEIGHT = 500
 
-/** Build the iframe DOM for an embed descriptor and start its height listener. */
-function buildEmbedIframe(embed: EmbedDescriptor): HTMLIFrameElement {
+/**
+ * Size a tweet iframe: the persisted or reported height, or neither yet
+ * (`null`), which restores the unknown-height placeholder.
+ */
+function applyTweetHeight(iframe: HTMLIFrameElement, height: number | null): void {
+  if (height == null) {
+    iframe.style.removeProperty('height')
+    delete iframe.dataset.sized
+    return
+  }
+  iframe.style.height = `${height}px`
+  iframe.dataset.sized = ''
+}
+
+/**
+ * Build the iframe DOM for an embed descriptor and start its height listener.
+ * A persisted tweet height seeds the iframe before `Tweet.html` reports the
+ * real one, so a revisited tweet keeps its space instead of shifting layout.
+ */
+function buildEmbedIframe(embed: EmbedDescriptor, height: number | null): HTMLIFrameElement {
   const iframe = document.createElement('iframe')
   iframe.src = embed.src
   iframe.title = embed.title
@@ -47,7 +65,10 @@ function buildEmbedIframe(embed: EmbedDescriptor): HTMLIFrameElement {
   iframe.setAttribute('frameborder', '0')
   if (embed.allow) iframe.allow = embed.allow
   if (embed.allowFullscreen) iframe.allowFullscreen = true
-  if (embed.kind === 'tweet') listenForTweetHeight(iframe)
+  if (embed.kind === 'tweet') {
+    if (height != null) applyTweetHeight(iframe, height)
+    listenForTweetHeight(iframe)
+  }
   return iframe
 }
 
@@ -136,6 +157,7 @@ class ImageMarkView implements MarkView {
   #attrs: MdImageAttrs
   #resizableRoot: HTMLElement | undefined
   #image: HTMLImageElement | undefined
+  #tweetIframe: HTMLIFrameElement | undefined
 
   constructor(mark: Mark, view: EditorView, options: ImageOptions) {
     this.#attrs = mark.attrs as MdImageAttrs
@@ -181,6 +203,9 @@ class ImageMarkView implements MarkView {
         applySize(this.#resizableRoot, next.width, next.height)
       }
     }
+    if (this.#tweetIframe && next.height !== previous.height) {
+      applyTweetHeight(this.#tweetIframe, next.height)
+    }
     return true
   }
 
@@ -195,7 +220,8 @@ class ImageMarkView implements MarkView {
     if (embed) {
       const wrapper = document.createElement('span')
       wrapper.className = 'md-image-view-preview md-atom-view-preview'
-      const iframe = buildEmbedIframe(embed)
+      const iframe = buildEmbedIframe(embed, this.#attrs.height)
+      if (embed.kind === 'tweet') this.#tweetIframe = iframe
       wrapper.appendChild(embed.kind === 'youtube' ? this.#buildResizableEmbed(iframe) : iframe)
       return wrapper
     }

--- a/packages/core/src/extensions/image.ts
+++ b/packages/core/src/extensions/image.ts
@@ -17,6 +17,7 @@ import {
   type MagicComment,
 } from './magic-comment.ts'
 import type { MarkName } from './mark-names.ts'
+import { applyTweetHeight } from './tweet.ts'
 import { formatSizedWikiEmbed, parseWikiEmbed } from './wiki-embed.ts'
 
 type ImageUrlResolver = (src: string) => string | undefined
@@ -48,20 +49,6 @@ export function defaultResolveImageUrl(src: string): string | undefined {
 const MAX_DISPLAY_HEIGHT = 500
 
 /**
- * Size a tweet iframe: the persisted or reported height, or neither yet
- * (`null`), which restores the unknown-height placeholder.
- */
-function applyTweetHeight(iframe: HTMLIFrameElement, height: number | null): void {
-  if (height == null) {
-    iframe.style.removeProperty('height')
-    delete iframe.dataset.sized
-    return
-  }
-  iframe.style.height = `${height}px`
-  iframe.dataset.sized = ''
-}
-
-/**
  * Build the iframe DOM for an embed descriptor and start its height listener.
  * A persisted tweet height seeds the iframe before `Tweet.html` reports the
  * real one, so a revisited tweet keeps its space instead of shifting layout.
@@ -69,7 +56,7 @@ function applyTweetHeight(iframe: HTMLIFrameElement, height: number | null): voi
 function buildEmbedIframe(
   embed: EmbedDescriptor,
   height: number | null,
-  onHeight: (height: number) => void,
+  onHeight?: (height: number) => void,
 ): HTMLIFrameElement {
   const iframe = document.createElement('iframe')
   iframe.src = embed.src
@@ -82,7 +69,7 @@ function buildEmbedIframe(
   if (embed.allow) iframe.allow = embed.allow
   if (embed.allowFullscreen) iframe.allowFullscreen = true
   if (embed.kind === 'tweet') {
-    if (height != null) applyTweetHeight(iframe, height)
+    applyTweetHeight(iframe, height)
     listenForTweetHeight(iframe, onHeight)
   }
   return iframe
@@ -279,12 +266,11 @@ class ImageMarkView implements MarkView {
     if (embed) {
       const wrapper = document.createElement('span')
       wrapper.className = 'md-image-view-preview md-atom-view-preview'
-      const onHeight = (height: number) => {
-        applyTweetHeight(iframe, height)
-        if (this.#persistTweetHeight) {
-          commitTweetHeight(this.#view, this.#contentDOM, height)
-        }
-      }
+      const onHeight = this.#persistTweetHeight
+        ? (height: number) => {
+            commitTweetHeight(this.#view, this.#contentDOM, height)
+          }
+        : undefined
       const iframe = buildEmbedIframe(embed, this.#attrs.height, onHeight)
       if (embed.kind === 'tweet') this.#tweetIframe = iframe
       wrapper.appendChild(embed.kind === 'youtube' ? this.#buildResizableEmbed(iframe) : iframe)

--- a/packages/core/src/extensions/magic-comment.ts
+++ b/packages/core/src/extensions/magic-comment.ts
@@ -19,32 +19,29 @@ const TRAILING_MAGIC_COMMENT_RE = /<!--\s*\{[^}]*\}\s*-->$/
  */
 export function parseMagicComment(comment: string): MagicComment | undefined {
   const match = MAGIC_COMMENT_RE.exec(comment.trim())
-  if (!match) return undefined
+  if (!match) return
+
   let data: unknown
   try {
     data = JSON.parse(match[1])
   } catch {
     return
   }
-  if (!isObject(data)) {
-    return
-  }
-  const magic = readMagicComment(data)
+  if (!isObject(data)) return
+
+  const width = toPositiveNumber(data.width)
+  const height = toPositiveNumber(data.height)
+
   // Not a magic comment unless it carries at least one recognized field.
-  return Object.keys(magic).length > 0 ? magic : undefined
+  if (!width && !height) return
+
+  return { width, height }
 }
 
-// Pick + validate the known fields. The single place new metadata fields are added.
-function readMagicComment(data: Record<string, unknown>): MagicComment {
-  const magic: MagicComment = {}
-  const { width, height } = data
-  if (typeof width === 'number' && Number.isFinite(width) && width > 0) {
-    magic.width = Math.round(width)
+function toPositiveNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return Math.round(value)
   }
-  if (typeof height === 'number' && Number.isFinite(height) && height > 0) {
-    magic.height = Math.round(height)
-  }
-  return magic
 }
 
 /** The canonical comment meowdown writes for the metadata. */

--- a/packages/core/src/extensions/tweet.ts
+++ b/packages/core/src/extensions/tweet.ts
@@ -40,7 +40,7 @@ export const matchTweet: EmbedMatcher = (src) => {
  */
 export function listenForTweetHeight(
   iframe: HTMLIFrameElement,
-  onHeight?: (height: number) => void,
+  onHeight: (height: number) => void,
 ): () => void {
   const onMessage = (event: MessageEvent) => {
     if (event.source !== iframe.contentWindow) return
@@ -56,10 +56,7 @@ export function listenForTweetHeight(
       // `Tweet.html` posts a transient `0` before it renders (and nothing else
       // when the tweet is unavailable); only a positive height is a real size.
       if (typeof height === 'number' && height > 0) {
-        iframe.style.height = `${height}px`
-        // `data-sized` releases the unknown-height placeholder (`min-height`).
-        iframe.dataset.sized = ''
-        onHeight?.(height)
+        onHeight(height)
       }
     } catch (error) {
       console.warn('[meowdown] failed to parse tweet resize message:', error)

--- a/packages/core/src/extensions/tweet.ts
+++ b/packages/core/src/extensions/tweet.ts
@@ -33,11 +33,15 @@ export const matchTweet: EmbedMatcher = (src) => {
 
 /**
  * `Tweet.html` reports its rendered height via `postMessage`; size the iframe to
- * fit. Returns a cleanup that removes the listener. The cleanup also runs once
- * the iframe leaves the DOM, so the editor's DOM mark view (which has no destroy
- * hook) is covered, while a React caller can call it on unmount.
+ * fit and pass each reported height to `onHeight`. Returns a cleanup that
+ * removes the listener. The cleanup also runs once the iframe leaves the DOM, so
+ * the editor's DOM mark view (which has no destroy hook) is covered, while a
+ * React caller can call it on unmount.
  */
-export function listenForTweetHeight(iframe: HTMLIFrameElement): () => void {
+export function listenForTweetHeight(
+  iframe: HTMLIFrameElement,
+  onHeight?: (height: number) => void,
+): () => void {
   const onMessage = (event: MessageEvent) => {
     if (event.source !== iframe.contentWindow) return
     try {
@@ -53,6 +57,7 @@ export function listenForTweetHeight(iframe: HTMLIFrameElement): () => void {
         iframe.style.height = `${height}px`
         // `data-sized` releases the unknown-height placeholder (`min-height`).
         iframe.dataset.sized = ''
+        onHeight?.(height)
       }
     } catch (error) {
       console.warn('[meowdown] failed to parse tweet resize message:', error)

--- a/packages/core/src/extensions/tweet.ts
+++ b/packages/core/src/extensions/tweet.ts
@@ -53,7 +53,9 @@ export function listenForTweetHeight(
       }
       const message = event.data as TweetResizeMessage | null
       const height = message?.['twttr.embed']?.params?.[0]?.height
-      if (typeof height === 'number') {
+      // `Tweet.html` posts a transient `0` before it renders (and nothing else
+      // when the tweet is unavailable); only a positive height is a real size.
+      if (typeof height === 'number' && height > 0) {
         iframe.style.height = `${height}px`
         // `data-sized` releases the unknown-height placeholder (`min-height`).
         iframe.dataset.sized = ''

--- a/packages/core/src/extensions/tweet.ts
+++ b/packages/core/src/extensions/tweet.ts
@@ -49,7 +49,11 @@ export function listenForTweetHeight(iframe: HTMLIFrameElement): () => void {
       }
       const message = event.data as TweetResizeMessage | null
       const height = message?.['twttr.embed']?.params?.[0]?.height
-      if (typeof height === 'number') iframe.style.height = `${height}px`
+      if (typeof height === 'number') {
+        iframe.style.height = `${height}px`
+        // `data-sized` releases the unknown-height placeholder (`min-height`).
+        iframe.dataset.sized = ''
+      }
     } catch (error) {
       console.warn('[meowdown] failed to parse tweet resize message:', error)
     }

--- a/packages/core/src/extensions/tweet.ts
+++ b/packages/core/src/extensions/tweet.ts
@@ -40,7 +40,7 @@ export const matchTweet: EmbedMatcher = (src) => {
  */
 export function listenForTweetHeight(
   iframe: HTMLIFrameElement,
-  onHeight: (height: number) => void,
+  onHeight?: (height: number) => void,
 ): () => void {
   const onMessage = (event: MessageEvent) => {
     if (event.source !== iframe.contentWindow) return
@@ -56,7 +56,8 @@ export function listenForTweetHeight(
       // `Tweet.html` posts a transient `0` before it renders (and nothing else
       // when the tweet is unavailable); only a positive height is a real size.
       if (typeof height === 'number' && height > 0) {
-        onHeight(height)
+        applyTweetHeight(iframe, height)
+        onHeight?.(height)
       }
     } catch (error) {
       console.warn('[meowdown] failed to parse tweet resize message:', error)
@@ -76,4 +77,14 @@ export function listenForTweetHeight(
   })
   observer.observe(document.body, { childList: true, subtree: true })
   return cleanup
+}
+
+/**
+ * Size a tweet iframe.
+ */
+export function applyTweetHeight(iframe: HTMLIFrameElement, height: number | null): void {
+  if (height && height > 0) {
+    iframe.style.height = `${height}px`
+    iframe.dataset.sized = ''
+  }
 }

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -669,6 +669,13 @@
     border: 0;
   }
 
+  /* Reserve space for a tweet whose height is unknown (no persisted size and no
+   * height report yet), so the loaded tweet shifts layout less. Released once a
+   * height is applied (`data-sized`). */
+  .ProseMirror .md-embed-tweet:not([data-sized]) {
+    min-height: 250px;
+  }
+
   /* A YouTube embed wrapped in the resizable root: the root owns the size (its
    * inline `aspect-ratio` derives the height from the persisted or dragged
    * width; block-level `width: auto` keeps the default width when nothing is

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -215,8 +215,12 @@ function WikilinkChip(props: {
   )
 }
 
-function EmbedFrame(props: { embed: EmbedDescriptor; width: number | null }): ReactElement {
-  const { embed, width } = props
+function EmbedFrame(props: {
+  embed: EmbedDescriptor
+  width: number | null
+  height: number | null
+}): ReactElement {
+  const { embed, width, height } = props
   const iframeRef = useRef<HTMLIFrameElement>(null)
   useEffect(() => {
     if (embed.kind !== 'tweet') return
@@ -225,8 +229,10 @@ function EmbedFrame(props: { embed: EmbedDescriptor; width: number | null }): Re
     return listenForTweetHeight(iframe)
   }, [embed.kind, embed.key])
   // A persisted width narrows the player; the `aspect-ratio` CSS on
-  // `.md-embed-youtube` derives the height. Tweets stay fluid-width.
+  // `.md-embed-youtube` derives the height. Tweets stay fluid-width and seed
+  // their persisted height instead.
   const youtubeWidth = embed.kind === 'youtube' ? width : null
+  const tweetHeight = embed.kind === 'tweet' ? height : null
   return (
     <span className="md-image-view-preview md-atom-view-preview" contentEditable={false}>
       <iframe
@@ -241,7 +247,14 @@ function EmbedFrame(props: { embed: EmbedDescriptor; width: number | null }): Re
         frameBorder="0"
         allow={embed.allow}
         allowFullScreen={embed.allowFullscreen}
-        style={youtubeWidth == null ? undefined : { width: youtubeWidth }}
+        style={
+          youtubeWidth != null
+            ? { width: youtubeWidth }
+            : tweetHeight != null
+              ? { height: tweetHeight }
+              : undefined
+        }
+        data-sized={tweetHeight == null ? undefined : ''}
       />
     </span>
   )
@@ -251,13 +264,14 @@ function ImagePreview(props: {
   src: string
   alt: string
   width: number | null
+  height: number | null
   resolveImageUrl?: (src: string) => string | undefined
   onImageClick?: ImageClickHandler
   interactive: boolean
 }): ReactElement | null {
-  const { src, alt, width, resolveImageUrl, onImageClick, interactive } = props
+  const { src, alt, width, height, resolveImageUrl, onImageClick, interactive } = props
   const embed = matchEmbed(src)
-  if (embed) return interactive ? <EmbedFrame embed={embed} width={width} /> : null
+  if (embed) return interactive ? <EmbedFrame embed={embed} width={width} height={height} /> : null
 
   const url = (resolveImageUrl ?? defaultResolveImageUrl)(src)
   if (!url) return null
@@ -285,16 +299,18 @@ function ImageView(props: {
   src: string
   alt: string
   width: number | null
+  height: number | null
   context: RenderContext
   children: ReactNode
 }): ReactElement {
-  const { src, alt, width, context, children } = props
+  const { src, alt, width, height, context, children } = props
   return (
     <span className="md-image-view md-atom-view">
       <ImagePreview
         src={src}
         alt={alt}
         width={width}
+        height={height}
         resolveImageUrl={context.resolveImageUrl}
         onImageClick={context.onImageClick}
         interactive={context.interactive}
@@ -493,7 +509,13 @@ function wrapMark(mark: Mark, children: ReactNode, context: RenderContext): Reac
     case 'mdImage': {
       const attrs = mark.attrs as MdImageAttrs
       return (
-        <ImageView src={attrs.src} alt={attrs.alt} width={attrs.width} context={context}>
+        <ImageView
+          src={attrs.src}
+          alt={attrs.alt}
+          width={attrs.width}
+          height={attrs.height}
+          context={context}
+        >
           {children}
         </ImageView>
       )


### PR DESCRIPTION
Seed a tweet embed iframe from the trailing `<!-- {"height":N} -->` size comment and write the height `Tweet.html` reports back into that comment, so a revisited tweet keeps its space instead of jumping from the 150px default. Tweets with no known height get a `min-height` placeholder until the first report.