### PR TITLE
ci: add `all-green` gate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,20 @@ jobs:
       - name: Report Coverage
         uses: davelosert/vitest-coverage-report-action@8b157684c6a6b259b97d45e72b44242865c0f6a5 # v2.12.2
 
+  ci-ok:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    if: always()
+    needs: [lint, build, test]
+
+    steps:
+      - name: Verify that all jobs succeeded
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        run: |
+          echo 'Some jobs did not succeed: ${{ toJSON(needs) }}'
+          exit 1
+
   publish-snapshot:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Report Coverage
         uses: davelosert/vitest-coverage-report-action@8b157684c6a6b259b97d45e72b44242865c0f6a5 # v2.12.2
 
-  ci-ok:
+  all-green:
     runs-on: ubuntu-latest
     timeout-minutes: 5
 


### PR DESCRIPTION
Adds an `all-green` job that depends on `lint`, `build` and `test` and fails unless all of them succeeded, so it can be used as the single required status check.