### PR TITLE
ci: add concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ permissions:
 concurrency:
   group: >-
     ${{ github.workflow }}-${{
-      github.event_name == 'push' && 'master' ||
-      (github.event.pull_request.stack != null &&
-        format('stack-{0}', github.event.pull_request.stack.number)) ||
-      format('pr-{0}', github.event.pull_request.number)
+      (github.event_name == 'push' && 'push') ||
+      (github.event.pull_request.stack == null && github.event.pull_request.number) ||
+      (github.event.pull_request.stack != null && github.event.pull_request.stack.number)
     }}
 
+  # Only cancel in-progress jobs for stacked PRs that are not the lowest unmerged PR or the top PR.
   # The lowest unmerged PR is the one whose base matches the stack base.
   # The top PR is the one whose position matches the stack size.
   # See: https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/optimizing-ci-for-stacked-pull-requests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,26 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{
+      github.event_name == 'push' && 'master' ||
+      (github.event.pull_request.stack != null &&
+        format('stack-{0}', github.event.pull_request.stack.number)) ||
+      format('pr-{0}', github.event.pull_request.number)
+    }}
+
+  # The lowest unmerged PR is the one whose base matches the stack base.
+  # The top PR is the one whose position matches the stack size.
+  # See: https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/optimizing-ci-for-stacked-pull-requests
+  cancel-in-progress: >-
+    ${{
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.stack != null &&
+      github.event.pull_request.stack.base.ref != github.event.pull_request.base.ref &&
+      github.event.pull_request.stack.position != github.event.pull_request.stack.size
+    }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Group master CI runs together, normal PR runs by PR number, and every layer in a stack by stack number. Only a newly triggered interior stacked PR cancels the active stack run, while bottom and top runs use the shared group without canceling on arrival. The workflow YAML was parsed locally; the full test matrix will run in GitHub Actions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated workflow handling to prevent redundant checks from running simultaneously.
  * Added controlled concurrency for release processes without interrupting active release runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->