### PR TITLE
fix: resolve the follow target from inside the selected atom unit

### DIFF
--- a/packages/core/src/extensions/atom-mark-navigation.ts
+++ b/packages/core/src/extensions/atom-mark-navigation.ts
@@ -74,6 +74,15 @@ function getSelectedRange(state: EditorState, markNames: MarkName[]): MarkRange 
   return range && range.from === from && range.to === to ? range : undefined
 }
 
+/**
+ * The atom source unit the selection exactly spans, or undefined. Inert (like
+ * the rest of atom navigation) in a state built without a mark mode.
+ */
+export function getSelectedAtomRange(state: EditorState): MarkRange | undefined {
+  if (!getMarkMode(state)) return undefined
+  return getSelectedRange(state, [...ATOM_SOURCE_MARK_NAMES])
+}
+
 function selectRange(state: EditorState, range: MarkRange): TextSelection {
   return TextSelection.create(state.doc, range.from, range.to)
 }

--- a/packages/core/src/extensions/follow-link.test.ts
+++ b/packages/core/src/extensions/follow-link.test.ts
@@ -136,7 +136,7 @@ describe('defineFollowLinkHandler', () => {
     expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`"see ❰[[Aaa]]❱[[Bbb]] here"`)
     expect(onWikilinkClick.mock.calls.map((call) => call[0].target)).toMatchInlineSnapshot(`
       [
-        "Bbb",
+        "Aaa",
       ]
     `)
   })

--- a/packages/core/src/extensions/follow-link.ts
+++ b/packages/core/src/extensions/follow-link.ts
@@ -1,6 +1,7 @@
 import { definePlugin, isApple, Priority, withPriority, type PlainExtension } from '@prosekit/core'
 import { Plugin, PluginKey } from '@prosekit/pm/state'
 
+import { getSelectedAtomRange } from './atom-mark-navigation.ts'
 import { findFileAt } from './file-click.ts'
 import type { FileClickHandler } from './file-click.ts'
 import { getLinkUnitAt } from './get-link-unit-at.ts'
@@ -37,7 +38,11 @@ function createFollowLinkPlugin(handlers: FollowLinkHandlers) {
         }
 
         const { state } = view
-        const pos = state.selection.head
+        const selectedAtom = getSelectedAtomRange(state)
+        // Resolve inside the selected unit, not at its edge: either edge may
+        // also touch an adjacent unit, and edge positions prefer the
+        // neighbour to the right.
+        const pos = selectedAtom ? selectedAtom.from + 1 : state.selection.head
 
         const wikilink = handlers.onWikilinkClick && findWikilinkAt(state, pos)
         if (wikilink) {


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>