### PR TITLE
fix: cycle a nested list item back to a bullet with `cycleBulletOrderedList`

### DIFF
--- a/packages/core/src/extensions/list.test.ts
+++ b/packages/core/src/extensions/list.test.ts
@@ -12,7 +12,7 @@ describe('input rule', () => {
     fixture.set(n.doc(n.paragraph('<a>todo')))
     fixture.view.focus()
     await userEvent.keyboard('+ ')
-    expect(docToMarkdown(fixture.doc)).toBe('+ [ ] todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('wraps a block into a plain bullet on `- ` (not a checkbox task)', async () => {
@@ -21,7 +21,7 @@ describe('input rule', () => {
     fixture.set(n.doc(n.paragraph('<a>todo')))
     fixture.view.focus()
     await userEvent.keyboard('- ')
-    expect(docToMarkdown(fixture.doc)).toBe('- todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 })
 
@@ -31,7 +31,7 @@ describe('commands', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('todo<a>')))
     fixture.editor.commands.wrapInCircleTask()
-    expect(docToMarkdown(fixture.doc)).toBe('+ [ ] todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('wrapInSquareTask makes a square checkbox task', () => {
@@ -39,7 +39,7 @@ describe('commands', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('todo<a>')))
     fixture.editor.commands.wrapInSquareTask()
-    expect(docToMarkdown(fixture.doc)).toBe('- [ ] todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('converts a square checkbox task to a circle checkbox task, keeping checked', () => {
@@ -47,7 +47,7 @@ describe('commands', () => {
     const { n } = fixture
     fixture.set(n.doc(n.list({ kind: 'task', checked: true }, n.paragraph('done<a>'))))
     fixture.editor.commands.wrapInCircleTask()
-    expect(docToMarkdown(fixture.doc)).toBe('+ [x] done\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('converts a circle checkbox task back to a square checkbox task, keeping checked', () => {
@@ -55,7 +55,7 @@ describe('commands', () => {
     const { n } = fixture
     fixture.set(n.doc(n.list({ kind: 'task', marker: '+', checked: true }, n.paragraph('done<a>'))))
     fixture.editor.commands.wrapInSquareTask()
-    expect(docToMarkdown(fixture.doc)).toBe('- [x] done\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('cycleCheckableList cycles plain content through square and circle tasks', () => {
@@ -64,11 +64,11 @@ describe('commands', () => {
     fixture.set(n.doc(n.paragraph('todo<a>')))
 
     fixture.editor.commands.cycleCheckableList()
-    expect(docToMarkdown(fixture.doc)).toBe('- [ ] todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
     fixture.editor.commands.cycleCheckableList()
-    expect(docToMarkdown(fixture.doc)).toBe('+ [ ] todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
     fixture.editor.commands.cycleCheckableList()
-    expect(docToMarkdown(fixture.doc)).toBe('- [ ] todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('cycleCheckableList preserves checked state and task-marker casing', () => {
@@ -84,9 +84,9 @@ describe('commands', () => {
     )
 
     fixture.editor.commands.cycleCheckableList()
-    expect(docToMarkdown(fixture.doc)).toBe('+ [X] done\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
     fixture.editor.commands.cycleCheckableList()
-    expect(docToMarkdown(fixture.doc)).toBe('- [X] done\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('cycleCheckableList clears latent checked state from non-task lists', () => {
@@ -100,7 +100,7 @@ describe('commands', () => {
       marker: null,
       checked: false,
     })
-    expect(docToMarkdown(fixture.doc)).toBe('- [ ] todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('cycleCheckableList changes only the closest nested list', () => {
@@ -117,9 +117,9 @@ describe('commands', () => {
     )
 
     fixture.editor.commands.cycleCheckableList()
-    expect(docToMarkdown(fixture.doc)).toBe('+ [ ] outer\n  + [ ] inner\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
     fixture.editor.commands.cycleCheckableList()
-    expect(docToMarkdown(fixture.doc)).toBe('+ [ ] outer\n  - [ ] inner\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('cycleBulletOrderedList cycles plain content through bullet, ordered, and text', () => {
@@ -149,7 +149,7 @@ describe('commands', () => {
       kind: 'bullet',
       checked: false,
     })
-    expect(docToMarkdown(fixture.doc)).toBe('- done\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('cycleBulletOrderedList cycles the closest nested list through ordered, plain, and bullet', () => {
@@ -166,13 +166,13 @@ describe('commands', () => {
     )
 
     fixture.editor.commands.cycleBulletOrderedList()
-    expect(docToMarkdown(fixture.doc)).toBe('- outer\n  1. inner\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
     fixture.editor.commands.cycleBulletOrderedList()
-    expect(docToMarkdown(fixture.doc)).toBe('- outer\n\n  inner\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
     fixture.editor.commands.cycleBulletOrderedList()
-    expect(docToMarkdown(fixture.doc)).toBe('- outer\n  - inner\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
     fixture.editor.commands.cycleBulletOrderedList()
-    expect(docToMarkdown(fixture.doc)).toBe('- outer\n  1. inner\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('cycleBulletOrderedList wraps a continuation paragraph into a bullet', () => {
@@ -181,7 +181,7 @@ describe('commands', () => {
     fixture.set(n.doc(n.list({ kind: 'bullet' }, n.paragraph('outer'), n.paragraph('inner<a>'))))
 
     fixture.editor.commands.cycleBulletOrderedList()
-    expect(docToMarkdown(fixture.doc)).toBe('- outer\n  - inner\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('cycleBulletOrderedList cycles a node-selected list through ordered and plain', () => {
@@ -192,9 +192,9 @@ describe('commands', () => {
     view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, 0)))
 
     fixture.editor.commands.cycleBulletOrderedList()
-    expect(docToMarkdown(fixture.doc)).toBe('1. todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
     fixture.editor.commands.cycleBulletOrderedList()
-    expect(docToMarkdown(fixture.doc)).toBe('todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('cycleCheckableList wraps a continuation paragraph into a square task', () => {
@@ -207,7 +207,7 @@ describe('commands', () => {
     )
 
     fixture.editor.commands.cycleCheckableList()
-    expect(docToMarkdown(fixture.doc)).toBe('- [ ] outer\n  - [ ] inner\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 })
 
@@ -223,11 +223,11 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await pressModEnter()
-    expect(docToMarkdown(fixture.doc)).toBe('- [ ] todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
     await pressModEnter()
-    expect(docToMarkdown(fixture.doc)).toBe('- [x] todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
     await pressModEnter()
-    expect(docToMarkdown(fixture.doc)).toBe('- todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('Mod-Shift-Enter cycles a circle checkbox task: unchecked -> checked -> bullet', async () => {
@@ -237,11 +237,11 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await pressModShiftEnter()
-    expect(docToMarkdown(fixture.doc)).toBe('+ [ ] todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
     await pressModShiftEnter()
-    expect(docToMarkdown(fixture.doc)).toBe('+ [x] todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
     await pressModShiftEnter()
-    expect(docToMarkdown(fixture.doc)).toBe('- todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('Mod-Enter converts a circle checkbox task into a square checkbox task', async () => {
@@ -253,7 +253,7 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await pressModEnter()
-    expect(docToMarkdown(fixture.doc)).toBe('- [ ] todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('Mod-Shift-Enter converts a square checkbox task into a circle checkbox task', async () => {
@@ -263,7 +263,7 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await pressModShiftEnter()
-    expect(docToMarkdown(fixture.doc)).toBe('+ [ ] todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('Enter continues a circle checkbox task with another circle checkbox task', async () => {
@@ -275,7 +275,7 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await userEvent.keyboard('{Enter}next')
-    expect(docToMarkdown(fixture.doc)).toBe('+ [ ] todo\n+ [ ] next\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('Enter on a checked circle checkbox task continues with an unchecked one', async () => {
@@ -285,7 +285,7 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await userEvent.keyboard('{Enter}next')
-    expect(docToMarkdown(fixture.doc)).toBe('+ [x] done\n+ [ ] next\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('Enter in the middle of a circle checkbox task keeps the circle on both halves', async () => {
@@ -297,7 +297,7 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await userEvent.keyboard('{Enter}')
-    expect(docToMarkdown(fixture.doc)).toBe('+ [ ] to\n+ [ ] do\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('Enter at the start of a circle checkbox task inserts an empty circle task above', async () => {
@@ -321,7 +321,7 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await userEvent.keyboard('{Enter}next')
-    expect(docToMarkdown(fixture.doc)).toBe('- [ ] todo\n- [ ] next\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('Enter continues a `*` bullet with a `*` bullet', async () => {
@@ -331,7 +331,7 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await userEvent.keyboard('{Enter}next')
-    expect(docToMarkdown(fixture.doc)).toBe('* todo\n* next\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('Enter on an empty circle checkbox task still unwraps it', async () => {
@@ -341,7 +341,7 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await userEvent.keyboard('{Enter}')
-    expect(fixture.doc.child(0).type.name).toBe('paragraph')
+    expect(fixture.doc.child(0).type.name).toMatchInlineSnapshot()
   })
 
   it('Enter at the end of a collapsed bullet adds the next item below its hidden children', async () => {
@@ -359,7 +359,7 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await userEvent.keyboard('{Enter}next')
-    expect(docToMarkdown(fixture.doc)).toBe('+ parent\n  - child\n* next\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('Enter keeps the marker gap on the next item', async () => {
@@ -369,7 +369,7 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await userEvent.keyboard('{Enter}next')
-    expect(docToMarkdown(fixture.doc)).toBe('-   todo\n-   next\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   // The physical digit keys, so the shifted character ('&', '*', '(' on a US
@@ -384,9 +384,9 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await pressModShiftDigit(8)
-    expect(docToMarkdown(fixture.doc)).toBe('- todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
     await pressModShiftDigit(8)
-    expect(docToMarkdown(fixture.doc)).toBe('todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('Mod-Shift-7 wraps a paragraph into an ordered list and unwraps it again', async () => {
@@ -396,9 +396,9 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await pressModShiftDigit(7)
-    expect(docToMarkdown(fixture.doc)).toBe('1. todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
     await pressModShiftDigit(7)
-    expect(docToMarkdown(fixture.doc)).toBe('todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('Mod-Shift-9 wraps a paragraph into a square checkbox task and unwraps it again', async () => {
@@ -408,9 +408,9 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await pressModShiftDigit(9)
-    expect(docToMarkdown(fixture.doc)).toBe('- [ ] todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
     await pressModShiftDigit(9)
-    expect(docToMarkdown(fixture.doc)).toBe('todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 
   it('Mod-Shift-7 converts a bullet into an ordered list in place', async () => {
@@ -420,6 +420,6 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await pressModShiftDigit(7)
-    expect(docToMarkdown(fixture.doc)).toBe('1. todo\n')
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
   })
 })

--- a/packages/core/src/extensions/list.test.ts
+++ b/packages/core/src/extensions/list.test.ts
@@ -12,7 +12,12 @@ describe('input rule', () => {
     fixture.set(n.doc(n.paragraph('<a>todo')))
     fixture.view.focus()
     await userEvent.keyboard('+ ')
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      + [ ] todo
+
+      """
+    `)
   })
 
   it('wraps a block into a plain bullet on `- ` (not a checkbox task)', async () => {
@@ -21,7 +26,12 @@ describe('input rule', () => {
     fixture.set(n.doc(n.paragraph('<a>todo')))
     fixture.view.focus()
     await userEvent.keyboard('- ')
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      - todo
+
+      """
+    `)
   })
 })
 
@@ -31,7 +41,12 @@ describe('commands', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('todo<a>')))
     fixture.editor.commands.wrapInCircleTask()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      + [ ] todo
+
+      """
+    `)
   })
 
   it('wrapInSquareTask makes a square checkbox task', () => {
@@ -39,7 +54,12 @@ describe('commands', () => {
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('todo<a>')))
     fixture.editor.commands.wrapInSquareTask()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      - [ ] todo
+
+      """
+    `)
   })
 
   it('converts a square checkbox task to a circle checkbox task, keeping checked', () => {
@@ -47,7 +67,12 @@ describe('commands', () => {
     const { n } = fixture
     fixture.set(n.doc(n.list({ kind: 'task', checked: true }, n.paragraph('done<a>'))))
     fixture.editor.commands.wrapInCircleTask()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      + [x] done
+
+      """
+    `)
   })
 
   it('converts a circle checkbox task back to a square checkbox task, keeping checked', () => {
@@ -55,7 +80,12 @@ describe('commands', () => {
     const { n } = fixture
     fixture.set(n.doc(n.list({ kind: 'task', marker: '+', checked: true }, n.paragraph('done<a>'))))
     fixture.editor.commands.wrapInSquareTask()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      - [x] done
+
+      """
+    `)
   })
 
   it('cycleCheckableList cycles plain content through square and circle tasks', () => {
@@ -64,11 +94,26 @@ describe('commands', () => {
     fixture.set(n.doc(n.paragraph('todo<a>')))
 
     fixture.editor.commands.cycleCheckableList()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      - [ ] todo
+
+      """
+    `)
     fixture.editor.commands.cycleCheckableList()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      + [ ] todo
+
+      """
+    `)
     fixture.editor.commands.cycleCheckableList()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      - [ ] todo
+
+      """
+    `)
   })
 
   it('cycleCheckableList preserves checked state and task-marker casing', () => {
@@ -84,9 +129,19 @@ describe('commands', () => {
     )
 
     fixture.editor.commands.cycleCheckableList()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      + [X] done
+
+      """
+    `)
     fixture.editor.commands.cycleCheckableList()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      - [X] done
+
+      """
+    `)
   })
 
   it('cycleCheckableList clears latent checked state from non-task lists', () => {
@@ -100,7 +155,12 @@ describe('commands', () => {
       marker: null,
       checked: false,
     })
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      - [ ] todo
+
+      """
+    `)
   })
 
   it('cycleCheckableList changes only the closest nested list', () => {
@@ -117,9 +177,21 @@ describe('commands', () => {
     )
 
     fixture.editor.commands.cycleCheckableList()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      + [ ] outer
+        + [ ] inner
+
+      """
+    `)
     fixture.editor.commands.cycleCheckableList()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      + [ ] outer
+        - [ ] inner
+
+      """
+    `)
   })
 
   it('cycleBulletOrderedList cycles plain content through bullet, ordered, and text', () => {
@@ -149,7 +221,12 @@ describe('commands', () => {
       kind: 'bullet',
       checked: false,
     })
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      - done
+
+      """
+    `)
   })
 
   it('cycleBulletOrderedList cycles the closest nested list through ordered, plain, and bullet', () => {
@@ -166,13 +243,38 @@ describe('commands', () => {
     )
 
     fixture.editor.commands.cycleBulletOrderedList()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      - outer
+        1. inner
+
+      """
+    `)
     fixture.editor.commands.cycleBulletOrderedList()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      - outer
+
+        inner
+
+      """
+    `)
     fixture.editor.commands.cycleBulletOrderedList()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      - outer
+        - inner
+
+      """
+    `)
     fixture.editor.commands.cycleBulletOrderedList()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      - outer
+        1. inner
+
+      """
+    `)
   })
 
   it('cycleBulletOrderedList wraps a continuation paragraph into a bullet', () => {
@@ -181,7 +283,13 @@ describe('commands', () => {
     fixture.set(n.doc(n.list({ kind: 'bullet' }, n.paragraph('outer'), n.paragraph('inner<a>'))))
 
     fixture.editor.commands.cycleBulletOrderedList()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      - outer
+        - inner
+
+      """
+    `)
   })
 
   it('cycleBulletOrderedList cycles a node-selected list through ordered and plain', () => {
@@ -192,9 +300,19 @@ describe('commands', () => {
     view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, 0)))
 
     fixture.editor.commands.cycleBulletOrderedList()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      1. todo
+
+      """
+    `)
     fixture.editor.commands.cycleBulletOrderedList()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      todo
+
+      """
+    `)
   })
 
   it('cycleCheckableList wraps a continuation paragraph into a square task', () => {
@@ -207,7 +325,13 @@ describe('commands', () => {
     )
 
     fixture.editor.commands.cycleCheckableList()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      - [ ] outer
+        - [ ] inner
+
+      """
+    `)
   })
 })
 
@@ -223,11 +347,26 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await pressModEnter()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      - [ ] todo
+
+      """
+    `)
     await pressModEnter()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      - [x] todo
+
+      """
+    `)
     await pressModEnter()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      - todo
+
+      """
+    `)
   })
 
   it('Mod-Shift-Enter cycles a circle checkbox task: unchecked -> checked -> bullet', async () => {
@@ -237,11 +376,26 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await pressModShiftEnter()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      + [ ] todo
+
+      """
+    `)
     await pressModShiftEnter()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      + [x] todo
+
+      """
+    `)
     await pressModShiftEnter()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      - todo
+
+      """
+    `)
   })
 
   it('Mod-Enter converts a circle checkbox task into a square checkbox task', async () => {
@@ -253,7 +407,12 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await pressModEnter()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      - [ ] todo
+
+      """
+    `)
   })
 
   it('Mod-Shift-Enter converts a square checkbox task into a circle checkbox task', async () => {
@@ -263,7 +422,12 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await pressModShiftEnter()
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      + [ ] todo
+
+      """
+    `)
   })
 
   it('Enter continues a circle checkbox task with another circle checkbox task', async () => {
@@ -275,7 +439,13 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await userEvent.keyboard('{Enter}next')
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      + [ ] todo
+      + [ ] next
+
+      """
+    `)
   })
 
   it('Enter on a checked circle checkbox task continues with an unchecked one', async () => {
@@ -285,7 +455,13 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await userEvent.keyboard('{Enter}next')
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      + [x] done
+      + [ ] next
+
+      """
+    `)
   })
 
   it('Enter in the middle of a circle checkbox task keeps the circle on both halves', async () => {
@@ -297,7 +473,13 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await userEvent.keyboard('{Enter}')
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      + [ ] to
+      + [ ] do
+
+      """
+    `)
   })
 
   it('Enter at the start of a circle checkbox task inserts an empty circle task above', async () => {
@@ -321,7 +503,13 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await userEvent.keyboard('{Enter}next')
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      - [ ] todo
+      - [ ] next
+
+      """
+    `)
   })
 
   it('Enter continues a `*` bullet with a `*` bullet', async () => {
@@ -331,7 +519,13 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await userEvent.keyboard('{Enter}next')
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      * todo
+      * next
+
+      """
+    `)
   })
 
   it('Enter on an empty circle checkbox task still unwraps it', async () => {
@@ -341,7 +535,7 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await userEvent.keyboard('{Enter}')
-    expect(fixture.doc.child(0).type.name).toMatchInlineSnapshot()
+    expect(fixture.doc.child(0).type.name).toMatchInlineSnapshot(`"paragraph"`)
   })
 
   it('Enter at the end of a collapsed bullet adds the next item below its hidden children', async () => {
@@ -359,7 +553,14 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await userEvent.keyboard('{Enter}next')
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      + parent
+        - child
+      * next
+
+      """
+    `)
   })
 
   it('Enter keeps the marker gap on the next item', async () => {
@@ -369,7 +570,13 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await userEvent.keyboard('{Enter}next')
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      -   todo
+      -   next
+
+      """
+    `)
   })
 
   // The physical digit keys, so the shifted character ('&', '*', '(' on a US
@@ -384,9 +591,19 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await pressModShiftDigit(8)
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      - todo
+
+      """
+    `)
     await pressModShiftDigit(8)
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      todo
+
+      """
+    `)
   })
 
   it('Mod-Shift-7 wraps a paragraph into an ordered list and unwraps it again', async () => {
@@ -396,9 +613,19 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await pressModShiftDigit(7)
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      1. todo
+
+      """
+    `)
     await pressModShiftDigit(7)
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      todo
+
+      """
+    `)
   })
 
   it('Mod-Shift-9 wraps a paragraph into a square checkbox task and unwraps it again', async () => {
@@ -408,9 +635,19 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await pressModShiftDigit(9)
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      - [ ] todo
+
+      """
+    `)
     await pressModShiftDigit(9)
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      todo
+
+      """
+    `)
   })
 
   it('Mod-Shift-7 converts a bullet into an ordered list in place', async () => {
@@ -420,6 +657,11 @@ describe('keymap', () => {
     fixture.view.focus()
 
     await pressModShiftDigit(7)
-    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot()
+    expect(docToMarkdown(fixture.doc)).toMatchInlineSnapshot(`
+      """
+      1. todo
+
+      """
+    `)
   })
 })

--- a/packages/core/src/extensions/list.test.ts
+++ b/packages/core/src/extensions/list.test.ts
@@ -1,3 +1,4 @@
+import { NodeSelection } from '@prosekit/pm/state'
 import { describe, expect, it } from 'vitest'
 import { userEvent } from 'vitest/browser'
 
@@ -151,7 +152,7 @@ describe('commands', () => {
     expect(docToMarkdown(fixture.doc)).toBe('- done\n')
   })
 
-  it('cycleBulletOrderedList changes only the closest nested list', () => {
+  it('cycleBulletOrderedList cycles the closest nested list through ordered, plain, and bullet', () => {
     using fixture = setupFixture()
     const { n } = fixture
     fixture.set(
@@ -168,6 +169,45 @@ describe('commands', () => {
     expect(docToMarkdown(fixture.doc)).toBe('- outer\n  1. inner\n')
     fixture.editor.commands.cycleBulletOrderedList()
     expect(docToMarkdown(fixture.doc)).toBe('- outer\n\n  inner\n')
+    fixture.editor.commands.cycleBulletOrderedList()
+    expect(docToMarkdown(fixture.doc)).toBe('- outer\n  - inner\n')
+    fixture.editor.commands.cycleBulletOrderedList()
+    expect(docToMarkdown(fixture.doc)).toBe('- outer\n  1. inner\n')
+  })
+
+  it('cycleBulletOrderedList wraps a continuation paragraph into a bullet', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.list({ kind: 'bullet' }, n.paragraph('outer'), n.paragraph('inner<a>'))))
+
+    fixture.editor.commands.cycleBulletOrderedList()
+    expect(docToMarkdown(fixture.doc)).toBe('- outer\n  - inner\n')
+  })
+
+  it('cycleBulletOrderedList cycles a node-selected list through ordered and plain', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.list({ kind: 'bullet' }, n.paragraph('todo'))))
+    const { view } = fixture
+    view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, 0)))
+
+    fixture.editor.commands.cycleBulletOrderedList()
+    expect(docToMarkdown(fixture.doc)).toBe('1. todo\n')
+    fixture.editor.commands.cycleBulletOrderedList()
+    expect(docToMarkdown(fixture.doc)).toBe('todo\n')
+  })
+
+  it('cycleCheckableList wraps a continuation paragraph into a square task', () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(
+      n.doc(
+        n.list({ kind: 'task', checked: false }, n.paragraph('outer'), n.paragraph('inner<a>')),
+      ),
+    )
+
+    fixture.editor.commands.cycleCheckableList()
+    expect(docToMarkdown(fixture.doc)).toBe('- [ ] outer\n  - [ ] inner\n')
   })
 })
 

--- a/packages/core/src/extensions/list.ts
+++ b/packages/core/src/extensions/list.ts
@@ -21,7 +21,7 @@ import {
 } from '@prosekit/extensions/list'
 import type { ProseMirrorNode } from '@prosekit/pm/model'
 import type { Command, EditorState } from '@prosekit/pm/state'
-import { Plugin } from '@prosekit/pm/state'
+import { NodeSelection, Plugin } from '@prosekit/pm/state'
 import {
   createListRenderingPlugin,
   createSafariInputMethodWorkaroundPlugin,
@@ -287,13 +287,23 @@ function wrapInSquareTask(): Command {
   return wrapInList<MeowdownListAttrs>({ kind: 'task', marker: null })
 }
 
-/** The attributes of the closest list node enclosing the selection, if any. */
+/**
+ * The attributes of the list item whose own content holds the selection, if
+ * any. A continuation block deeper inside an item (a paragraph after the
+ * item's first block) is not the item's content, so it reports no list: the
+ * cycle commands then wrap it into a new nested list instead of reading the
+ * ancestor's kind.
+ */
 function getListAttrsAtSelection(state: EditorState): MeowdownListAttrs | null {
-  const { $from } = state.selection
+  const { selection } = state
+  if (selection instanceof NodeSelection && isNodeOfType(selection.node, 'list')) {
+    return selection.node.attrs
+  }
+  const { $from } = selection
   for (let depth = $from.depth; depth > 0; depth--) {
     const node = $from.node(depth)
     if (isNodeOfType(node, 'list')) {
-      return node.attrs
+      return $from.index(depth) === 0 ? node.attrs : null
     }
   }
   return null
@@ -329,11 +339,22 @@ function cycleCheckableList(): Command {
 function cycleBulletOrderedList(): Command {
   return (state, dispatch, view) => {
     const attrs = getListAttrsAtSelection(state)
-    const next: MeowdownListAttrs =
-      attrs?.kind === 'bullet' || attrs?.kind === 'ordered'
-        ? { kind: 'ordered', marker: null, checked: false, collapsed: false }
-        : { kind: 'bullet', marker: null, checked: false, collapsed: false }
-    return toggleList<MeowdownListAttrs>(next)(state, dispatch, view)
+    if (attrs?.kind === 'bullet' || attrs?.kind === 'ordered') {
+      return toggleList<MeowdownListAttrs>({
+        kind: 'ordered',
+        marker: null,
+        checked: false,
+        collapsed: false,
+      })(state, dispatch, view)
+    }
+    // Not `toggleList`: its unwrap branch would lift the whole enclosing item
+    // when a continuation block sits inside a same-kind list.
+    return wrapInList<MeowdownListAttrs>({
+      kind: 'bullet',
+      marker: null,
+      checked: false,
+      collapsed: false,
+    })(state, dispatch, view)
   }
 }
 

--- a/packages/core/src/extensions/list.ts
+++ b/packages/core/src/extensions/list.ts
@@ -5,6 +5,7 @@ import {
   defineKeymap,
   defineNodeAttr,
   definePlugin,
+  isNodeSelection,
   union,
   type Extension,
   type PlainExtension,
@@ -21,7 +22,7 @@ import {
 } from '@prosekit/extensions/list'
 import type { ProseMirrorNode } from '@prosekit/pm/model'
 import type { Command, EditorState } from '@prosekit/pm/state'
-import { NodeSelection, Plugin } from '@prosekit/pm/state'
+import { Plugin } from '@prosekit/pm/state'
 import {
   createListRenderingPlugin,
   createSafariInputMethodWorkaroundPlugin,
@@ -300,7 +301,8 @@ function wrapInSquareTask(): Command {
  */
 function getListAttrsAtSelection(state: EditorState): MeowdownListAttrs | null {
   const { selection } = state
-  if (selection instanceof NodeSelection && isNodeOfType(selection.node, 'list')) {
+
+  if (isNodeSelection(selection) && isNodeOfType(selection.node, 'list')) {
     return selection.node.attrs
   }
   const { $from } = selection


### PR DESCRIPTION
Repeatedly triggering `cycleBulletOrderedList` on a nested list item got stuck oscillating between ordered and plain, because `getListAttrsAtSelection` reported the ancestor list for a continuation paragraph; the paragraph then wrapped into an ordered list, skipping the bullet state. The helper now reports a list only when the selection sits in the item's own content (or a node-selected list), and the bullet branch uses `wrapInList` so a same-kind ancestor no longer unwraps. This also fixes the same skip in `cycleCheckableList` and the task rotation keymaps.