### PR TITLE
feat: resizable YouTube embed with persisted size

### DIFF
--- a/packages/core/src/extensions/image.ts
+++ b/packages/core/src/extensions/image.ts
@@ -52,15 +52,11 @@ function buildEmbedIframe(embed: EmbedDescriptor): HTMLIFrameElement {
 }
 
 /**
- * Write a persisted display size onto a resizable embed root. The root's fixed
- * `data-aspect-ratio` derives the height whenever a width is present, so
- * missing dimensions simply fall back to the CSS default (full width).
+ * Write a persisted display size onto a resizable resizable root.
  */
-function applyEmbedSize(root: HTMLElement, width: number | null, height: number | null): void {
-  if (width != null) root.setAttribute('data-width', String(width))
-  else root.removeAttribute('data-width')
-  if (height != null) root.setAttribute('data-height', String(height))
-  else root.removeAttribute('data-height')
+function applySize(root: HTMLElement, width: number | null, height: number | null): void {
+  if (width != null) root.setAttribute('data-width', String(Math.ceil(width)))
+  if (height != null) root.setAttribute('data-height', String(Math.ceil(height)))
 }
 
 /**
@@ -69,28 +65,25 @@ function applyEmbedSize(root: HTMLElement, width: number | null, height: number 
  * MAX_DISPLAY_HEIGHT, never upscaling). Before the image has loaded, only the
  * persisted dimensions are seeded; the load listener fills in the rest.
  */
-function applyDisplaySize(
+function applyImageDisplaySize(
   root: HTMLElement,
   image: HTMLImageElement,
   width: number | null,
   height: number | null,
 ): void {
   if (width != null && height != null) {
-    root.setAttribute('data-width', String(width))
-    root.setAttribute('data-height', String(height))
+    applySize(root, width, height)
     return
   }
   const ratio = image.naturalWidth / image.naturalHeight
   if (!Number.isFinite(ratio) || ratio <= 0) {
-    if (width != null) root.setAttribute('data-width', String(width))
-    if (height != null) root.setAttribute('data-height', String(height))
+    applySize(root, width, height)
     return
   }
   const displayHeight =
     width == null ? Math.min(image.naturalHeight, MAX_DISPLAY_HEIGHT) : width / ratio
   const displayWidth = width ?? displayHeight * ratio
-  root.setAttribute('data-width', String(Math.round(displayWidth)))
-  root.setAttribute('data-height', String(Math.round(displayHeight)))
+  applySize(root, displayWidth, displayHeight)
 }
 
 /**
@@ -126,7 +119,7 @@ function commitImageSize(
   const currentComment = current.slice(base.length)
 
   const nextComment = formatMagicComment({
-    ...(parseMagicComment(currentComment) ?? {}),
+    ...parseMagicComment(currentComment),
     width: Math.round(rawWidth),
     height: Math.round(rawHeight),
   })
@@ -183,9 +176,9 @@ class ImageMarkView implements MarkView {
     }
     if (this.#resizableRoot && (next.width !== previous.width || next.height !== previous.height)) {
       if (this.#image) {
-        applyDisplaySize(this.#resizableRoot, this.#image, next.width, next.height)
+        applyImageDisplaySize(this.#resizableRoot, this.#image, next.width, next.height)
       } else {
-        applyEmbedSize(this.#resizableRoot, next.width, next.height)
+        applySize(this.#resizableRoot, next.width, next.height)
       }
     }
     return true
@@ -231,7 +224,7 @@ class ImageMarkView implements MarkView {
     root.className = 'md-embed-resizable'
     root.dataset.testid = 'embed-resizable'
     root.setAttribute('data-aspect-ratio', String(16 / 9))
-    applyEmbedSize(root, this.#attrs.width, this.#attrs.height)
+    applySize(root, this.#attrs.width, this.#attrs.height)
     root.appendChild(iframe)
 
     const handle = document.createElement('prosekit-resizable-handle')
@@ -275,14 +268,14 @@ class ImageMarkView implements MarkView {
     // A persisted size is known up front, so seed both dimensions before the
     // image loads. This gives the box its final dimensions immediately, with no
     // layout shift when the natural size arrives.
-    applyDisplaySize(root, image, this.#attrs.width, this.#attrs.height)
+    applyImageDisplaySize(root, image, this.#attrs.width, this.#attrs.height)
     image.addEventListener('load', () => {
       root.removeAttribute('data-loading')
       const ratio = image.naturalWidth / image.naturalHeight
       if (!Number.isFinite(ratio) || ratio <= 0) return
       root.setAttribute('data-aspect-ratio', String(ratio))
       // Reread the attrs: an update() may have landed while the image was loading.
-      applyDisplaySize(root, image, this.#attrs.width, this.#attrs.height)
+      applyImageDisplaySize(root, image, this.#attrs.width, this.#attrs.height)
     })
     image.addEventListener('error', () => {
       root.removeAttribute('data-loading')

--- a/packages/core/src/extensions/image.ts
+++ b/packages/core/src/extensions/image.ts
@@ -52,6 +52,18 @@ function buildEmbedIframe(embed: EmbedDescriptor): HTMLIFrameElement {
 }
 
 /**
+ * Write a persisted display size onto a resizable embed root. The root's fixed
+ * `data-aspect-ratio` derives the height whenever a width is present, so
+ * missing dimensions simply fall back to the CSS default (full width).
+ */
+function applyEmbedSize(root: HTMLElement, width: number | null, height: number | null): void {
+  if (width != null) root.setAttribute('data-width', String(width))
+  else root.removeAttribute('data-width')
+  if (height != null) root.setAttribute('data-height', String(height))
+  else root.removeAttribute('data-height')
+}
+
+/**
  * Write the display size onto the resizable root. Persisted dimensions win;
  * missing ones derive from the image's natural size (capping the height at
  * MAX_DISPLAY_HEIGHT, never upscaling). Before the image has loaded, only the
@@ -169,12 +181,12 @@ class ImageMarkView implements MarkView {
     if (this.#image && next.alt !== previous.alt) {
       this.#image.alt = next.alt
     }
-    if (
-      this.#resizableRoot &&
-      this.#image &&
-      (next.width !== previous.width || next.height !== previous.height)
-    ) {
-      applyDisplaySize(this.#resizableRoot, this.#image, next.width, next.height)
+    if (this.#resizableRoot && (next.width !== previous.width || next.height !== previous.height)) {
+      if (this.#image) {
+        applyDisplaySize(this.#resizableRoot, this.#image, next.width, next.height)
+      } else {
+        applyEmbedSize(this.#resizableRoot, next.width, next.height)
+      }
     }
     return true
   }
@@ -190,7 +202,8 @@ class ImageMarkView implements MarkView {
     if (embed) {
       const wrapper = document.createElement('span')
       wrapper.className = 'md-image-view-preview md-atom-view-preview'
-      wrapper.appendChild(buildEmbedIframe(embed))
+      const iframe = buildEmbedIframe(embed)
+      wrapper.appendChild(embed.kind === 'youtube' ? this.#buildResizableEmbed(iframe) : iframe)
       return wrapper
     }
 
@@ -202,6 +215,39 @@ class ImageMarkView implements MarkView {
     wrapper.dataset.testid = 'image-preview'
     wrapper.appendChild(this.#buildResizableImage(url))
     return wrapper
+  }
+
+  /**
+   * A resizable YouTube embed: the same resizable web component as images, with
+   * the player's fixed 16:9 ratio, so a drag only ever picks a width. Releasing
+   * a drag writes the size into the markdown source as a
+   * `<!-- {"width":N,"height":M} -->` comment, exactly like an image.
+   */
+  #buildResizableEmbed(iframe: HTMLIFrameElement): HTMLElement {
+    registerResizableRootElement()
+    registerResizableHandleElement()
+
+    const root = document.createElement('prosekit-resizable-root')
+    root.className = 'md-embed-resizable'
+    root.dataset.testid = 'embed-resizable'
+    root.setAttribute('data-aspect-ratio', String(16 / 9))
+    applyEmbedSize(root, this.#attrs.width, this.#attrs.height)
+    root.appendChild(iframe)
+
+    const handle = document.createElement('prosekit-resizable-handle')
+    handle.className = 'md-image-resize-handle'
+    handle.setAttribute('position', 'bottom-right')
+    // A click (no drag) on the handle must not bubble to the image-click handler.
+    handle.addEventListener('click', (event) => event.stopPropagation())
+    root.appendChild(handle)
+
+    root.addEventListener('resizeEnd', (event) => {
+      const { width: nextWidth, height: nextHeight } = (event as ResizeEndEvent).detail
+      commitImageSize(this.#view, this.#contentDOM, nextWidth, nextHeight)
+    })
+
+    this.#resizableRoot = root
+    return root
   }
 
   /**

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -656,6 +656,7 @@
   .ProseMirror .md-embed-youtube {
     display: block;
     width: 100%;
+    max-width: 100%;
     aspect-ratio: 16 / 9;
     border: 0;
     border-radius: var(--meowdown-image-radius, 0.5rem);
@@ -666,6 +667,35 @@
     width: 100%;
     max-width: 550px;
     border: 0;
+  }
+
+  /* A YouTube embed wrapped in the resizable root: the root owns the size (its
+   * inline `aspect-ratio` derives the height from the persisted or dragged
+   * width; block-level `width: auto` keeps the default width when nothing is
+   * persisted), and the iframe just fills it. The bare `.md-embed-youtube` rule
+   * above keeps covering iframes rendered without the root (the static React
+   * renderer). */
+  .ProseMirror .md-embed-resizable {
+    position: relative;
+    display: block;
+    /* New stacking context so the handle's `mix-blend-mode` mixes only with the
+     * video, not the page behind it. */
+    isolation: isolate;
+    max-width: 100%;
+    min-width: 2.5rem;
+    min-height: 2.5rem;
+  }
+
+  .ProseMirror .md-embed-resizable .md-embed-youtube {
+    width: 100%;
+    height: 100%;
+    aspect-ratio: auto;
+  }
+
+  /* The resize handle tracks pointer moves on `window`; a cross-origin iframe
+   * would swallow them mid-drag, so mute it while resizing. */
+  .ProseMirror .md-embed-resizable[data-resizing] iframe {
+    pointer-events: none;
   }
 
   /* ---------------------------------------------------------------------------
@@ -920,7 +950,9 @@
     }
 
     .md-image-resizable:hover .md-image-resize-handle,
-    .md-image-resizable[data-resizing] .md-image-resize-handle {
+    .md-image-resizable[data-resizing] .md-image-resize-handle,
+    .md-embed-resizable:hover .md-image-resize-handle,
+    .md-embed-resizable[data-resizing] .md-image-resize-handle {
       opacity: 1;
       transform: scale(1);
       pointer-events: auto;

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -215,7 +215,8 @@ function WikilinkChip(props: {
   )
 }
 
-function EmbedFrame({ embed }: { embed: EmbedDescriptor }): ReactElement {
+function EmbedFrame(props: { embed: EmbedDescriptor; width: number | null }): ReactElement {
+  const { embed, width } = props
   const iframeRef = useRef<HTMLIFrameElement>(null)
   useEffect(() => {
     if (embed.kind !== 'tweet') return
@@ -223,6 +224,9 @@ function EmbedFrame({ embed }: { embed: EmbedDescriptor }): ReactElement {
     if (!iframe) return
     return listenForTweetHeight(iframe)
   }, [embed.kind, embed.key])
+  // A persisted width narrows the player; the `aspect-ratio` CSS on
+  // `.md-embed-youtube` derives the height. Tweets stay fluid-width.
+  const youtubeWidth = embed.kind === 'youtube' ? width : null
   return (
     <span className="md-image-view-preview md-atom-view-preview" contentEditable={false}>
       <iframe
@@ -237,6 +241,7 @@ function EmbedFrame({ embed }: { embed: EmbedDescriptor }): ReactElement {
         frameBorder="0"
         allow={embed.allow}
         allowFullScreen={embed.allowFullscreen}
+        style={youtubeWidth == null ? undefined : { width: youtubeWidth }}
       />
     </span>
   )
@@ -252,7 +257,7 @@ function ImagePreview(props: {
 }): ReactElement | null {
   const { src, alt, width, resolveImageUrl, onImageClick, interactive } = props
   const embed = matchEmbed(src)
-  if (embed) return interactive ? <EmbedFrame embed={embed} /> : null
+  if (embed) return interactive ? <EmbedFrame embed={embed} width={width} /> : null
 
   const url = (resolveImageUrl ?? defaultResolveImageUrl)(src)
   if (!url) return null


### PR DESCRIPTION
Wrap the YouTube embed iframe in the existing resizable root (fixed 16:9 ratio) so it can be resized like an image, persisting the size into the trailing `<!-- {"width":N,"height":M} -->` comment. Pointer events on the iframe are muted during a drag so the resize does not die when the cursor crosses the player.