### PR TITLE
fix(core): resolve the link `href` from the `URL` after the closing `]`

### DIFF
--- a/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
@@ -979,6 +979,18 @@ describe('bare autolink', () => {
     `)
   })
 
+  it('inside link label', () => {
+    expect(parse('[see www.example.com](http://x)')).toMatchInlineSnapshot(`
+      "
+      [0, 1]   mdPack(key=link,data={"href":"http://x","title":"","isReference":false},revealInFocus=true) + mdLinkText(href=http://x) + mdMark
+      [1, 20]  mdPack(key=link,data={"href":"http://x","title":"","isReference":false},revealInFocus=true) + mdLinkText(href=http://x)
+      [20, 22] mdPack(key=link,data={"href":"http://x","title":"","isReference":false},revealInFocus=true) + mdMark
+      [22, 30] mdPack(key=link,data={"href":"http://x","title":"","isReference":false},revealInFocus=true) + mdLinkUri
+      [30, 31] mdPack(key=link,data={"href":"http://x","title":"","isReference":false},revealInFocus=true) + mdMark
+      "
+    `)
+  })
+
   it('email after @', () => {
     expect(parse('mail a@google.com here')).toMatchInlineSnapshot(`
       "

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.ts
@@ -341,6 +341,9 @@ interface LinkParts {
  * Locate the pieces of a `Link` node in Lezer's flat child list:
  *   LinkMark `[`, [label children], LinkMark `]`, LinkMark `(`, URL,
  *   optional LinkTitle, LinkMark `)`.
+ *
+ * An autolink inside the label also emits a `URL` child, so only a `URL`
+ * after the second `LinkMark` (the `]` closing the label) is the destination.
  */
 function scanLinkParts(node: InlineElement): LinkParts {
   let labelFrom = -1
@@ -357,7 +360,7 @@ function scanLinkParts(node: InlineElement): LinkParts {
       bracketCount++
       if (bracketCount === 1) labelFrom = child.to
       if (bracketCount === 2) labelTo = child.from
-    } else if (urlNode == null && childType === LEZER_NODE_IDS.URL) {
+    } else if (urlNode == null && bracketCount >= 2 && childType === LEZER_NODE_IDS.URL) {
       urlNode = child
     } else if (titleNode == null && childType === LEZER_NODE_IDS.LinkTitle) {
       titleNode = child
@@ -534,6 +537,13 @@ function walkResolvedLink(
     }
     if (isReference && child.type === LEZER_NODE_IDS.LinkLabel) {
       emit(out, child.from, child.to, [...baseForChild, marks.mdMark.create()])
+      pos = child.to
+      continue
+    }
+    // An autolink inside the label is plain label text: the outer link owns
+    // the href, and the muted `mdLinkUri` styling belongs to the destination.
+    if (child.type === LEZER_NODE_IDS.URL && inLabel(child.from)) {
+      emit(out, child.from, child.to, baseForChild)
       pos = child.to
       continue
     }


### PR DESCRIPTION
For `[see www.example.com](http://x)`, lezer also emits a `URL` node for the autolink inside the label, and `scanLinkParts` picked that first `URL` as the destination: the link's `href` became `www.example.com` and the label text rendered with the muted `mdLinkUri` mark. Only accept a `URL` after the `]` closing the label, and render a label autolink as plain link text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Markdown links containing bare autolinks in their labels.
  - Autolinks inside link labels now remain part of the displayed link text, while the enclosing link destination is preserved.

- **Tests**
  - Added coverage to verify correct handling of autolinks within Markdown link labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->