### PR TITLE
docs: show the marker-run case in the `normalizing` docs

### DIFF
--- a/packages/core/src/converters/check-roundtrip.test.ts
+++ b/packages/core/src/converters/check-roundtrip.test.ts
@@ -231,6 +231,10 @@ describe('checkRoundTrip', () => {
 
     // a bare bullet opens an item even empty, so it cannot keep the prefix
     '>\t*\t\\\n\t+',
+
+    // a git conflict marker run is a blockquote nest, so `>>>>>>> b` is
+    // rewritten as `> > > > > > > b`: same document, different bytes
+    '<<<<<<< a\nx\n=======\ny\n>>>>>>> b',
   ])('reports normalizing for %j', (markdown) => {
     expect(checkRoundTrip(markdown)).toBe('normalizing')
   })

--- a/packages/core/src/converters/check-roundtrip.ts
+++ b/packages/core/src/converters/check-roundtrip.ts
@@ -8,13 +8,10 @@ import { docToMarkdown } from './pm-to-md.ts'
  * - `exact`: byte-identical (modulo the trailing newline).
  * - `normalizing`: bytes differ, but only as layout the parser reads back
  *   through - every content line survives and the output re-parses to the same
- *   document (e.g. a lazy continuation re-indented to its canonical column, or
- *   a table delimiter row rewritten to canonical dashes).
+ *   document (e.g. a lazy continuation re-indented, or `>>>>>>> x` respaced to
+ *   the seven blockquotes it already meant).
  * - `lossy`: content changed - a content line differs or disappeared, or the
  *   output re-parses to a different document.
- *
- * `normalizing` grades the document, not the bytes: `>>>>>>> x` comes back as
- * `> > > > > > > x`. Not a byte-fidelity gate.
  */
 export type RoundTripFidelity = 'exact' | 'normalizing' | 'lossy'
 

--- a/packages/core/src/converters/check-roundtrip.ts
+++ b/packages/core/src/converters/check-roundtrip.ts
@@ -13,10 +13,8 @@ import { docToMarkdown } from './pm-to-md.ts'
  * - `lossy`: content changed - a content line differs or disappeared, or the
  *   output re-parses to a different document.
  *
- * `normalizing` grades the document, not the bytes: a content-bearing line may
- * be respelled as long as it parses the same. A blockquote marker run is the
- * sharp edge, since `>>>>>>> x` comes back as `> > > > > > > x`. Do not read it
- * as a byte-fidelity gate.
+ * `normalizing` grades the document, not the bytes: `>>>>>>> x` comes back as
+ * `> > > > > > > x`. Not a byte-fidelity gate.
  */
 export type RoundTripFidelity = 'exact' | 'normalizing' | 'lossy'
 

--- a/packages/core/src/converters/check-roundtrip.ts
+++ b/packages/core/src/converters/check-roundtrip.ts
@@ -12,6 +12,11 @@ import { docToMarkdown } from './pm-to-md.ts'
  *   a table delimiter row rewritten to canonical dashes).
  * - `lossy`: content changed - a content line differs or disappeared, or the
  *   output re-parses to a different document.
+ *
+ * `normalizing` grades the document, not the bytes: a content-bearing line may
+ * be respelled as long as it parses the same. A blockquote marker run is the
+ * sharp edge, since `>>>>>>> x` comes back as `> > > > > > > x`. Do not read it
+ * as a byte-fidelity gate.
  */
 export type RoundTripFidelity = 'exact' | 'normalizing' | 'lossy'
 


### PR DESCRIPTION
The `normalizing` docstring illustrated itself with two benign examples (re-indentation, delimiter dashes), neither of which prepares a reader for a content-bearing line being respelled. This swaps one example for `>>>>>>> x` respacing to `> > > > > > > x`, and pins that case in the test list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Git conflict markers during document conversion, including correct normalization of closing markers.
  * Preserved document content when blockquote structure or spacing is adjusted.

* **Documentation**
  * Clarified round-trip conversion behavior for block markers and lazy blockquote continuation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->