### PR TITLE
docs: slim down the README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-./packages/react/README.md
+# Meowdown
+
+A hybrid (live-preview) Markdown editor: the document stays Markdown text,
+rendered in place as rich content.
+
+[**Live demo**](https://meowdown.vercel.app/)
+
+## Packages
+
+- [**@meowdown/core**](https://www.npmjs.com/package/@meowdown/core): the framework-free editor engine (parsing, serializing, shortcuts, styling)
+- [**@meowdown/react**](https://www.npmjs.com/package/@meowdown/react): React components (`MeowdownEditor`, `MarkdownView`, `WikilinkHoverCard`)
+- [**@meowdown/markdown**](https://www.npmjs.com/package/@meowdown/markdown): the Lezer grammar for meowdown's Markdown dialect
+
+## License
+
+MIT

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,8 @@
 # @meowdown/core
 
-The engine powering the editor in [`@meowdown/react`](https://www.npmjs.com/package/@meowdown/react): a hybrid (live-preview) Markdown editor core built on ProseKit and Lezer.
+The engine behind Meowdown, a hybrid (live-preview) Markdown editor: Markdown
+parsing, serializing, editing commands, and a default theme. Framework-free;
+pairs with [@meowdown/react](https://www.npmjs.com/package/@meowdown/react).
 
 [**Live demo**](https://meowdown.vercel.app/)
 
@@ -25,40 +27,22 @@ editor.mount(document.querySelector<HTMLElement>('#editor')!)
 const markdown = docToMarkdown(editor.state.doc)
 ```
 
-## Supported Markdown features
+## Markdown features
 
-- CommonMark
-  - ATX headings (`# Heading 1`, `## Heading 2`, etc.)
-  - Setext headings (`Heading 1\n===`, `Heading 2\n---`)
-  - Bullet lists (`- item`, `* item`, `+ item`)
-  - Ordered lists (`1. item`, `2) item`, etc.)
-  - Blockquotes (`> quote`)
-  - Fenced code blocks (` ```lang\ncode\n``` `), keeping tilde fences (`~~~`) and fence lengths through a round-trip
-  - Indented code blocks (four leading spaces)
-  - Thematic breaks (`---`, `***`, `___`)
-  - Bold (`**bold**`), italic (`*italic*`), and inline code
-  - Inline and reference links (`[text](url)`, `[text][label]`, `[label][]`, `[label]`)
-  - Inline and reference images (`![alt](src)`, `![alt][label]`)
-  - Link reference definitions (`[label]: url "title"`)
-  - Autolinks (`<https://example.com>`)
-  - Hard line breaks
-- GitHub Flavored Markdown (GFM)
-  - Tables, including column alignment (`:--`, `:-:`, `--:`)
-  - Strikethrough (`~~text~~`)
-  - Task lists (`- [ ]`, `- [x]`)
-  - Autolinks for `www.`, scheme, and email URLs
-- Wikilinks (`[[target]]` and `[[target|alias]]`)
-- Highlight (`==highlight==`)
+CommonMark and GFM, plus:
+
+- Wikilinks (`[[target]]`, `[[target|alias]]`)
+- Wiki embeds (`![[path]]`)
 - Tags (`#tag`)
-- Bare-domain autolinks (`google.com`, `sub.domain.io/path`)
-- Math, compiled by KaTeX to native MathML (no stylesheet or fonts needed)
-  - Inline math (`$x$` and `$$x$$`), Pandoc-style delimiter rules so `$20,000 and $30,000` stays plain text
-  - Display math (`$$` fences on their own lines), kept as `$$` through a round-trip
-  - ` ```math ` fenced code blocks
+- Highlight (`==highlight==`)
+- Math (`$x$`, `$$x$$`, and ` ```math ` fenced code blocks), rendered as native MathML
+- Bare-domain autolinks (`google.com`), behind a curated TLD allowlist so `README.md` and `node.js` stay plain text
 
 ## Keyboard shortcuts
 
-`Mod` is Cmd on macOS and Ctrl elsewhere. Each formatting shortcut inserts or removes the literal Markdown delimiters around the selection; each heading shortcut toggles the current block to that level (or back to a paragraph).
+`Mod` is Cmd on macOS and Ctrl elsewhere. Formatting shortcuts insert or remove
+the literal Markdown delimiters around the selection; heading shortcuts toggle
+the current block to that level (or back to a paragraph).
 
 | Key                    | Action                                                    | Markdown            |
 | ---------------------- | --------------------------------------------------------- | ------------------- |
@@ -89,57 +73,30 @@ const markdown = docToMarkdown(editor.state.doc)
 | `Shift-Meta-ArrowDown` | Select to the document end                                |                     |
 | `Escape`               | Collapse the selection                                    |                     |
 
-The list-type toggles wrap the current block, convert a list of a different kind in place, and unwrap a list of the same kind back to a paragraph. `Mod-Shift-7/8/9` follow the physical digit key, so they work on layouts where Shift+digit types punctuation. `Alt-ArrowUp`/`Alt-ArrowDown` move a list item together with its nested children, or swap a non-list block with its neighbor. The `Meta-Arrow` document-boundary motions (Cmd on macOS) are bound explicitly because browsers do not reliably perform the native move (WebKit gives up when the document starts with a list marker). Typing `[` over a selection wraps it into an open wikilink (`[[selection`) with the wikilink menu searching it.
-
-`EDITOR_KEY_BINDINGS` is a literal (`as const`) object mapping every key above to its description, for host settings UIs and keybinding-collision checks.
+`Mod-Shift-7/8/9` wrap the current block, convert a list of a different kind in
+place, and unwrap a list of the same kind back to a paragraph. `Alt-ArrowUp` /
+`Alt-ArrowDown` move the block or list item with its nested children. Typing `[`
+over a selection wraps it into an open wikilink (`[[selection`) with the
+wikilink menu searching it. `EDITOR_KEY_BINDINGS` exports this table as a
+literal object for host settings UIs.
 
 ## Round-trip fidelity
 
-[`checkRoundTrip(markdown)`](https://npmx.dev/package-docs/@meowdown%2Fcore#function-checkRoundTrip) reports how faithfully markdown survives a parse-then-serialize round trip: `'exact'`, `'normalizing'`, or `'lossy'`. Hosts that keep markdown on disk can gate saves on it, opening lossy files read-only so a save never rewrites content.
+[`checkRoundTrip(markdown)`](https://npmx.dev/package-docs/@meowdown%2Fcore#function-checkRoundTrip) reports how faithfully Markdown survives a parse-then-serialize round trip: `'exact'`, `'normalizing'`, or `'lossy'`.
 
 ## Styling
 
-`@meowdown/core/style.css` ships a default editor theme. Colors use `light-dark()`, so they follow the page's `color-scheme` (set `color-scheme: light dark` on `:root` for automatic dark mode). Theme it by overriding the `--meowdown-*` variables on `:root` or any ancestor. The full list, with a one-line description and default for each, lives in the commented `:root` block at the top of [`style.css`](./src/style.css), which is the single source of truth.
+`@meowdown/core/style.css` ships a default theme. Colors use `light-dark()`, so they follow the page's `color-scheme` (set `color-scheme: light dark` on `:root` for automatic dark mode). Override the `--meowdown-*` variables on `:root` or any ancestor; the full list, with a one-line description and default for each, lives in the commented `:root` block at the top of `style.css`, which is the single source of truth.
 
-meowdown's CSS is wrapped in a cascade layer, `@layer meowdown` (with sub-layers `meowdown.base` for the bundled ProseMirror / prosekit base styles, `meowdown.theme` for the variables, and `meowdown.editor` for the editor rules). Because an un-layered rule always beats a layered one, **any plain rule you write overrides meowdown with no `!important` and no specificity hacks** (e.g. `.ProseMirror h1 { font-size: 2rem }` wins over meowdown's layered heading rule). Put your overrides outside any `@layer`, or in a layer you declare after `meowdown`.
+CSS is wrapped in `@layer meowdown` (sub-layers `meowdown.base`, `meowdown.theme`, `meowdown.editor`). An un-layered rule always beats a layered one, so any plain rule you write overrides meowdown with no `!important` and no specificity hacks. Put your overrides outside any `@layer`, or in a layer you declare after `meowdown`.
 
-**With Tailwind CSS v4**, import `@meowdown/core/style.css` _after_ `@import 'tailwindcss'` so the `meowdown` layer sorts after Tailwind's `theme` / `base` / `components` / `utilities`. That keeps meowdown's editor styles from being reset by Tailwind's `base` (Preflight) while your own un-layered rules still win. One caveat: with that order the `meowdown` layer also sorts after `utilities`, so a Tailwind utility _class_ placed directly on an editor element will not beat meowdown. If you need utilities to win (while meowdown still beats Preflight), declare the layer order yourself with `utilities` last, referencing the umbrella `meowdown` layer (not its sub-layers). Doing this at the top of your CSS also pins the order even when meowdown's stylesheet is code-split / lazy-loaded:
+**With Tailwind CSS v4**, import `@meowdown/core/style.css` _after_ `@import 'tailwindcss'` so the `meowdown` layer sorts after Tailwind's `base` (Preflight). If you also need Tailwind utilities to win over meowdown (while meowdown still beats Preflight), declare the layer order yourself:
 
 ```css
 @layer theme, base, components, meowdown, utilities;
 @import 'tailwindcss';
 @import '@meowdown/core/style.css';
 ```
-
-Two things the variable list cannot show: `--meowdown-gutter` is the horizontal editor padding, applied to the editable root's `.meowdown-content` class, not `.ProseMirror`, so the block handle's drag preview stays unpadded; floating UI such as the block handle lives inside it, so keep it at least `3.5rem`. `defineEditorExtension` puts `.meowdown-content` on the editable root itself, so every mount (the headless quick start above included) is padded from the first paint. The selection variables (`--meowdown-selection`, `--meowdown-node-outline`, `--meowdown-node-selection`) are standalone, not derived from `--meowdown-accent`, so selection can be restyled independently.
-
-Tags (`#tag`) render as pills via the `.md-tag` class, tinted from `--meowdown-accent`. Wire click handling with `defineTagClickHandler(({ tag, event }) => ...)` (or `@meowdown/react`'s `onTagClick` prop); `tag` is read from the rendered text without the leading `#`.
-
-Wikilinks (`[[target]]`/`[[target|alias]]`) render in place via a mark view as an immutable label (the alias, or the target when there is no alias), with the raw source hidden in hide and focus modes and shown dimmed in show mode. The label uses the `.md-wikilink-view-label` class, dashed-underlined and colored by `--meowdown-accent`. In every mark mode the link is a single immutable caret stop: arrowing onto it selects the whole source (ringed with `--meowdown-node-outline` in hide and focus, the native selection over the visible source in show), and Backspace/Delete remove it as a unit, and `Enter` on the selected unit fires the click handler instead of replacing it. A caret that lands inside the hidden source anyway, from a host command or a position remapped by undo or paste, moves back out to a unit edge, so no keystroke writes into the source. Wire click navigation with `defineWikilinkClickHandler(({ target, event }) => ...)` (or `@meowdown/react`'s `onWikilinkClick` prop); `Mod-Enter` with the caret on a wikilink, tag, or Markdown link fires the same handler, with the `KeyboardEvent` as `event`. `defineWikilinkHoverHandler` reports the hovered target, source range, and visible anchor element, then reports `undefined` on leave, deletion, replacement, or editor teardown.
-
-Markdown links render the label as an `<a href>` with the `.md-link` class, colored by `--meowdown-accent`; the source syntax dims in show mode and hides in hide and focus modes. This includes inline links (`[text](url)`), full references (`[text][label]`), collapsed references (`[label][]`), and shortcut references (`[label]`). Definitions use CommonMark label normalization and first-definition-wins semantics. Definitions remain visible and editable as literal source in the editor, while unresolved references remain literal and preserve nested formatting. Reference destinations are read-only through the link commands and menu because editing one safely requires a definition-aware workflow. Citing links update after a 200 ms pause in definition editing, which coalesces large fan-out restyles; definition-shaped textblocks longer than 1,024 characters stay literal and are not indexed. `[[target]]` continues to use meowdown's wikilink syntax. Wire click handling with `defineLinkClickHandler(({ href, event }) => ...)` (or `@meowdown/react`'s `onLinkClick` prop).
-
-Low-level renderers can import `collectReferenceDefinitions` and `inlineTextToMarkChunksWithContext` directly from `@meowdown/core` to share the editor's definition collection and reference resolution.
-
-Bare URLs autolink without `[text](url)` brackets and share the same `.md-link` rendering and click handling: a scheme URL (`https://example.com`), an angle autolink (`<https://example.com>`), a `www.` host (`www.example.com`), an email (`me@example.com`), and a bare domain (`google.com`, `sub.domain.io/path`). Bare domains are matched against a curated list of common TLDs, so file names and prose keep their dots without linkifying (`README.md`, `node.js`, `i.e.` stay plain text); reach for `[text](url)` or `<url>` to link anything off that list. Autolinks are derived live from the text, so editing one re-evaluates it; the caret sitting inside a link never un-links it.
-
-Inline and reference images (`![alt](src)`, `![alt][label]`, `![label][]`, and `![label]`) stay literal text and render in place via a mark view, with their raw source hidden in hide and focus modes. Add an inline image with [`defineImage`](https://npmx.dev/package-docs/@meowdown%2Fcore#function-defineImage) (or `@meowdown/react`'s image props) and wire click handling with [`defineImageClickHandler`](https://npmx.dev/package-docs/@meowdown%2Fcore#function-defineImageClickHandler) (`@meowdown/react`'s `onImageClick` prop).
-
-Pasted or dropped files persist through [`defineFilePaste`](https://npmx.dev/package-docs/@meowdown%2Fcore#function-defineFilePaste) (or `@meowdown/react`'s `onFilePaste` prop): the handler persists each file and returns its markdown destination. An image (`image/*` MIME type) inserts `![](src)`; any other file inserts a `[name](src)` link; multiple files insert one link per line, in the order they appear in the drop. Without `onFilePaste`, file events are left to the browser's default handling. A host command that inserts file links itself (e.g. an attach-file picker) can build the same markdown with [`buildFileMarkdown`](https://npmx.dev/package-docs/@meowdown%2Fcore#function-buildFileMarkdown).
-
-A host can render chosen file links as inline **file pills**: pass `resolveFileLink` to [`defineEditorExtension`](https://npmx.dev/package-docs/@meowdown%2Fcore#function-defineEditorExtension) (or `@meowdown/react`'s `resolveFileLink` prop) to claim inline or resolved reference links by their href (e.g. everything under `assets/`), and add [`defineFileView`](https://npmx.dev/package-docs/@meowdown%2Fcore#function-defineFileView) to render each claimed link as a pill: a file-kind icon, the name, and the size supplied (possibly async) by `resolveFileInfo`. The markdown text is untouched, and a claimed link behaves like an image: one caret unit with an editable source, clicks (and `Enter` on the selected pill or `Mod-Enter` with the caret on it) reported through [`defineFileClickHandler`](https://npmx.dev/package-docs/@meowdown%2Fcore#function-defineFileClickHandler) (`@meowdown/react`'s `onFileClick`) rather than the link click handler, and no link hover or edit menu.
-
-Rendered images are resizable: drag the corner handle and the chosen size is written back into the source as a trailing comment, `![alt](src)<!-- {"width":320,"height":240} -->`, which round-trips as plain Markdown. A comment immediately after an image is folded into its mark and drives the image's `width` and `height` attributes, so the box keeps its dimensions before the image loads; any other comment stays literal text.
-
-GFM table column alignment (`| :-: |` in the delimiter row) is kept as an `align` attribute on every cell and rendered through a `data-align` DOM attribute (`text-align` in the bundled stylesheet). Alignment is a column property: the header row's cells carry the source of truth, data cells (including rows inserted later) follow it automatically. Change it with the `setTableColumnAlign` command (`editor.commands.setTableColumnAlign('center')`, `null` resets to `---`), and read the alignment of the selection's column with [`getTableColumnAlign`](https://npmx.dev/package-docs/@meowdown%2Fcore#function-getTableColumnAlign).
-
-Pasting a lone tweet or YouTube link can auto-embed it: [`defineEmbedPaste`](https://npmx.dev/package-docs/@meowdown%2Fcore#function-defineEmbedPaste) (`@meowdown/react`'s `embedPaste` prop, on by default).
-
-The clipboard pipeline ships inside `defineEditorExtension`. Copying writes two flavors: `text/html` is standard semantic HTML (`<h3>`, `<ol><li>`, `<strong>`, real `<table>`) with the Markdown source preserved in `data-md` attributes so meowdown-to-meowdown pastes stay byte-exact, and `text/plain` is Markdown, where opening markers such as ATX heading and blockquote prefixes are kept when the selection includes the block's content start, while fenced code blocks and tables keep their markers only when selected completely; the mark mode decides the inline layer (hide strips the syntax characters, focus and show keep the full source). Pasting picks a path by flavor: meowdown's own HTML (stamped `data-meowdown`) parses natively; foreign rich-text HTML, including other ProseMirror editors, converts to Markdown through the unified (rehype / remark) pipeline; plain text follows Markdown newline semantics (a blank line separates paragraphs without inserting an empty one, a single newline stays a soft break) while a Shift-paste keeps ProseMirror's line-per-paragraph behavior; a paste landing in a code block stays plain text.
-
-Enter at the end of the document's first heading (the title line) can start a fresh empty bullet instead of a plain paragraph: [`defineBulletAfterHeading`](https://npmx.dev/package-docs/@meowdown%2Fcore#function-defineBulletAfterHeading) (`@meowdown/react`'s `bulletAfterHeading` prop). Not part of `defineEditorExtension`.
-
-An arrow press that can move the caret no further can notify the host, so it can move focus elsewhere (a previous/next note or page): [`defineExitBoundaryHandler`](https://npmx.dev/package-docs/@meowdown%2Fcore#function-defineExitBoundaryHandler) (`@meowdown/react`'s `onExitBoundary` prop). Not part of `defineEditorExtension`.
 
 ## API
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -29,7 +29,7 @@ const markdown = docToMarkdown(editor.state.doc)
 
 ## Markdown features
 
-CommonMark and GFM, plus:
+[CommonMark](https://commonmark.org/) and [GFM](https://github.github.com/gfm/), plus:
 
 - Wikilinks (`[[target]]`, `[[target|alias]]`)
 - Wiki embeds (`![[path]]`)

--- a/packages/core/src/extensions/image.ts
+++ b/packages/core/src/extensions/image.ts
@@ -377,7 +377,13 @@ class ImageMarkView implements MarkView {
   }
 }
 
-/** Inline image/embed rendering: a mark view on the `mdImage` mark. */
+/**
+ * Inline image/embed rendering: a mark view on the `mdImage` mark. Images
+ * render in place from their literal Markdown source. Drag a rendered image's
+ * corner handle to write the size back into the source as a trailing comment,
+ * `![alt](src)<!-- {"width":320,"height":240} -->`, which round-trips as
+ * plain Markdown.
+ */
 export function defineImage(options: ImageOptions = {}): PlainExtension {
   return defineMarkView({
     name: 'mdImage' satisfies MarkName,

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.ts
@@ -74,6 +74,10 @@ export type FileLinkResolver = (link: FileLinkPayload) => boolean
 
 /** Host options that influence inline parsing. */
 export interface FileLinkOptions {
+  /**
+   * Claim `[label](url)` links as file attachments; see {@link FileLinkResolver}.
+   * Read once when the editor is created.
+   */
   resolveFileLink?: FileLinkResolver
 }
 

--- a/packages/core/src/extensions/link-click.ts
+++ b/packages/core/src/extensions/link-click.ts
@@ -20,6 +20,11 @@ export interface LinkCopyPayload {
 
 export type LinkCopyHandler = (payload: LinkCopyPayload) => void
 
+/**
+ * Call `onClick` when the user clicks a rendered Markdown link
+ * (`[text](url)`), or presses `Mod-Enter` with the caret on one. The `event`
+ * is the originating `MouseEvent` or `KeyboardEvent`.
+ */
 export function defineLinkClickHandler(onClick: LinkClickHandler): PlainExtension {
   return defineMarkClickHandler<string>({
     key: linkClickKey,

--- a/packages/core/src/extensions/tag-click.ts
+++ b/packages/core/src/extensions/tag-click.ts
@@ -37,6 +37,11 @@ export interface TagClickPayload {
 
 export type TagClickHandler = (payload: TagClickPayload) => void
 
+/**
+ * Call `onClick` when the user clicks a rendered `#tag`, or presses
+ * `Mod-Enter` with the caret on one. The `tag` is read from the rendered text
+ * without the leading `#`.
+ */
 export function defineTagClickHandler(onClick: TagClickHandler): PlainExtension {
   return defineMarkClickHandler<string>({
     key: tagClickKey,

--- a/packages/core/src/extensions/wikilink-click.ts
+++ b/packages/core/src/extensions/wikilink-click.ts
@@ -48,6 +48,11 @@ export interface WikilinkClickPayload {
 
 export type WikilinkClickHandler = (payload: WikilinkClickPayload) => void
 
+/**
+ * Call `onClick` when the user clicks a rendered wikilink label, or presses
+ * `Mod-Enter` with the caret on one. The `event` is the originating
+ * `MouseEvent` or `KeyboardEvent`.
+ */
 export function defineWikilinkClickHandler(onClick: WikilinkClickHandler): PlainExtension {
   return defineMarkClickHandler<string>({
     key: wikilinkClickKey,

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -11,3 +11,10 @@ import { gfmParser } from '@meowdown/markdown'
 
 const tree = gfmParser.parse('Meeting with [[Ada Lovelace|Ada]]')
 ```
+
+## Exports
+
+- `gfmParser` / `gfmBlockOnlyParser`: the full and block-only Markdown parsers
+- `parseInline` / `collectInlineElements`: low-level inline syntax parsing
+- `getAutolinkHref`: bare-domain autolink matching against the TLD allowlist
+- `LEZER_NODE_IDS`: the node id table shared with `@meowdown/core`

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -1,6 +1,6 @@
 # @meowdown/markdown
 
-The [`@lezer/markdown`](https://github.com/lezer-parser/markdown) grammar layer behind [`@meowdown/core`](https://www.npmjs.com/package/@meowdown/core): GFM plus meowdown's inline syntax (wiki links, wiki embeds, hashtags, `==highlight==`, `$math$`, bare autolinks).
+The [`@lezer/markdown`](https://github.com/lezer-parser/markdown) grammar layer behind [`@meowdown/core`](https://www.npmjs.com/package/@meowdown/core): [GFM](https://github.github.com/gfm/) plus meowdown's inline syntax (wiki links, wiki embeds, hashtags, `==highlight==`, `$math$`, bare autolinks).
 
 ```sh
 npm install @meowdown/markdown

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -27,9 +27,6 @@ export function App() {
 ## Usage
 
 ```tsx
-import '@meowdown/core/style.css'
-import '@meowdown/react/style.css'
-
 import { MeowdownEditor, type EditorHandle } from '@meowdown/react'
 import { useRef, useCallback } from 'react'
 
@@ -50,125 +47,27 @@ export function App() {
 }
 ```
 
-## API
+## Components
 
-See the full API reference [here](https://npmx.dev/package-docs/@meowdown%2Freact/).
+| Component | Description |
+| --- | --- |
+| `MeowdownEditor` | The editor. Callbacks and resolvers must be stable; pass them via `useCallback`. |
+| `MarkdownView` | Read-only Markdown renderer. `interactive={false}` renders passive content for previews. |
+| `WikilinkHoverCard` | Mount inside `MeowdownEditor`; renders host content for the hovered wiki link's `target`. Return `null` to render no card. |
 
-Slash menu host items can include `keywords` to match hidden terms without changing the displayed label.
+Common `MeowdownEditor` props:
 
-The caret glides between positions by default; pass `caretGlide={false}` to move it instantly (hosts can also tune the duration via the `--meowdown-caret-glide` CSS variable).
+| Prop | What it does |
+| --- | --- |
+| `mode` | `'focus'` (default), `'show'`, or `'hide'`: how much Markdown syntax stays in view |
+| `searchQuery` / `onSearchChange` | Find in document, with `EditorHandle.findNext()` / `findPrevious()` |
+| `onWikilinkClick` / `onLinkClick` / `onTagClick` / `onImageClick` / `onFileClick` | Click handling for the rendered atoms |
+| `resolveImageUrl` / `resolveWikiEmbed` / `resolveFileLink` / `resolveFileInfo` | Resolve and classify local content |
+| `onFilePaste` | Persist pasted or dropped files |
+| `onSlashMenuSearch` / `onTagSearch` / `onWikilinkSearch` / `onSelectionMenuSearch` | Search menus for `/`, `#`, `[[`, and selection commands |
+| `readOnly` / `placeholder` / `blockHandle` / `caretGlide` / `embedPaste` / `linkPaste` / `bulletAfterHeading` | Behavior toggles |
 
-`MarkdownView` folds collapsed (`+`) bullets like the editor; pass `expandCollapsed` to render them expanded at every depth, for views that show slices of a note (e.g. a backlinks panel) where the source's fold state must not hide the content the view exists to show.
-
-Both `MeowdownEditor` and `MarkdownView` resolve CommonMark full, collapsed,
-and shortcut reference links and images. The editor keeps reference definitions
-visible as editable source and preserves them through `getMarkdown()`.
-`MarkdownView` uses the same first-definition-wins resolution but omits
-definition paragraphs from its rendered output. Reference links are read-only
-in the editor's link menu; edit their definition source to change the target.
-
-### Wiki embeds
-
-Obsidian-style wiki embeds (`![[path]]`, with optional `|width` or
-`|widthxheight`) stay literal and editable unless the host classifies them.
-`resolveWikiEmbed` is a pure, creation-time resolver: return an image, file, or
-note result to reuse the corresponding Meowdown atom and its existing click
-hook; return `undefined` for missing or ambiguous targets.
-
-```tsx
-<MeowdownEditor
-  initialMarkdown="![[assets/photo.png|320]]"
-  resolveWikiEmbed={({ target }) => (target.endsWith('.png') ? { kind: 'image' } : undefined)}
-  resolveImageUrl={resolveLocalImageUrl}
-  onImageClick={openLightbox}
-/>
-```
-
-Use `EditorHandle.revealHeading('#Section%20name')` to move the selection to a
-matching heading and scroll it into view after following a heading link.
-
-Both `MeowdownEditor` and the read-only `MarkdownView` accept
-`resolveFileLink`. Return `true` to render a standard `[label](path)` Markdown
-link with the same file pill, metadata resolver, and click hook used by wiki
-file embeds; return `false` to keep it as a normal link.
-
-```tsx
-<MarkdownView
-  markdown="[Quarterly report](docs/report.pdf)"
-  resolveFileLink={({ href }) => href.startsWith('docs/')}
-  resolveFileInfo={resolveLocalFileInfo}
-  onFileClick={openLocalFile}
-/>
-```
-
-### Find in document
-
-`searchQuery` highlights every match and selects the first one at or after the
-caret; changing it re-anchors from wherever the selection is, so refining a
-query keeps the match the user is looking at. A query that matches nothing
-collapses the previous match selection to a caret, and an empty string (the
-default) clears the highlights and leaves the selection alone. `onSearchChange` reports
-`{ total, active }` for a match counter (`active` is one-based; `0` means the
-selection is not on a match), and `EditorHandle.findNext()` /
-`EditorHandle.findPrevious()` walk the matches and wrap at the document edges.
-The query is applied through `useDeferredValue`, so fast typing may skip
-intermediate values on a slow device.
-
-```tsx
-const [query, setQuery] = useState('')
-const [status, setStatus] = useState({ total: 0, active: 0 })
-
-<input value={query} onChange={(event) => setQuery(event.target.value)} />
-<span>{status.active} / {status.total}</span>
-<MeowdownEditor
-  handleRef={editorRef}
-  searchQuery={query}
-  onSearchChange={setStatus}
-/>
-```
-
-### Wiki-link hover cards
-
-Mount `WikilinkHoverCard` inside `MeowdownEditor` and render host-owned preview
-content from the hovered wiki link's `target`. Returning `null` renders no
-card. The render function may also return a promise: the card stays closed
-until it resolves, resolving to `null` (or rejecting) renders no card, and a
-result that lands after the pointer moved on is discarded, so a host can look
-up local content without ever flashing an empty card.
-
-```tsx
-<MeowdownEditor initialMarkdown="See [[Project plan]]">
-  <WikilinkHoverCard>
-    {async (hit) => {
-      const note = await readLocalNote(hit.target)
-      return note == null ? null : <LocalNotePreview note={note} />
-    }}
-  </WikilinkHoverCard>
-</MeowdownEditor>
-```
-
-For local-only passive preview content, render Markdown with interaction
-disabled: the tree contains no anchors or focusable controls, and recognized
-tweet and YouTube embeds are omitted before any image resolver runs. Supply a
-resolver that accepts only trusted local image sources.
-
-```tsx
-<MarkdownView markdown={markdown} interactive={false} resolveImageUrl={resolveLocalImageUrl} />
-```
-
-### Mermaid code blocks
-
-Fenced `mermaid` code blocks render as diagrams in both `MeowdownEditor` and
-`MarkdownView`. The editor shows only the preview while the caret is outside
-the block, then shows source and a live preview while editing it.
-
-Rendering uses `beautiful-mermaid`, which currently supports Flowchart, State,
-Sequence, Class, ER, and XY Chart diagrams. Unsupported syntax renders an error
-instead of an empty preview. Override `--meowdown-mermaid-bg`,
-`--meowdown-mermaid-fg`, `--meowdown-mermaid-line`,
-`--meowdown-mermaid-accent`, `--meowdown-mermaid-muted`,
-`--meowdown-mermaid-surface`, `--meowdown-mermaid-border`, or
-`--meowdown-mermaid-error` to customize the diagram palette.
+Every prop, callback, and `EditorHandle` method is documented in the [API reference](https://npmx.dev/package-docs/@meowdown%2Freact/).
 
 ## Styling
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -49,23 +49,23 @@ export function App() {
 
 ## Components
 
-| Component | Description |
-| --- | --- |
-| `MeowdownEditor` | The editor. Callbacks and resolvers must be stable; pass them via `useCallback`. |
-| `MarkdownView` | Read-only Markdown renderer. `interactive={false}` renders passive content for previews. |
+| Component           | Description                                                                                                                |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `MeowdownEditor`    | The editor. Callbacks and resolvers must be stable; pass them via `useCallback`.                                           |
+| `MarkdownView`      | Read-only Markdown renderer. `interactive={false}` renders passive content for previews.                                   |
 | `WikilinkHoverCard` | Mount inside `MeowdownEditor`; renders host content for the hovered wiki link's `target`. Return `null` to render no card. |
 
 Common `MeowdownEditor` props:
 
-| Prop | What it does |
-| --- | --- |
-| `mode` | `'focus'` (default), `'show'`, or `'hide'`: how much Markdown syntax stays in view |
-| `searchQuery` / `onSearchChange` | Find in document, with `EditorHandle.findNext()` / `findPrevious()` |
-| `onWikilinkClick` / `onLinkClick` / `onTagClick` / `onImageClick` / `onFileClick` | Click handling for the rendered atoms |
-| `resolveImageUrl` / `resolveWikiEmbed` / `resolveFileLink` / `resolveFileInfo` | Resolve and classify local content |
-| `onFilePaste` | Persist pasted or dropped files |
-| `onSlashMenuSearch` / `onTagSearch` / `onWikilinkSearch` / `onSelectionMenuSearch` | Search menus for `/`, `#`, `[[`, and selection commands |
-| `readOnly` / `placeholder` / `blockHandle` / `caretGlide` / `embedPaste` / `linkPaste` / `bulletAfterHeading` | Behavior toggles |
+| Prop                                                                                                          | What it does                                                                       |
+| ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `mode`                                                                                                        | `'focus'` (default), `'show'`, or `'hide'`: how much Markdown syntax stays in view |
+| `searchQuery` / `onSearchChange`                                                                              | Find in document, with `EditorHandle.findNext()` / `findPrevious()`                |
+| `onWikilinkClick` / `onLinkClick` / `onTagClick` / `onImageClick` / `onFileClick`                             | Click handling for the rendered atoms                                              |
+| `resolveImageUrl` / `resolveWikiEmbed` / `resolveFileLink` / `resolveFileInfo`                                | Resolve and classify local content                                                 |
+| `onFilePaste`                                                                                                 | Persist pasted or dropped files                                                    |
+| `onSlashMenuSearch` / `onTagSearch` / `onWikilinkSearch` / `onSelectionMenuSearch`                            | Search menus for `/`, `#`, `[[`, and selection commands                            |
+| `readOnly` / `placeholder` / `blockHandle` / `caretGlide` / `embedPaste` / `linkPaste` / `bulletAfterHeading` | Behavior toggles                                                                   |
 
 Every prop, callback, and `EditorHandle` method is documented in the [API reference](https://npmx.dev/package-docs/@meowdown%2Freact/).
 


### PR DESCRIPTION
Rewrite the package READMEs to focus on behavior, not implementation. The core README drops its implementation-heavy feature prose (mark modes, caret mechanics, the clipboard pipeline); the react README drops its feature examples in favor of a components/props overview; the root README becomes a short project intro instead of a copy of the react README. Behavior that was only documented in the README moved into jsdoc on the affected APIs first, so nothing is lost from the API reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an introductory README with a live demo link, package overview, and MIT license.
  * Clarified Markdown editing capabilities, supported syntax, keyboard shortcuts, styling, themes, and round-trip fidelity.
  * Expanded guidance for images, file links, link clicks, tag interactions, and wikilink interactions.
  * Documented Markdown parsers, inline helpers, autolinking, shared syntax references, and available React components.
  * Simplified usage examples and linked to the generated API reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->