### PR TITLE
fix: grow a dragged selection to whole atom units

### DIFF
--- a/packages/core/src/extensions/atom-mark-navigation.test.ts
+++ b/packages/core/src/extensions/atom-mark-navigation.test.ts
@@ -46,6 +46,13 @@ function dropCaret(fixture: Fixture, pos: number, isPointer = false): void {
   fixture.view.dispatch(isPointer ? tr.setMeta('pointer', true) : tr)
 }
 
+// Drop a range selection the same way, from `anchor` to `head`. A drag arrives
+// exactly like this, `pointer` meta included.
+function dropRange(fixture: Fixture, anchor: number, head: number, isPointer = false): void {
+  const tr = fixture.state.tr.setSelection(TextSelection.create(fixture.doc, anchor, head))
+  fixture.view.dispatch(isPointer ? tr.setMeta('pointer', true) : tr)
+}
+
 async function walkKey(fixture: Fixture, key: string, times: number): Promise<string> {
   return formatSelectionSteps(await traceKeySelection(fixture, key, times))
 }
@@ -535,6 +542,63 @@ describe('caret snapping out of hidden atom source', () => {
     // `[[` is the escape for a literal `[` in userEvent's keyboard syntax.
     await userEvent.keyboard('[[[[Aaa]]')
     expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`"see [[Aaa]]┃"`)
+  })
+})
+
+describe('dragged selections growing to whole atom units', () => {
+  it('focus: a drag ending inside the source swallows the unit whole', () => {
+    using fixture = setup('focus', ['see [[Aaa]] here'])
+    dropRange(fixture, 1, findText(fixture.doc, '[[Aaa]]') + 4, true)
+    expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`"❰see [[Aaa]]❱ here"`)
+  })
+
+  it('focus: a drag starting inside the source swallows the unit whole', () => {
+    using fixture = setup('focus', ['see [[Aaa]] here'])
+    dropRange(
+      fixture,
+      findText(fixture.doc, '[[Aaa]]') + 4,
+      findText(fixture.doc, ' here') + 5,
+      true,
+    )
+    expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`"see ❰[[Aaa]] here❱"`)
+  })
+
+  it('focus: a backwards drag keeps its direction while growing', () => {
+    using fixture = setup('focus', ['see [[Aaa]] here'])
+    const head = findText(fixture.doc, '[[Aaa]]') + 4
+    dropRange(fixture, findText(fixture.doc, ' here') + 5, head, true)
+    expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`"see ❰[[Aaa]] here❱"`)
+    expect(fixture.state.selection.head).toBe(findText(fixture.doc, '[[Aaa]]'))
+  })
+
+  it('focus: typing over a drag that cut the source keeps the unit whole', async () => {
+    using fixture = setup('focus', ['see [[Aaa]] here'])
+    dropRange(fixture, 1, findText(fixture.doc, '[[Aaa]]') + 4, true)
+    await userEvent.keyboard('X')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      X here
+
+      """
+    `)
+  })
+
+  it('focus: a drag inside plain text is left alone', () => {
+    using fixture = setup('focus', ['see [[Aaa]] here'])
+    dropRange(fixture, 1, 3, true)
+    expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`"❰se❱e [[Aaa]] here"`)
+  })
+
+  it('focus: a selection that is not from a pointer keeps its endpoints', () => {
+    using fixture = setup('focus', ['see [[Aaa]] here'])
+    dropRange(fixture, 1, findText(fixture.doc, '[[Aaa]]') + 4)
+    expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`"❰see [[Aa❱a]] here"`)
+  })
+
+  it('focus: a drag ending inside an image source swallows the image whole', () => {
+    using fixture = setup('focus', ['see ![a](one.png) here'])
+    dropRange(fixture, 1, findText(fixture.doc, '![a](one.png)') + 5, true)
+    expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`"❰see ![a](one.png)❱ here"`)
   })
 })
 

--- a/packages/core/src/extensions/atom-mark-navigation.ts
+++ b/packages/core/src/extensions/atom-mark-navigation.ts
@@ -244,7 +244,7 @@ function getUnitEdge(range: MarkRange, oldPos: number, newPos: number, isPointer
   return newPos >= oldPos ? range.to : range.from
 }
 
-// Keep the caret out of a unit's hidden source, whatever put it there: a
+// Keep the selection out of a unit's hidden source, whatever put it there: a
 // pointer, a programmatic setSelection, a position remapped by undo or paste.
 // Every write from inside dissolves the unit, and the keymap commands that
 // would prevent it only cover the keys they bind.
@@ -256,10 +256,23 @@ function createCaretSnapPlugin(marks: AtomMarks): Plugin {
       const markNames = getActiveMarkNames(marks, newState)
       if (markNames.length === 0) return null
       const selection = newState.selection
-      if (!isTextSelection(selection) || !selection.empty) return null
+      if (!isTextSelection(selection)) return null
+      const isPointer = hasPointerSelectionTransaction(transactions)
+      if (!selection.empty) {
+        // Only a dragged range grows to whole units. Find deliberately selects
+        // text inside a unit's source so it can highlight and replace it.
+        if (!isPointer) return null
+        const from =
+          getMarkRangeStrictlyAround(newState, selection.from, markNames)?.from ?? selection.from
+        const to =
+          getMarkRangeStrictlyAround(newState, selection.to, markNames)?.to ?? selection.to
+        if (from === selection.from && to === selection.to) return null
+        const anchor = selection.anchor === selection.from ? from : to
+        const head = selection.head === selection.from ? from : to
+        return newState.tr.setSelection(TextSelection.create(newState.doc, anchor, head))
+      }
       const range = getMarkRangeStrictlyAround(newState, selection.head, markNames)
       if (!range) return null
-      const isPointer = hasPointerSelectionTransaction(transactions)
       const head = getUnitEdge(range, oldState.selection.head, selection.head, isPointer)
       return newState.tr.setSelection(TextSelection.create(newState.doc, head))
     },

--- a/packages/core/src/extensions/atom-mark-navigation.ts
+++ b/packages/core/src/extensions/atom-mark-navigation.ts
@@ -264,8 +264,7 @@ function createCaretSnapPlugin(marks: AtomMarks): Plugin {
         if (!isPointer) return null
         const from =
           getMarkRangeStrictlyAround(newState, selection.from, markNames)?.from ?? selection.from
-        const to =
-          getMarkRangeStrictlyAround(newState, selection.to, markNames)?.to ?? selection.to
+        const to = getMarkRangeStrictlyAround(newState, selection.to, markNames)?.to ?? selection.to
         if (from === selection.from && to === selection.to) return null
         const anchor = selection.anchor === selection.from ? from : to
         const head = selection.head === selection.from ? from : to


### PR DESCRIPTION
A text selection whose endpoint fell inside a unit's hidden source dissolved the unit on the next write. A pointer-made selection now grows to whole units; a programmatic one is left alone, because find deliberately selects text inside a unit's source so it can highlight and replace it.