### PR TITLE
fix: paint the virtual caret above code backgrounds

### DIFF
--- a/packages/core/src/extensions/virtual-caret.test.ts
+++ b/packages/core/src/extensions/virtual-caret.test.ts
@@ -327,6 +327,39 @@ describe('virtual caret when the editor reflows', () => {
   })
 })
 
+describe('virtual caret paints above code backgrounds', () => {
+  function topmostAtCaretCenter(): Element | undefined {
+    const caretElement = getCaretElement()
+    const rect = caretElement.getBoundingClientRect()
+    // `elementsFromPoint` skips `pointer-events: none` elements.
+    caretElement.style.pointerEvents = 'auto'
+    const top = document.elementsFromPoint(
+      rect.left + rect.width / 2,
+      rect.top + rect.height / 2,
+    )[0]
+    caretElement.style.pointerEvents = ''
+    return top
+  }
+
+  it('stays visible inside a code block', async () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.codeBlock('line1\nline2<a>')))
+    fixture.view.focus()
+    await expect.element(caret).toBeVisible()
+    await expect.poll(() => topmostAtCaretCenter() === caret.element()).toBe(true)
+  })
+
+  it('stays visible inside inline code', async () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('a `b<a>c` d')))
+    fixture.view.focus()
+    await expect.element(caret).toBeVisible()
+    await expect.poll(() => topmostAtCaretCenter() === caret.element()).toBe(true)
+  })
+})
+
 describe('virtual caret tails (hide mode)', () => {
   it('shows a right tail after a closing run', async () => {
     using fixture = setupMode('hide', 'foo **bold**<a> bar')

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -170,9 +170,15 @@
    * browser's editing behavior. The caret is positioned against the layer;
    * the extension stamps `data-focused` on the layer while the editor has
    * focus.
+   *
+   * A positive z-index paints the layer above the positioned `.ProseMirror`
+   * (prosemirror-view sets `position: relative`); at stack level 0 the editor
+   * would win on DOM order and its opaque code backgrounds would cover the
+   * caret.
    * ------------------------------------------------------------------------- */
   .md-virtual-caret-layer {
     position: relative;
+    z-index: 1;
     width: 0;
     height: 0;
     overflow: visible;


### PR DESCRIPTION
The virtual caret disappears when the caret sits inside inline code or a code block: the editor element is `position: relative` (set by prosemirror-view), so the caret layer rendered before it paints beneath the editor's opaque code backgrounds. Lift the caret layer with `z-index: 1` and add browser tests that probe the painted element at the caret.