### PR TITLE
fix: stop Safari skipping a boundary unit on block entry

### DIFF
--- a/packages/core/src/extensions/atom-mark-navigation.ts
+++ b/packages/core/src/extensions/atom-mark-navigation.ts
@@ -66,23 +66,30 @@ export function getSelectedAtomRange(state: EditorState): MarkRange | undefined 
 // the step is not this keymap's to take. Chromium and WebKit cannot move the
 // native caret across the contenteditable=false preview at a textblock edge,
 // and prosemirror-view's own blockwise handling only covers vertical arrows.
+// The probes look past the atom marks to every inline unit: WebKit's native
+// entry into a block skips all caret stops inside a `display: contents`
+// subtree (the mdPack wrapper), so a unit touching the boundary from either
+// side takes the owned step.
 function findSelectionAcrossBlockBoundary(
   state: EditorState,
   pos: number,
   markNames: readonly MarkName[],
   direction: -1 | 1,
 ): Selection | undefined {
+  const unitMarkNames: readonly MarkName[] = [...markNames, 'mdPack']
   const $pos = state.doc.resolve(pos)
   // Only a caret sitting exactly on the textblock edge can leave the block.
   const atEdge =
     direction === -1 ? $pos.parentOffset === 0 : $pos.parentOffset === $pos.parent.content.size
   if (!atEdge || $pos.depth === 0) return
   // The unit being left behind: one starting (going left) or ending (going
-  // right) exactly at the caret. Chromium/WebKit cannot walk out past it.
+  // right) exactly at the caret. Chromium/WebKit cannot walk out past an
+  // atom's preview; a plain unit exits natively, but owning its step too
+  // keeps the walk deterministic.
   const nearUnit =
     direction === -1
-      ? getMarkRangeAfter(state, pos, markNames)
-      : getMarkRangeBefore(state, pos, markNames)
+      ? getMarkRangeAfter(state, pos, unitMarkNames)
+      : getMarkRangeBefore(state, pos, unitMarkNames)
   // The nearest selection past the boundary: the adjacent textblock's near
   // edge, or a NodeSelection for a selectable block such as a horizontal rule
   // (the same landing prosemirror-view's moveSelectionBlock would pick).
@@ -93,8 +100,8 @@ function findSelectionAcrossBlockBoundary(
   // side. WebKit skips caret stops when walking into such a block.
   const farUnit = isTextSelection(target)
     ? direction === -1
-      ? getMarkRangeBefore(state, target.head, markNames)
-      : getMarkRangeAfter(state, target.head, markNames)
+      ? getMarkRangeBefore(state, target.head, unitMarkNames)
+      : getMarkRangeAfter(state, target.head, unitMarkNames)
     : undefined
   // No unit on either side of the boundary: stay out of the browser's way
   // (native handles bidi/RTL horizontal motion better than we can).

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 
 import { findText } from '../testing/find-text.ts'
-import { setupFixture } from '../testing/index.ts'
+import { setupFixture, traceKeySelection, traceShiftKeySelection } from '../testing/index.ts'
 
 import { defineImage } from './image.ts'
 import type { MarkMode } from './mark-mode.ts'
@@ -1225,6 +1225,59 @@ describe('focus mode', () => {
     expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`"text **bold**┃*italic* text"`)
     await userEvent.keyboard('{Backspace}')
     expect(fixture.selectionSnapshot).toMatchInlineSnapshot(`"text **bold*┃*italic* text"`)
+  })
+
+  // Entering a paragraph from the block after it must land at the paragraph
+  // end, then walk the revealed source one position per press. WebKit's native
+  // block-entry motion skips a trailing `display: contents` subtree (the
+  // mdPack wrapper), jumping straight to `foo ┃**bar**` and passing the
+  // visible "bar" without a single caret stop.
+  it('ArrowLeft from an empty paragraph lands at the end of a trailing bold unit', async () => {
+    using fixture = setupFixture({ extensionOptions: { markMode: 'focus' } })
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('foo **bar**'), n.paragraph(), n.paragraph('<a>')))
+    fixture.view.focus()
+
+    expect(await traceKeySelection(fixture, 'ArrowLeft', 4)).toMatchInlineSnapshot(`
+      [
+        "foo **bar**\\n\\n┃",
+        "foo **bar**\\n┃\\n",
+        "foo **bar**┃\\n\\n",
+        "foo **bar*┃*\\n\\n",
+        "foo **bar┃**\\n\\n",
+      ]
+    `)
+  })
+
+  it('ArrowRight from an empty paragraph lands at the start of a leading bold unit', async () => {
+    using fixture = setupFixture({ extensionOptions: { markMode: 'focus' } })
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('<a>'), n.paragraph('**bar** foo')))
+    fixture.view.focus()
+
+    expect(await traceKeySelection(fixture, 'ArrowRight', 3)).toMatchInlineSnapshot(`
+      [
+        "┃\\n**bar** foo",
+        "\\n┃**bar** foo",
+        "\\n*┃*bar** foo",
+        "\\n**┃bar** foo",
+      ]
+    `)
+  })
+
+  it('Shift-ArrowLeft from an empty paragraph extends to the end of a trailing bold unit', async () => {
+    using fixture = setupFixture({ extensionOptions: { markMode: 'focus' } })
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('foo **bar**'), n.paragraph('<a>')))
+    fixture.view.focus()
+
+    expect(await traceShiftKeySelection(fixture, 'ArrowLeft', 2)).toMatchInlineSnapshot(`
+      [
+        "foo **bar**\\n┃",
+        "foo **bar**❰\\n❱",
+        "foo **bar*❰*\\n❱",
+      ]
+    `)
   })
 })
 


### PR DESCRIPTION
Safari's native caret motion skips an inline unit's whole source when an arrow key enters a paragraph whose edge touches the unit, because WebKit skips caret stops inside `display: contents` subtrees. Own the blockwise arrow step whenever a unit touches the boundary, the same step atom units already take.