### PR TITLE
feat: fire `onImageClick` on `Enter` over a selected image

### DIFF
--- a/packages/core/src/extensions/follow-link.test.ts
+++ b/packages/core/src/extensions/follow-link.test.ts
@@ -6,6 +6,7 @@ import { setupFixture, type Fixture } from '../testing/index.ts'
 
 import type { FileClickHandler } from './file-click.ts'
 import { defineFollowLinkHandler, type FollowLinkHandlers } from './follow-link.ts'
+import type { ImageClickHandler } from './image-click.ts'
 import type { LinkClickHandler } from './link-click.ts'
 import type { TagClickHandler } from './tag-click.ts'
 import type { WikilinkClickHandler } from './wikilink-click.ts'
@@ -210,6 +211,38 @@ describe('defineFollowLinkHandler', () => {
 
       """
     `)
+  })
+
+  it('Enter on a selected image', async () => {
+    const onImageClick = vi.fn<ImageClickHandler>()
+    using fixture = setup({ onImageClick })
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('see ![pic](https://example.com/a.png)<a> here')))
+    fixture.view.focus()
+
+    await userEvent.keyboard('{ArrowLeft}')
+    await userEvent.keyboard('{Enter}')
+
+    expect(onImageClick).toHaveBeenCalledWith(
+      expect.objectContaining({ src: 'https://example.com/a.png', alt: 'pic', mod: false }),
+    )
+    expect(onImageClick.mock.calls[0][0].event).toBeInstanceOf(KeyboardEvent)
+    // The key was consumed: the image survived and the paragraph did not split.
+    expect(docToMarkdown(fixture.doc)).toBe('see ![pic](https://example.com/a.png) here\n')
+  })
+
+  it('Mod-Enter on a selected image reports `mod`', async () => {
+    const onImageClick = vi.fn<ImageClickHandler>()
+    using fixture = setup({ onImageClick })
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('see ![pic](https://example.com/a.png)<a> here')))
+    fixture.view.focus()
+
+    await userEvent.keyboard('{ArrowLeft}')
+    await pressModEnter()
+
+    expect(onImageClick).toHaveBeenCalledWith(expect.objectContaining({ mod: true }))
+    expect(docToMarkdown(fixture.doc)).toBe('see ![pic](https://example.com/a.png) here\n')
   })
 
   it('Enter on a selected image with no matching handler is a no-op', async () => {

--- a/packages/core/src/extensions/follow-link.ts
+++ b/packages/core/src/extensions/follow-link.ts
@@ -14,6 +14,8 @@ import { getSelectedAtomRange } from './atom-mark-navigation.ts'
 import type { FileClickHandler } from './file-click.ts'
 import { findFileAt } from './file-click.ts'
 import { getLinkUnitAt } from './get-link-unit-at.ts'
+import type { ImageClickHandler } from './image-click.ts'
+import { findImageAt } from './image-click.ts'
 import type { LinkClickHandler } from './link-click.ts'
 import type { TagClickHandler } from './tag-click.ts'
 import { findTagAt } from './tag-click.ts'
@@ -27,6 +29,7 @@ export interface FollowLinkHandlers {
   onTagClick?: TagClickHandler
   onFileClick?: FileClickHandler
   onLinkClick?: LinkClickHandler
+  onImageClick?: ImageClickHandler
 }
 
 function createFollowLinkPlugin(handlers: FollowLinkHandlers) {
@@ -72,7 +75,7 @@ function handlerAtomMarkTrigger(
   // neighbour to the right.
   const pos = selectedAtom.from + 1
 
-  const { onWikilinkClick, onFileClick } = handlers
+  const { onWikilinkClick, onFileClick, onImageClick } = handlers
 
   const wikilink = onWikilinkClick && findWikilinkAt(state, pos)
   if (wikilink) {
@@ -85,6 +88,12 @@ function handlerAtomMarkTrigger(
   const file = onFileClick && findFileAt(state, pos)
   if (file) {
     onFileClick({ href: file.href, name: file.name, event, mod })
+    return true
+  }
+
+  const image = onImageClick && findImageAt(state, pos)
+  if (image) {
+    onImageClick({ src: image.src, alt: image.alt, event, mod })
     return true
   }
 }
@@ -114,9 +123,10 @@ function handlerTextMarkTrigger(
 
 /**
  * Binds `Mod-Enter` to follow the wikilink, tag, file pill, or Markdown link
- * under the caret, and plain `Enter` to follow a selected atom unit, firing
- * the same handlers a click does. "Under the caret" means strictly inside
- * the unit: a caret merely touching a unit's edge is next to it, not on it.
+ * under the caret, and plain `Enter` to follow a selected atom unit (a
+ * wikilink, file pill, or image), firing the same handlers a click does.
+ * "Under the caret" means strictly inside the unit: a caret merely touching
+ * a unit's edge is next to it, not on it.
  * Off a link, `Mod-Enter` falls through so the list keymap keeps cycling
  * checkbox tasks; off a selected unit, `Enter` falls through to the regular
  * split. High priority puts this ahead of every keymap binding.

--- a/packages/core/src/extensions/image-click.ts
+++ b/packages/core/src/extensions/image-click.ts
@@ -2,6 +2,8 @@ import { definePlugin, type PlainExtension } from '@prosekit/core'
 import { Plugin, PluginKey, type EditorState } from '@prosekit/pm/state'
 import type { EditorView } from '@prosekit/pm/view'
 
+import { isModEvent } from '../utils/is-mod-event.ts'
+
 import type { MdImageAttrs } from './inline-marks.ts'
 import { getMarkRangeAt } from './mark-range.ts'
 
@@ -18,7 +20,7 @@ function getClosestImagePreview(target: EventTarget | null): HTMLElement | false
   return target instanceof HTMLElement && target.closest('.md-image-view-preview')
 }
 
-function findImageAt(state: EditorState, pos: number): ImageHit | undefined {
+export function findImageAt(state: EditorState, pos: number): ImageHit | undefined {
   const range = getMarkRangeAt(state, pos, 'mdImage')
   if (!range) return
   const { src, alt } = range.mark.attrs as MdImageAttrs
@@ -49,10 +51,16 @@ export interface ImageClickPayload {
    */
   alt: string
   /**
-   * The originating click or touch tap. Read the target or position a popover
+   * The originating click or touch tap, or the `Enter`/`Mod-Enter` key press
+   * that followed the selected image. Read the target or position a popover
    * from it; a touch surface delivers the `touchend` instead of a click.
    */
-  event: MouseEvent | TouchEvent
+  event: MouseEvent | TouchEvent | KeyboardEvent
+  /**
+   * Whether the platform's mod key (`Command` on Apple, `Ctrl` elsewhere) was held
+   * beyond the gesture that triggered the activation.
+   */
+  mod: boolean
 }
 
 export type ImageClickHandler = (payload: ImageClickPayload) => void
@@ -108,7 +116,7 @@ export function defineImageClickHandler(onClick: ImageClickHandler): PlainExtens
     // handler fires here instead of in handleClick.
     event.preventDefault()
     const hit = findImageForPreview(view, preview)
-    if (hit) onClick({ src: hit.src, alt: hit.alt, event })
+    if (hit) onClick({ src: hit.src, alt: hit.alt, event, mod: isModEvent(event) })
     return true
   }
 
@@ -165,7 +173,7 @@ export function defineImageClickHandler(onClick: ImageClickHandler): PlainExtens
           if (!preview) return false
           const hit = findImageForPreview(view, preview)
           if (!hit) return false
-          onClick({ src: hit.src, alt: hit.alt, event })
+          onClick({ src: hit.src, alt: hit.alt, event, mod: isModEvent(event) })
           return true
         },
       },

--- a/packages/react/src/components/editor-extensions.tsx
+++ b/packages/react/src/components/editor-extensions.tsx
@@ -156,10 +156,16 @@ export function EditorExtensions({
     useMemo(() => {
       // Mod-Enter follows the link under the caret through the same handlers
       // a click uses.
-      return onWikilinkClick || onTagClick || onFileClick || onLinkClick
-        ? defineFollowLinkHandler({ onWikilinkClick, onTagClick, onFileClick, onLinkClick })
+      return onWikilinkClick || onTagClick || onFileClick || onLinkClick || onImageClick
+        ? defineFollowLinkHandler({
+            onWikilinkClick,
+            onTagClick,
+            onFileClick,
+            onLinkClick,
+            onImageClick,
+          })
         : null
-    }, [onWikilinkClick, onTagClick, onFileClick, onLinkClick]),
+    }, [onWikilinkClick, onTagClick, onFileClick, onLinkClick, onImageClick]),
   )
 
   useExtension(

--- a/packages/react/src/components/editor.tsx
+++ b/packages/react/src/components/editor.tsx
@@ -217,9 +217,9 @@ export interface EditorProps {
   onFileSaveError?: FilePasteOptions['onFileSaveError']
 
   /**
-   * Called when the user clicks a rendered image, with its markdown `src`,
-   * `alt`, and the originating `MouseEvent`. Pass a stable function (e.g. from
-   * `useCallback`).
+   * Called when the user clicks a rendered image (or presses `Enter` on a
+   * selected one), with its markdown `src`, `alt`, and the originating event.
+   * Pass a stable function (e.g. from `useCallback`).
    */
   onImageClick?: ImageClickHandler
 

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -316,7 +316,13 @@ function ImagePreview(props: {
   const url = (resolveImageUrl ?? defaultResolveImageUrl)(src)
   if (!url) return null
   const handleClick = onImageClick
-    ? (event: MouseEvent) => onImageClick({ src, alt, event: event.nativeEvent })
+    ? (event: MouseEvent) =>
+        onImageClick({
+          src,
+          alt,
+          event: event.nativeEvent,
+          mod: isModEvent(event),
+        })
     : undefined
   return (
     <span


### PR DESCRIPTION
Pressing `Enter` (or `Mod-Enter`) on a keyboard-selected image now fires `onImageClick` with the same required `mod: boolean` flag the other follow payloads carry, instead of falling through to the paragraph split that deleted the image.