### PR TITLE
ci: remove test shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,24 +10,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: >-
-    ${{ github.workflow }}-${{
-      (github.event_name == 'push' && 'push') ||
-      (github.event.pull_request.stack == null && github.event.pull_request.number) ||
-      (github.event.pull_request.stack != null && github.event.pull_request.stack.number)
-    }}
-
-  # Only cancel in-progress jobs for stacked PRs that are not the lowest unmerged PR or the top PR.
-  # The lowest unmerged PR is the one whose base matches the stack base.
-  # The top PR is the one whose position matches the stack size.
-  # See: https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/optimizing-ci-for-stacked-pull-requests
-  cancel-in-progress: >-
-    ${{
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.stack != null &&
-      github.event.pull_request.stack.base.ref != github.event.pull_request.base.ref &&
-      github.event.pull_request.stack.position != github.event.pull_request.stack.size
-    }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,12 @@ jobs:
 
   test:
     runs-on: ${{ matrix.config.runner }}
-    name: test-${{ matrix.config.os }}-${{ matrix.config.browser }} (${{ matrix.shard_index }}/${{ matrix.shard_total }})
+    name: test-${{ matrix.config.os }}-${{ matrix.config.browser }}
     timeout-minutes: 15
+
+    permissions:
+      contents: read
+      pull-requests: write
 
     strategy:
       fail-fast: false
@@ -84,8 +88,6 @@ jobs:
           - os: windows
             runner: windows-latest
             browser: chromium
-        shard_index: [1, 2]
-        shard_total: [2]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -98,47 +100,13 @@ jobs:
         run: pnpm run test:install:${{ matrix.config.browser }}
 
       - name: Test
-        run: pnpm run test --shard=${{ matrix.shard_index }}/${{ matrix.shard_total }}
+        run: pnpm run test
         env:
           MEOWDOWN_TEST_BROWSER: ${{ matrix.config.browser }}
           MEOWDOWN_TEST_COVERAGE: ${{ matrix.config.coverage && 'true' || '' }}
 
-      - name: Upload blob report to GitHub Actions Artifacts
-        if: ${{ !cancelled() && matrix.config.coverage }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: blob-report-${{ matrix.config.os }}-${{ matrix.config.browser }}-${{ matrix.shard_index }}
-          path: .vitest-reports/*
-          include-hidden-files: true
-          retention-days: 1
-
-  test-coverage:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    needs: [test]
-
-    permissions:
-      contents: read
-      pull-requests: write
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - uses: ./.github/actions/setup
-
-      - name: Download blob reports from GitHub Actions Artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: blob-report-*
-          path: .vitest-reports
-          merge-multiple: true
-
-      - name: Merge blob reports
-        run: pnpm run test:merge-coverage
-
       - name: Report Coverage
+        if: ${{ !cancelled() && matrix.config.coverage && github.event_name == 'pull_request' }}
         uses: davelosert/vitest-coverage-report-action@8b157684c6a6b259b97d45e72b44242865c0f6a5 # v2.12.2
 
   all-green:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         uses: davelosert/vitest-coverage-report-action@8b157684c6a6b259b97d45e72b44242865c0f6a5 # v2.12.2
 
   all-green:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
 
     if: always()

--- a/.github/workflows/fix.yml
+++ b/.github/workflows/fix.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   fix:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "fix:eslint": "eslint --cache --max-warnings 0 --fix",
     "fix:tsconfig": "monorepo-typescript-references fix",
     "test": "vitest",
-    "test:merge-coverage": "vitest --merge-reports --coverage --reporter=verbose",
     "test:install:chromium": "playwright install chromium",
     "test:install:webkit": "playwright install webkit",
     "test:install:firefox": "playwright install firefox",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ const coverageEnabled = !!process.env.MEOWDOWN_TEST_COVERAGE
 
 export default defineConfig({
   test: {
-    reporters: process.env.GITHUB_ACTIONS ? ['github-actions', 'verbose', 'blob'] : ['default'],
+    reporters: process.env.GITHUB_ACTIONS ? ['github-actions', 'verbose'] : ['default'],
     retry: process.env.CI ? 3 : 0,
     coverage: {
       enabled: coverageEnabled,


### PR DESCRIPTION
Sharding split each browser config into two jobs, but the measured critical path is a Windows job dominated by setup cost, not test time, so the shards bought no wall clock while paying 5 extra runner startups. Dropping them leaves exactly one coverage-producing job, so the blob-report upload/download/merge round-trip and the standalone `test-coverage` job are gone too: `test-linux-chromium` now reports coverage itself.

Note: `test-coverage` is currently a required status check, so it has to be removed from the repository ruleset before this can merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow efficiency by cancelling duplicate pull-request runs.
  * Simplified test execution and integrated coverage reporting directly into test jobs.
  * Streamlined workflow validation and autofix runs.
  * Removed obsolete coverage aggregation and reporting configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->