### PR TITLE
test: repro `Mod-Enter` following the wrong target on a selected wikilink

### DIFF
--- a/packages/core/src/extensions/follow-link.test.ts
+++ b/packages/core/src/extensions/follow-link.test.ts
@@ -123,4 +123,19 @@ describe('defineFollowLinkHandler', () => {
     expect(onTagClick).not.toHaveBeenCalled()
     expect(docToMarkdown(fixture.doc)).toBe('- [ ] see [[Note]] here\n')
   })
+  it('Mod-Enter on a selected wikilink next to another wikilink', async () => {
+    const onWikilinkClick = vi.fn<WikilinkClickHandler>()
+    using fixture = setup({ onWikilinkClick })
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('see <a>[[Aaa]][[Bbb]] here')))
+    fixture.view.focus()
+
+    await userEvent.keyboard('{ArrowRight}')
+    await pressModEnter()
+    expect(onWikilinkClick.mock.calls.map((call) => call[0].target)).toMatchInlineSnapshot(`
+      [
+        "Bbb",
+      ]
+    `)
+  })
 })

--- a/packages/core/src/extensions/follow-link.test.ts
+++ b/packages/core/src/extensions/follow-link.test.ts
@@ -129,11 +129,11 @@ describe('defineFollowLinkHandler', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('see <a>[[Aaa]][[Bbb]] here')))
     fixture.view.focus()
-    expect(fixture.selectionSnapshot).toMatchInlineSnapshot()
+    expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`"see ┃[[Aaa]][[Bbb]] here"`)
     await userEvent.keyboard('{ArrowRight}')
-    expect(fixture.selectionSnapshot).toMatchInlineSnapshot()
+    expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`"see ❰[[Aaa]]❱[[Bbb]] here"`)
     await pressModEnter()
-    expect(fixture.selectionSnapshot).toMatchInlineSnapshot()
+    expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`"see ❰[[Aaa]]❱[[Bbb]] here"`)
     expect(onWikilinkClick.mock.calls.map((call) => call[0].target)).toMatchInlineSnapshot(`
       [
         "Bbb",

--- a/packages/core/src/extensions/follow-link.test.ts
+++ b/packages/core/src/extensions/follow-link.test.ts
@@ -129,9 +129,11 @@ describe('defineFollowLinkHandler', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('see <a>[[Aaa]][[Bbb]] here')))
     fixture.view.focus()
-
+    expect(fixture.selectionSnapshot).toMatchInlineSnapshot()
     await userEvent.keyboard('{ArrowRight}')
+    expect(fixture.selectionSnapshot).toMatchInlineSnapshot()
     await pressModEnter()
+    expect(fixture.selectionSnapshot).toMatchInlineSnapshot()
     expect(onWikilinkClick.mock.calls.map((call) => call[0].target)).toMatchInlineSnapshot(`
       [
         "Bbb",


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Mod-Enter could follow the wrong wikilink when navigating between adjacent links.

* **Tests**
  * Added regression coverage for selecting and following the second adjacent wikilink.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->