### PR TITLE
fix: render two identical adjacent units as two previews

### DIFF
--- a/packages/core/src/extensions/atom-mark-navigation.test.ts
+++ b/packages/core/src/extensions/atom-mark-navigation.test.ts
@@ -685,6 +685,35 @@ describe('caret navigation between adjacent inline units', () => {
     `)
   })
 
+  it('focus: ArrowLeft walks two identical adjacent wikilinks as two units', async () => {
+    using fixture = setup('focus', ['see [[Aaa]][[Aaa]]<a> here'])
+    expect(await walkKey(fixture, 'ArrowLeft', 4)).toMatchInlineSnapshot(`
+      """
+      see [[Aaa]][[Aaa]]┃ here
+      ----------
+      see [[Aaa]]❰[[Aaa]]❱ here
+      ----------
+      see [[Aaa]]┃[[Aaa]] here
+      ----------
+      see ❰[[Aaa]]❱[[Aaa]] here
+      ----------
+      see ┃[[Aaa]][[Aaa]] here
+      """
+    `)
+  })
+
+  it('focus: Backspace between two identical adjacent wikilinks removes only the left one', async () => {
+    using fixture = setup('focus', ['see [[Aaa]][[Aaa]]<a> here'])
+    await userEvent.keyboard('{ArrowLeft}{ArrowLeft}')
+    await userEvent.keyboard('{Backspace}')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      see [[Aaa]] here
+
+      """
+    `)
+  })
+
   it('focus: ArrowLeft between two adjacent wikilinks', async () => {
     using fixture = setup('focus', ['see [[Aaa]][[Bbb]]<a> here'])
     expect(await walkKey(fixture, 'ArrowLeft', 4)).toMatchInlineSnapshot(`

--- a/packages/core/src/extensions/inline-marks.ts
+++ b/packages/core/src/extensions/inline-marks.ts
@@ -3,10 +3,23 @@ import { defineMarkSpec, union } from '@prosekit/core'
 import type { MarkName } from './mark-names.ts'
 
 /**
+ * Attribute every unit mark carries so two adjacent units with otherwise equal
+ * attributes (`[[foo]][[foo]]`) stay two text nodes, and each keeps its own
+ * mark view instead of merging into one preview. The parser alternates it
+ * between such neighbours; it carries no meaning on its own and is `null`
+ * everywhere else.
+ */
+export interface MdUnitSlotAttrs {
+  slot?: number | null
+}
+
+const unitSlotAttr = { slot: { default: null } }
+
+/**
  * Attributes of the `mdImage` mark, derived from either `![alt](src "title")`
  * (plus an optional trailing size comment) or a resolved wiki image embed.
  */
-export interface MdImageAttrs {
+export interface MdImageAttrs extends MdUnitSlotAttrs {
   /** The image destination, exactly as written in the source. */
   src: string
   /** The image alt text. */
@@ -35,6 +48,7 @@ function defineMdImage() {
       height: { default: null },
       syntax: { default: null },
       wikiTarget: { default: null },
+      ...unitSlotAttr,
     },
     toDOM: () => ['span', { class: 'md-image' }, 0],
     parseDOM: [{ tag: 'span.md-image' }],
@@ -151,13 +165,13 @@ function defineMdWikilink() {
   return defineMarkSpec<'mdWikilink', MdWikilinkAttrs>({
     name: 'mdWikilink' satisfies MarkName,
     inclusive: false,
-    attrs: { target: { default: '' }, display: { default: '' } },
+    attrs: { target: { default: '' }, display: { default: '' }, ...unitSlotAttr },
     toDOM: () => ['span', { class: 'md-wikilink' }, 0],
     parseDOM: [{ tag: 'span.md-wikilink' }],
   })
 }
 
-export interface MdWikilinkAttrs {
+export interface MdWikilinkAttrs extends MdUnitSlotAttrs {
   target: string
   display: string
 }
@@ -166,7 +180,7 @@ export interface MdWikilinkAttrs {
  * Attributes of the `mdFile` mark: a whole `[label](url)` link that the host's
  * `resolveFileLink` claimed as a file attachment, rendered as a file pill.
  */
-export interface MdFileAttrs {
+export interface MdFileAttrs extends MdUnitSlotAttrs {
   /** The link destination, exactly as written in the source. */
   href: string
   /** The display name: the raw label slice, or the `href` basename when the label is empty. */
@@ -183,6 +197,7 @@ function defineMdFile() {
       href: { default: '' },
       name: { default: '' },
       title: { default: '' },
+      ...unitSlotAttr,
     },
     toDOM: () => ['span', { class: 'md-file' }, 0],
     parseDOM: [{ tag: 'span.md-file' }],
@@ -193,7 +208,7 @@ function defineMdFile() {
  * Attributes of the `mdMath` mark: a whole `$formula$` / `$$formula$$` inline
  * math expression, rendered by `MathMarkView`.
  */
-export interface MdMathAttrs {
+export interface MdMathAttrs extends MdUnitSlotAttrs {
   /** The TeX source between the dollar delimiters. */
   formula: string
 }
@@ -203,7 +218,7 @@ function defineMdMath() {
   return defineMarkSpec<'mdMath', MdMathAttrs>({
     name: 'mdMath' satisfies MarkName,
     inclusive: false,
-    attrs: { formula: { default: '' } },
+    attrs: { formula: { default: '' }, ...unitSlotAttr },
     toDOM: () => ['span', { class: 'md-math' }, 0],
     parseDOM: [{ tag: 'span.md-math' }],
   })

--- a/packages/core/src/extensions/inline-marks.ts
+++ b/packages/core/src/extensions/inline-marks.ts
@@ -9,7 +9,7 @@ import type { MarkName } from './mark-names.ts'
  * between such neighbours; it carries no meaning on its own and is `null`
  * everywhere else.
  */
-export interface MdUnitSlotAttrs {
+interface MdUnitSlotAttrs {
   slot?: number | null
 }
 

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
@@ -509,6 +509,15 @@ describe('image', () => {
     `)
   })
 
+  it('adjacent and identical', () => {
+    expect(parse('![a](x.png)![a](x.png)')).toMatchInlineSnapshot(`
+      "
+      [0, 11]  mdImage(src=x.png,alt=a)
+      [11, 22] mdImage(src=x.png,alt=a,slot=1)
+      "
+    `)
+  })
+
   it('only URL', () => {
     expect(parse('![](image.png)')).toMatchInlineSnapshot(`
       "
@@ -1016,6 +1025,35 @@ describe('wikilink', () => {
       "
       [0, 5]  mdWikilink(target=a)
       [5, 10] mdWikilink(target=b)
+      "
+    `)
+  })
+
+  it('adjacent and identical', () => {
+    expect(parse('[[a]][[a]]')).toMatchInlineSnapshot(`
+      "
+      [0, 5]  mdWikilink(target=a)
+      [5, 10] mdWikilink(target=a,slot=1)
+      "
+    `)
+  })
+
+  it('three adjacent and identical', () => {
+    expect(parse('[[a]][[a]][[a]]')).toMatchInlineSnapshot(`
+      "
+      [0, 5]   mdWikilink(target=a)
+      [5, 10]  mdWikilink(target=a,slot=1)
+      [10, 15] mdWikilink(target=a)
+      "
+    `)
+  })
+
+  it('identical but separated by text', () => {
+    expect(parse('[[a]] [[a]]')).toMatchInlineSnapshot(`
+      "
+      [0, 5]  mdWikilink(target=a)
+      [5, 6]
+      [6, 11] mdWikilink(target=a)
       "
     `)
   })

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.ts
@@ -15,7 +15,7 @@ import type {
 } from './inline-marks.ts'
 import { parseMagicComment, type MagicComment } from './magic-comment.ts'
 import type { MarkChunk } from './mark-chunk.ts'
-import type { MarkName } from './mark-names.ts'
+import { ATOM_MARK_NAMES, type MarkName } from './mark-names.ts'
 import { marksEqual } from './marks-equal.ts'
 import {
   normalizeReferenceLabel,
@@ -114,6 +114,7 @@ export function inlineTextToMarkChunksWithContext(
   const elements = parseInline(text)
   const out: MarkChunk[] = []
   walk(elements, [], 0, text.length, text, marks, out, options, context)
+  separateAdjacentUnits(out)
   return out
 }
 
@@ -655,6 +656,48 @@ function walkWikiEmbed(
   emit(out, node.from, node.to, [...parentMarks, marks.mdWikilink.create({ target, display })])
 }
 
+// The unit mark of a mark set (a wikilink, image, file pill or math run), or
+// undefined for ordinary text. Every chunk of one unit carries the very same
+// mark instance, which is what tells two neighbours apart from one unit split
+// across chunks (math emits its dollar runs separately).
+function getUnitMark(marks: readonly Mark[]): Mark | undefined {
+  return marks.find((mark) => ATOM_MARK_NAMES.has(mark.type.name))
+}
+
+/**
+ * Alternate `slot` on a unit whose mark equals the one on the unit ending
+ * exactly where it starts. `[[foo]][[foo]]` gives both units an equal
+ * `mdWikilink` mark, so ProseMirror merges them into one text node and one mark
+ * view renders one preview for both; unequal marks keep them apart.
+ */
+function separateAdjacentUnits(chunks: MarkChunk[]): void {
+  let previousMark: Mark | undefined
+  let previousEnd = -1
+  let index = 0
+  while (index < chunks.length) {
+    const mark = getUnitMark(chunks[index][2])
+    if (!mark) {
+      index++
+      continue
+    }
+    let end = index
+    while (end < chunks.length && getUnitMark(chunks[end][2]) === mark) end++
+    const merges = previousMark != null && previousEnd === chunks[index][0] && previousMark.eq(mark)
+    const unitMark = merges
+      ? mark.type.create({ ...mark.attrs, slot: mark.attrs.slot == null ? 1 : null })
+      : mark
+    if (unitMark !== mark) {
+      for (let i = index; i < end; i++) {
+        const [from, to, marks] = chunks[i]
+        chunks[i] = [from, to, marks.map((other) => (other === mark ? unitMark : other))]
+      }
+    }
+    previousMark = unitMark
+    previousEnd = chunks[end - 1][1]
+    index = end
+  }
+}
+
 /**
  * Push `[from, to, marks]` to `out`, coalescing with the previous chunk
  * when both share the same mark set. Coalescing keeps the chunk list
@@ -668,8 +711,14 @@ function emit(out: MarkChunk[], from: number, to: number, marks: readonly Mark[]
 
   const last = out.at(-1)
   if (last && last[1] === from && marksEqual(last[2], marks)) {
-    out[out.length - 1] = [last[0], to, last[2]]
-    return
+    // Two units of the same kind with equal attributes must stay two chunks,
+    // even though their mark sets match: `separateAdjacentUnits` tells them
+    // apart by mark instance and then makes the marks differ.
+    const unit = getUnitMark(marks)
+    if (unit == null || getUnitMark(last[2]) === unit) {
+      out[out.length - 1] = [last[0], to, last[2]]
+      return
+    }
   }
   out.push([from, to, marks])
 }

--- a/packages/core/src/extensions/wikilink.test.ts
+++ b/packages/core/src/extensions/wikilink.test.ts
@@ -38,6 +38,14 @@ describe.each(ALL_MODES)('wikilink rendering in %s mode', (mode) => {
     await expect.element(label).toHaveTextContent('Note')
   })
 
+  it('renders one label per unit when two identical wikilinks touch', async () => {
+    using fixture = setupFixture({ extensionOptions: { markMode: mode } })
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('see [[Note]][[Note]] here')))
+    await expect.element(label.first()).toHaveTextContent('Note')
+    expect(label.all()).toHaveLength(2)
+  })
+
   it('renders the alias as the label', async () => {
     using fixture = setupFixture({ extensionOptions: { markMode: mode } })
     const { n } = fixture

--- a/packages/core/src/utils/display-text.test.ts
+++ b/packages/core/src/utils/display-text.test.ts
@@ -33,12 +33,10 @@ describe('getTextblockDisplayText', () => {
     expect(getTextblockDisplayText(fixture.doc.child(0))).toBe('read report.pdf')
   })
 
-  it('cannot split adjacent identical atoms', () => {
+  it('replaces both of two adjacent identical atoms', () => {
     using fixture = setupFixture()
     const { n } = fixture
-    // Adjacent same-attrs units merge into one text node carrying one mark
-    // instance, so the document cannot tell the two units apart.
     fixture.set(n.doc(n.heading({ level: 1 }, '[[a]][[a]]')))
-    expect(getTextblockDisplayText(fixture.doc.child(0))).toBe('a')
+    expect(getTextblockDisplayText(fixture.doc.child(0))).toBe('aa')
   })
 })


### PR DESCRIPTION
Two adjacent units with identical attributes (`[[foo]][[foo]]`) merged into one text node, so one mark view rendered a single preview for both and navigation treated the pair as one unit. The parser now alternates a `slot` attribute between such neighbours, which keeps their marks unequal and gives each unit its own preview.