### PR TITLE
feat: add ordered list cycle command

### DIFF
--- a/packages/core/src/extensions/list.test.ts
+++ b/packages/core/src/extensions/list.test.ts
@@ -121,28 +121,28 @@ describe('commands', () => {
     expect(docToMarkdown(fixture.doc)).toBe('+ [ ] outer\n  - [ ] inner\n')
   })
 
-  it('cyclePlainList cycles plain content through bullet, ordered, and text', () => {
+  it('cycleOrderedList cycles plain content through bullet, ordered, and text', () => {
     using fixture = setupFixture()
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('todo<a>')))
 
     expect(docToMarkdown(fixture.doc).trim()).toMatchInlineSnapshot(`"todo"`)
-    fixture.editor.commands.cyclePlainList()
+    fixture.editor.commands.cycleOrderedList()
     expect(docToMarkdown(fixture.doc).trim()).toMatchInlineSnapshot(`"- todo"`)
-    fixture.editor.commands.cyclePlainList()
+    fixture.editor.commands.cycleOrderedList()
     expect(docToMarkdown(fixture.doc).trim()).toMatchInlineSnapshot(`"1. todo"`)
-    fixture.editor.commands.cyclePlainList()
+    fixture.editor.commands.cycleOrderedList()
     expect(docToMarkdown(fixture.doc).trim()).toMatchInlineSnapshot(`"todo"`)
-    fixture.editor.commands.cyclePlainList()
+    fixture.editor.commands.cycleOrderedList()
     expect(docToMarkdown(fixture.doc).trim()).toMatchInlineSnapshot(`"- todo"`)
   })
 
-  it('cyclePlainList converts a task to a plain bullet first', () => {
+  it('cycleOrderedList converts a task to a plain bullet first', () => {
     using fixture = setupFixture()
     const { n } = fixture
     fixture.set(n.doc(n.list({ kind: 'task', marker: '+', checked: true }, n.paragraph('done<a>'))))
 
-    fixture.editor.commands.cyclePlainList()
+    fixture.editor.commands.cycleOrderedList()
 
     expect(fixture.doc.child(0).attrs).toMatchObject({
       kind: 'bullet',
@@ -151,7 +151,7 @@ describe('commands', () => {
     expect(docToMarkdown(fixture.doc)).toBe('- done\n')
   })
 
-  it('cyclePlainList changes only the closest nested list', () => {
+  it('cycleOrderedList changes only the closest nested list', () => {
     using fixture = setupFixture()
     const { n } = fixture
     fixture.set(
@@ -164,9 +164,9 @@ describe('commands', () => {
       ),
     )
 
-    fixture.editor.commands.cyclePlainList()
+    fixture.editor.commands.cycleOrderedList()
     expect(docToMarkdown(fixture.doc)).toBe('- outer\n  1. inner\n')
-    fixture.editor.commands.cyclePlainList()
+    fixture.editor.commands.cycleOrderedList()
     expect(docToMarkdown(fixture.doc)).toBe('- outer\n\n  inner\n')
   })
 })

--- a/packages/core/src/extensions/list.test.ts
+++ b/packages/core/src/extensions/list.test.ts
@@ -120,6 +120,52 @@ describe('commands', () => {
     fixture.editor.commands.cycleCheckableList()
     expect(docToMarkdown(fixture.doc)).toBe('+ [ ] outer\n  - [ ] inner\n')
   })
+
+  it('cyclePlainList cycles plain content through bullet, ordered, and text', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('todo<a>')))
+
+    fixture.editor.commands.cyclePlainList()
+    expect(docToMarkdown(fixture.doc)).toBe('- todo\n')
+    fixture.editor.commands.cyclePlainList()
+    expect(docToMarkdown(fixture.doc)).toBe('1. todo\n')
+    fixture.editor.commands.cyclePlainList()
+    expect(docToMarkdown(fixture.doc)).toBe('todo\n')
+  })
+
+  it('cyclePlainList converts a task to a plain bullet first', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.list({ kind: 'task', marker: '+', checked: true }, n.paragraph('done<a>'))))
+
+    fixture.editor.commands.cyclePlainList()
+
+    expect(fixture.doc.child(0).attrs).toMatchObject({
+      kind: 'bullet',
+      checked: false,
+    })
+    expect(docToMarkdown(fixture.doc)).toBe('- done\n')
+  })
+
+  it('cyclePlainList changes only the closest nested list', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(
+      n.doc(
+        n.list(
+          { kind: 'bullet' },
+          n.paragraph('outer'),
+          n.list({ kind: 'bullet' }, n.paragraph('inner<a>')),
+        ),
+      ),
+    )
+
+    fixture.editor.commands.cyclePlainList()
+    expect(docToMarkdown(fixture.doc)).toBe('- outer\n  1. inner\n')
+    fixture.editor.commands.cyclePlainList()
+    expect(docToMarkdown(fixture.doc)).toBe('- outer\n\n  inner\n')
+  })
 })
 
 describe('keymap', () => {

--- a/packages/core/src/extensions/list.test.ts
+++ b/packages/core/src/extensions/list.test.ts
@@ -126,12 +126,15 @@ describe('commands', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('todo<a>')))
 
+    expect(docToMarkdown(fixture.doc).trim()).toMatchInlineSnapshot(`"todo"`)
     fixture.editor.commands.cyclePlainList()
-    expect(docToMarkdown(fixture.doc)).toBe('- todo\n')
+    expect(docToMarkdown(fixture.doc).trim()).toMatchInlineSnapshot(`"- todo"`)
     fixture.editor.commands.cyclePlainList()
-    expect(docToMarkdown(fixture.doc)).toBe('1. todo\n')
+    expect(docToMarkdown(fixture.doc).trim()).toMatchInlineSnapshot(`"1. todo"`)
     fixture.editor.commands.cyclePlainList()
-    expect(docToMarkdown(fixture.doc)).toBe('todo\n')
+    expect(docToMarkdown(fixture.doc).trim()).toMatchInlineSnapshot(`"todo"`)
+    fixture.editor.commands.cyclePlainList()
+    expect(docToMarkdown(fixture.doc).trim()).toMatchInlineSnapshot(`"- todo"`)
   })
 
   it('cyclePlainList converts a task to a plain bullet first', () => {

--- a/packages/core/src/extensions/list.ts
+++ b/packages/core/src/extensions/list.ts
@@ -20,8 +20,8 @@ import {
   type ListAttrs,
 } from '@prosekit/extensions/list'
 import type { ProseMirrorNode } from '@prosekit/pm/model'
-import { Plugin } from '@prosekit/pm/state'
 import type { Command, EditorState } from '@prosekit/pm/state'
+import { Plugin } from '@prosekit/pm/state'
 import {
   createListRenderingPlugin,
   createSafariInputMethodWorkaroundPlugin,
@@ -300,7 +300,11 @@ function getListAttrsAtSelection(state: EditorState): MeowdownListAttrs | null {
 }
 
 /**
- * Cycle the selected block between square and circle checkbox tasks. Non-task
+ * Cycle the selected block between square and circle checkbox tasks.
+ *
+ * - A square task becomes a circle task;
+ * - A circle task becomes a square task;
+ * - Other content becomes a square task.
  * content becomes an unchecked square task; shape changes preserve checked state.
  */
 function cycleCheckableList(): Command {
@@ -317,10 +321,13 @@ function cycleCheckableList(): Command {
 }
 
 /**
- * Cycle the selected block between plain list states. Non-plain-list content
- * becomes a bullet; bullets become ordered lists; ordered lists unwrap.
+ * Cycle the selected block between bullet and ordered list.
+ *
+ * - A bullet list become a ordered list;
+ * - An ordered list unwrap;
+ * - Other content becomes a bullet list;
  */
-function cyclePlainList(): Command {
+function cycleOrderedList(): Command {
   return (state, dispatch, view) => {
     const attrs = getListAttrsAtSelection(state)
     const next: MeowdownListAttrs =
@@ -334,7 +341,7 @@ function cyclePlainList(): Command {
 function defineTaskCommands() {
   return defineCommands({
     cycleCheckableList,
-    cyclePlainList,
+    cycleOrderedList,
     wrapInCircleTask,
     wrapInSquareTask,
   })

--- a/packages/core/src/extensions/list.ts
+++ b/packages/core/src/extensions/list.ts
@@ -338,12 +338,17 @@ function cycleOrderedList(): Command {
   }
 }
 
-function defineTaskCommands() {
+function toggleListCollapsed(): Command {
+  return createToggleCollapsedCommand({ isToggleable: isCollapsibleBullet })
+}
+
+function defineMeowdownListCommands() {
   return defineCommands({
     cycleCheckableList,
     cycleOrderedList,
     wrapInCircleTask,
     wrapInSquareTask,
+    toggleListCollapsed,
   })
 }
 
@@ -436,12 +441,6 @@ function defineMeowdownListPlugins(): PlainExtension {
   ])
 }
 
-function defineCollapseCommands() {
-  return defineCommands({
-    toggleListCollapsed: () => createToggleCollapsedCommand({ isToggleable: isCollapsibleBullet }),
-  })
-}
-
 function defineMeowdownListKeymap(): PlainExtension {
   return defineKeymap({
     'Mod-Enter': rotateSquareTask(),
@@ -473,7 +472,6 @@ export function defineMeowdownList() {
     defineListMarkerAttr(),
     defineListTaskMarkerAttr(),
     defineListMarkerGapAttr(),
-    defineTaskCommands(),
-    defineCollapseCommands(),
+    defineMeowdownListCommands(),
   )
 }

--- a/packages/core/src/extensions/list.ts
+++ b/packages/core/src/extensions/list.ts
@@ -316,9 +316,25 @@ function cycleCheckableList(): Command {
   }
 }
 
+/**
+ * Cycle the selected block between plain list states. Non-plain-list content
+ * becomes a bullet; bullets become ordered lists; ordered lists unwrap.
+ */
+function cyclePlainList(): Command {
+  return (state, dispatch, view) => {
+    const attrs = getListAttrsAtSelection(state)
+    const next: MeowdownListAttrs =
+      attrs?.kind === 'bullet' || attrs?.kind === 'ordered'
+        ? { kind: 'ordered', marker: null, checked: false, collapsed: false }
+        : { kind: 'bullet', marker: null, checked: false, collapsed: false }
+    return toggleList<MeowdownListAttrs>(next)(state, dispatch, view)
+  }
+}
+
 function defineTaskCommands() {
   return defineCommands({
     cycleCheckableList,
+    cyclePlainList,
     wrapInCircleTask,
     wrapInSquareTask,
   })

--- a/packages/core/src/extensions/list.ts
+++ b/packages/core/src/extensions/list.ts
@@ -302,10 +302,9 @@ function getListAttrsAtSelection(state: EditorState): MeowdownListAttrs | null {
 /**
  * Cycle the selected block between square and circle checkbox tasks.
  *
- * - A square task becomes a circle task;
- * - A circle task becomes a square task;
- * - Other content becomes a square task.
- * content becomes an unchecked square task; shape changes preserve checked state.
+ * - A square task becomes a circle task, keeping its checked state;
+ * - A circle task becomes a square task, keeping its checked state;
+ * - Other content becomes an unchecked square task.
  */
 function cycleCheckableList(): Command {
   return (state, dispatch, view) => {
@@ -321,11 +320,11 @@ function cycleCheckableList(): Command {
 }
 
 /**
- * Cycle the selected block between bullet and ordered list.
+ * Cycle the selected block between a bullet list, an ordered list, and no list.
  *
- * - A bullet list become a ordered list;
- * - An ordered list unwrap;
- * - Other content becomes a bullet list;
+ * - A bullet list becomes an ordered list;
+ * - An ordered list unwraps;
+ * - Other content, including a task, becomes a bullet list.
  */
 function cycleOrderedList(): Command {
   return (state, dispatch, view) => {


### PR DESCRIPTION
## Summary
- add `cyclePlainList` to cycle plain blocks through bullet, ordered, and text
- normalize task/list attrs when converting task-like content to a plain bullet
- cover the command state table and closest-nested-list behavior in list extension tests

## State table
| Current selection state | Next state |
| --- | --- |
| Not a plain bullet or ordered list | Unordered list |
| Unordered list | Ordered list |
| Ordered list | No list |

Task items are treated as non-plain-list content on the first press, so they convert to a plain bullet and clear stale task attrs instead of preserving checkbox semantics invisibly. Nested selections follow the existing closest-list convention used by `cycleCheckableList`.

## Verification
- `pnpm test --run packages/core/src/extensions/list.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`

Reflect dependency PR will wire the iOS toolbar button to this command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added list cycling to switch between bullet, ordered, and plain text formats.
  * Cycling task items converts them to unchecked bullet items.
  * List cycling applies to the nearest nested list without changing surrounding lists.

* **Tests**
  * Added coverage for list cycling, task conversion, and nested list behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->