### PR TITLE
fix: stop the virtual caret drifting after a window resize

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -141,8 +141,6 @@ Enter at the end of the document's first heading (the title line) can start a fr
 
 An arrow press that can move the caret no further can notify the host, so it can move focus elsewhere (a previous/next note or page): [`defineExitBoundaryHandler`](https://npmx.dev/package-docs/@meowdown%2Fcore#function-defineExitBoundaryHandler) (`@meowdown/react`'s `onExitBoundary` prop). Not part of `defineEditorExtension`.
 
-The caret is drawn by the editor itself (the native one is hidden via `caret-color: transparent`), so it can glide between positions and stay visible beside zero-width hidden syntax: [`defineVirtualCaret(layer)`](https://npmx.dev/package-docs/@meowdown%2Fcore#function-defineVirtualCaret), where `layer` is a host-supplied element the caret draws into; place it outside the contenteditable, scrolling together with the content. `@meowdown/react` wires this up automatically. Not part of `defineEditorExtension`.
-
 ## API
 
 See the full API reference [here](https://npmx.dev/package-docs/@meowdown%2Fcore/).

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -141,6 +141,8 @@ Enter at the end of the document's first heading (the title line) can start a fr
 
 An arrow press that can move the caret no further can notify the host, so it can move focus elsewhere (a previous/next note or page): [`defineExitBoundaryHandler`](https://npmx.dev/package-docs/@meowdown%2Fcore#function-defineExitBoundaryHandler) (`@meowdown/react`'s `onExitBoundary` prop). Not part of `defineEditorExtension`.
 
+The caret is drawn by the editor itself (the native one is hidden via `caret-color: transparent`), so it can glide between positions and stay visible beside zero-width hidden syntax: [`defineVirtualCaret(layer)`](https://npmx.dev/package-docs/@meowdown%2Fcore#function-defineVirtualCaret), where `layer` is a host-supplied element the caret draws into; place it outside the contenteditable, scrolling together with the content. `@meowdown/react` wires this up automatically. Not part of `defineEditorExtension`.
+
 ## API
 
 See the full API reference [here](https://npmx.dev/package-docs/@meowdown%2Fcore/).

--- a/packages/core/src/extensions/extension.ts
+++ b/packages/core/src/extensions/extension.ts
@@ -40,7 +40,6 @@ import { defineScrollToSelection } from './scroll-to-selection.ts'
 import { defineSelectDocBoundary } from './select-doc-boundary.ts'
 import { defineTable } from './table.ts'
 import { defineViewAttributes } from './view-attributes.ts'
-import { defineVirtualCaret } from './virtual-caret.ts'
 import { defineWikilink } from './wikilink.ts'
 
 function defineEditorExtensionImpl(options: EditorExtensionOptions) {
@@ -75,7 +74,6 @@ function defineEditorExtensionImpl(options: EditorExtensionOptions) {
     defineMath(),
     defineMarkMode(options.markMode ?? 'focus'),
     defineClipboard(),
-    defineVirtualCaret(),
     defineScrollToSelection(),
     defineHiddenRunCaret(),
     defineAtomMarkNavigation({

--- a/packages/core/src/extensions/virtual-caret.test.ts
+++ b/packages/core/src/extensions/virtual-caret.test.ts
@@ -294,6 +294,39 @@ describe('virtual caret at a line-wrapped wikilink', () => {
   })
 })
 
+describe('virtual caret when the editor reflows', () => {
+  function caretToSelectionDistance(): number {
+    const selection = document.getSelection()
+    if (selection == null || selection.rangeCount === 0) return Number.POSITIVE_INFINITY
+    const range = selection.getRangeAt(0).cloneRange()
+    range.collapse(true)
+    const rects = Array.from(range.getClientRects()).filter((rect) => rect.height > 0)
+    const selectionRect = rects[rects.length - 1]
+    if (selectionRect == null) return Number.POSITIVE_INFINITY
+    // The caret bar is centered on the measured x and stretched around the
+    // measured rect's vertical center.
+    const caretRect = getCaretElement().getBoundingClientRect()
+    const horizontalDistance = Math.abs(caretRect.left + caretRect.width / 2 - selectionRect.left)
+    const verticalDistance = Math.abs(
+      caretRect.top + caretRect.height / 2 - (selectionRect.top + selectionRect.height / 2),
+    )
+    return Math.max(horizontalDistance, verticalDistance)
+  }
+
+  it('repositions when text below the caret rewraps without moving the caret line', async () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.dom.style.width = '380px'
+    fixture.set(n.doc(n.paragraph('short<a>'), n.paragraph('wrap and wrap '.repeat(30).trim())))
+    fixture.view.focus()
+    await expect.element(caret).toBeVisible()
+    await expect.poll(caretToSelectionDistance).toBeLessThanOrEqual(2)
+
+    fixture.dom.style.width = '220px'
+    await expect.poll(caretToSelectionDistance).toBeLessThanOrEqual(2)
+  })
+})
+
 describe('virtual caret tails (hide mode)', () => {
   it('shows a right tail after a closing run', async () => {
     using fixture = setupMode('hide', 'foo **bold**<a> bar')

--- a/packages/core/src/extensions/virtual-caret.test.ts
+++ b/packages/core/src/extensions/virtual-caret.test.ts
@@ -297,12 +297,12 @@ describe('virtual caret at a line-wrapped wikilink', () => {
 describe('virtual caret when the editor reflows', () => {
   function caretToSelectionDistance(): number {
     const selection = document.getSelection()
-    if (selection == null || selection.rangeCount === 0) return Number.POSITIVE_INFINITY
+    if (selection == null || selection.rangeCount === 0) return Infinity
     const range = selection.getRangeAt(0).cloneRange()
     range.collapse(true)
     const rects = Array.from(range.getClientRects()).filter((rect) => rect.height > 0)
     const selectionRect = rects[rects.length - 1]
-    if (selectionRect == null) return Number.POSITIVE_INFINITY
+    if (selectionRect == null) return Infinity
     // The caret bar is centered on the measured x and stretched around the
     // measured rect's vertical center.
     const caretRect = getCaretElement().getBoundingClientRect()

--- a/packages/core/src/extensions/virtual-caret.ts
+++ b/packages/core/src/extensions/virtual-caret.ts
@@ -95,7 +95,17 @@ class VirtualCaretView implements PluginView {
     if (view.isDestroyed) return
     const state = view.state
     const selection = state.selection
-    const rect = isTextSelection(selection) && selection.empty ? measureCaretRect(view) : undefined
+    const viewportRect =
+      isTextSelection(selection) && selection.empty ? measureCaretRect(view) : undefined
+    let rect: CaretRect | undefined
+    if (viewportRect != null) {
+      const layerRect = this.#layer.getBoundingClientRect()
+      rect = {
+        left: viewportRect.left - layerRect.left,
+        top: viewportRect.top - layerRect.top,
+        height: viewportRect.height,
+      }
+    }
     // In hide mode the two doc positions at a hidden run boundary render at
     // one x; the tail (typing affinity) tells them apart.
     const tail =
@@ -116,12 +126,11 @@ class VirtualCaretView implements PluginView {
       view.dom.removeAttribute(DATA_ATTRIBUTE)
       return
     }
-    const layerRect = this.#layer.getBoundingClientRect()
     // A reappearing caret must not glide in from its stale position.
     if (wasHidden) this.#caret.style.transitionProperty = 'none'
     this.#caret.style.visibility = ''
-    this.#caret.style.left = `${rect.left - layerRect.left}px`
-    this.#caret.style.top = `${rect.top - layerRect.top}px`
+    this.#caret.style.left = `${rect.left}px`
+    this.#caret.style.top = `${rect.top}px`
     this.#caret.style.height = `${rect.height}px`
     view.dom.setAttribute(DATA_ATTRIBUTE, '')
     if (wasHidden) {

--- a/packages/core/src/extensions/virtual-caret.ts
+++ b/packages/core/src/extensions/virtual-caret.ts
@@ -40,13 +40,13 @@ function sameRect(left: CaretRect | undefined, right: CaretRect | undefined): bo
   return left.left === right.left && left.top === right.top && left.height === right.height
 }
 
-// The caret lives in a zero-height in-flow layer right after `view.dom`, never
-// inside the contenteditable: a `contenteditable=false` element inside the
-// content DOM shifts the browser's insertion point at the document edges
-// (Chrome inserts typed text before the element instead of into the first
-// textblock). The layer moves with the content when the host scrolls, and the
-// caret's coordinates are re-derived from the layer's own measured rect, so no
-// positioned ancestor is required.
+// The caret draws into a host-owned zero-size in-flow layer, never inside the
+// contenteditable: a `contenteditable=false` element inside the content DOM
+// shifts the browser's insertion point at the document edges (Chrome inserts
+// typed text before the element instead of into the first textblock). The
+// layer must live outside `view.dom` and scroll together with the content;
+// the caret's coordinates are re-derived from the layer's own measured rect,
+// so its exact placement is free and no positioned ancestor is required.
 class VirtualCaretView implements PluginView {
   readonly #view: EditorView
   readonly #layer: HTMLElement
@@ -57,20 +57,22 @@ class VirtualCaretView implements PluginView {
   #lastTail: CaretTail | undefined
   #blinkIndex = 0
 
-  constructor(view: EditorView) {
+  constructor(view: EditorView, layer: HTMLElement) {
     this.#view = view
     this.#document = view.dom.ownerDocument
-    this.#layer = this.#document.createElement('div')
-    this.#layer.className = 'md-virtual-caret-layer'
+    this.#layer = layer
+    this.#layer.classList.add('md-virtual-caret-layer')
     this.#caret = this.#layer.appendChild(this.#document.createElement('div'))
     this.#caret.className = 'md-virtual-caret'
     this.#caret.dataset.testid = 'virtual-caret'
-    view.dom.insertAdjacentElement('afterend', this.#layer)
     this.#document.addEventListener('selectionchange', this.#reposition)
+    view.dom.addEventListener('focus', this.#handleFocus)
+    view.dom.addEventListener('blur', this.#handleBlur)
     if (typeof ResizeObserver !== 'undefined') {
       this.#resizeObserver = new ResizeObserver(this.#reposition)
       this.#resizeObserver.observe(view.dom)
     }
+    if (view.hasFocus()) this.#handleFocus()
     this.#reposition()
   }
 
@@ -81,8 +83,21 @@ class VirtualCaretView implements PluginView {
 
   destroy() {
     this.#document.removeEventListener('selectionchange', this.#reposition)
+    this.#view.dom.removeEventListener('focus', this.#handleFocus)
+    this.#view.dom.removeEventListener('blur', this.#handleBlur)
     this.#resizeObserver?.disconnect()
-    this.#layer.remove()
+    this.#caret.remove()
+    this.#layer.classList.remove('md-virtual-caret-layer')
+    delete this.#layer.dataset.focused
+    this.#view.dom.removeAttribute(DATA_ATTRIBUTE)
+  }
+
+  readonly #handleFocus = (): void => {
+    this.#layer.dataset.focused = ''
+  }
+
+  readonly #handleBlur = (): void => {
+    delete this.#layer.dataset.focused
   }
 
   #restartBlink() {
@@ -145,12 +160,16 @@ class VirtualCaretView implements PluginView {
  * (`caret-color: transparent`). The native DOM selection stays fully alive,
  * so IME, clicks, and typing keep their native behavior; only the caret pixels
  * are ours. Applies to every mark mode.
+ *
+ * `layer` is the element the caret draws into. The host owns its placement:
+ * it must live outside the contenteditable and scroll together with the
+ * content.
  */
-export function defineVirtualCaret(): PlainExtension {
+export function defineVirtualCaret(layer: HTMLElement): PlainExtension {
   return definePlugin(
     new Plugin({
       key,
-      view: (view) => new VirtualCaretView(view),
+      view: (view) => new VirtualCaretView(view, layer),
     }),
   )
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -141,6 +141,7 @@ export {
   type TagClickPayload,
 } from './extensions/tag-click.ts'
 export { defineViewAttributes } from './extensions/view-attributes.ts'
+export { defineVirtualCaret } from './extensions/virtual-caret.ts'
 export {
   formatSizedWikiEmbed,
   parseWikiEmbed,

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -165,9 +165,11 @@
   /* ---------------------------------------------------------------------------
    * Virtual caret
    *
-   * A zero-height in-flow layer right after `.ProseMirror` (outside the
+   * A host-owned zero-size in-flow layer near `.ProseMirror` (outside the
    * contenteditable), so it scrolls with the content and never disturbs the
-   * browser's editing behavior. The caret is positioned against the layer.
+   * browser's editing behavior. The caret is positioned against the layer;
+   * the extension stamps `data-focused` on the layer while the editor has
+   * focus.
    * ------------------------------------------------------------------------- */
   .md-virtual-caret-layer {
     position: relative;
@@ -202,7 +204,7 @@
     }
   }
 
-  .ProseMirror.ProseMirror-focused ~ .md-virtual-caret-layer .md-virtual-caret {
+  .md-virtual-caret-layer[data-focused] .md-virtual-caret {
     display: block;
     animation: md-virtual-caret-blink 1.2s ease-in-out infinite;
   }

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -7,6 +7,7 @@ import type { EditorNode } from '@prosekit/pm/model'
 import { formatHTML } from 'diffable-html-snapshot'
 
 import { defineEditorExtension, type EditorExtensionOptions } from '../extensions/extension.ts'
+import { defineVirtualCaret } from '../extensions/virtual-caret.ts'
 
 import { getSelectionSnapshot } from './selection-snapshot.ts'
 
@@ -40,7 +41,10 @@ export function setupFixture({
   const div = getTestContainer(containerId)
 
   if (mount) {
+    // Mirror the react host: the caret layer sits before the editor element.
+    const caretLayer = div.appendChild(document.createElement('div'))
     editor.mount(div)
+    editor.use(defineVirtualCaret(caretLayer))
   }
 
   const dispose = () => {

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -40,10 +40,13 @@ export function setupFixture({
 
   const div = getTestContainer(containerId)
 
+  // Mirror the react host: the caret layer sits right before the editor
+  // element (`mount` turns `div` itself into the editable root).
+  const caretLayer = document.createElement('div')
+
   if (mount) {
-    // Mirror the react host: the caret layer sits before the editor element.
-    const caretLayer = div.appendChild(document.createElement('div'))
     editor.mount(div)
+    div.insertAdjacentElement('beforebegin', caretLayer)
     editor.use(defineVirtualCaret(caretLayer))
   }
 
@@ -51,6 +54,7 @@ export function setupFixture({
     if (mount) {
       editor.unmount()
     }
+    caretLayer.remove()
     div.remove()
   }
 

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -65,6 +65,7 @@ import type {
   TagSearchHandler,
   WikilinkSearchHandler,
 } from './types.ts'
+import { VirtualCaret } from './virtual-caret.tsx'
 import { WikilinkMenu } from './wikilink-menu.tsx'
 
 // Selections coming through `setState` are hints: restore them exactly when
@@ -448,6 +449,9 @@ export function ProseKitEditor({
 
   return (
     <ProseKit editor={editor}>
+      {/* Before the editor element, so a document height change below the
+          caret cannot move the layer. */}
+      <VirtualCaret />
       <div ref={editor.mount}></div>
       <EditorExtensions
         markMode={markMode}

--- a/packages/react/src/components/virtual-caret.tsx
+++ b/packages/react/src/components/virtual-caret.tsx
@@ -1,0 +1,11 @@
+import { defineVirtualCaret } from '@meowdown/core'
+import { useExtension } from '@prosekit/react'
+import { useMemo, useState, type ReactElement } from 'react'
+
+// A leaf that owns the caret layer: React renders the div and the extension
+// draws into it. `useExtension` reads the editor from context.
+export function VirtualCaret(): ReactElement {
+  const [layer, setLayer] = useState<HTMLDivElement | null>(null)
+  useExtension(useMemo(() => (layer == null ? null : defineVirtualCaret(layer)), [layer]))
+  return <div ref={setLayer}></div>
+}


### PR DESCRIPTION

https://github.com/user-attachments/assets/8c7f14f4-4c08-4a56-bade-9a1b23b33d3a

