### PR TITLE
docs(core): drop the stale mark-order comment

### DIFF
--- a/packages/core/src/extensions/get-link-unit-at.ts
+++ b/packages/core/src/extensions/get-link-unit-at.ts
@@ -74,11 +74,10 @@ function lastMarkRunIn(
  */
 export function getLinkUnitAt(state: EditorState, pos: number): LinkUnit | undefined {
   const linkText = getMarkRangeAt(state, pos, 'mdLinkText')
-  // A position inside nested units carries one `mdPack` per level and the mark
-  // set's order follows edit history, so select the pack by `key` instead of
-  // taking whichever sits first. `[text](url)` and `<url>` carry a pack over
-  // the whole unit; bare/www autolinks carry only `mdLinkText`, so fall back to
-  // that run.
+  // A position inside nested units carries one `mdPack` per level, so select
+  // the pack by `key`: a link inside `**bold**` must find its own pack, not
+  // the outer unit's. `[text](url)` and `<url>` carry a pack over the whole
+  // unit; bare/www autolinks carry only `mdLinkText`, so fall back to that run.
   const pack =
     getMarkRangeAt(state, pos, 'mdPack', { key: 'link' } satisfies Partial<MdPackAttrs>) ??
     getMarkRangeAt(state, pos, 'mdPack', { key: 'autolink' } satisfies Partial<MdPackAttrs>)


### PR DESCRIPTION
The mark order on a text node is always parser order (both `BatchSetMarkStep` apply paths rewrite marks wholesale), so the comment's edit-history claim is wrong.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how nested link packs are selected to prevent confusion when resolving links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->