### PR TITLE
fix: stop reporting loss when only a closing fence shortens

### DIFF
--- a/packages/core/src/converters/check-roundtrip.bench.ts
+++ b/packages/core/src/converters/check-roundtrip.bench.ts
@@ -1,0 +1,41 @@
+import { createEditor, type NodeJSON } from '@prosekit/core'
+import { bench, describe } from 'vitest'
+
+import { defineEditorExtension } from '../extensions/extension.ts'
+
+import { checkRoundTrip } from './check-roundtrip.ts'
+import { docToMarkdown } from './pm-to-md.ts'
+import { sampleContent } from './sample-content.ts'
+
+// Run with:  pnpm bench
+//
+// Latest results (chromium, M2 MacBook):
+//   sampleMarkdown  10,358 hz    0.0965 ms mean
+//   largeMarkdown       57 hz   17.6069 ms mean
+//
+// Two markdown parses and one serialization account for roughly 14 of those 18
+// ms, so the line comparison is the only part worth tuning here.
+
+const editor = createEditor({ extension: defineEditorExtension() })
+
+const largeContent: NodeJSON = {
+  type: 'doc',
+  content: Array.from({ length: 200 }, () => sampleContent.content ?? []).flat(),
+}
+
+// A loose list serializes tight, so the trip is never byte-identical and the
+// whole text goes through the line comparison instead of the early return.
+const PERTURBATION = '- a\n\n- b\n\n'
+
+const sampleMarkdown = PERTURBATION + docToMarkdown(editor.schema.nodeFromJSON(sampleContent))
+const largeMarkdown = PERTURBATION + docToMarkdown(editor.schema.nodeFromJSON(largeContent))
+
+describe('checkRoundTrip', () => {
+  bench('sampleMarkdown', () => {
+    checkRoundTrip(sampleMarkdown)
+  })
+
+  bench('largeMarkdown', () => {
+    checkRoundTrip(largeMarkdown)
+  })
+})

--- a/packages/core/src/converters/check-roundtrip.test.ts
+++ b/packages/core/src/converters/check-roundtrip.test.ts
@@ -161,6 +161,14 @@ const NORMALIZING_CASES: string[] = [
   '$$',
   '~~~',
 
+  // a closing fence may be longer than the one it closes
+  '```\ncode\n````',
+  '~~~\ncode\n~~~~~',
+  '```js\ncode\n````',
+  '```\n````',
+  '> ```\n> ````',
+  '- ```\n  ````',
+
   // a lazy setext underline stays text, and gains nothing but the marker space
   '>a\n=',
 
@@ -234,15 +242,7 @@ const NORMALIZING_CASES: string[] = [
   '<<<<<<< a\nx\n=======\ny\n>>>>>>> b',
 ]
 
-const LOSSY_CASES: string[] = [
-  // a closing fence may be longer than the one it closes
-  '```\ncode\n````',
-  '~~~\ncode\n~~~~~',
-  '```js\ncode\n````',
-  '```\n````',
-  '> ```\n> ````',
-  '- ```\n  ````',
-]
+const LOSSY_CASES: string[] = []
 
 describe('checkRoundTrip', () => {
   it.each(EXACT_CASES)('reports exact for %j', (markdown) => {

--- a/packages/core/src/converters/check-roundtrip.ts
+++ b/packages/core/src/converters/check-roundtrip.ts
@@ -39,6 +39,19 @@ function stripWhitespace(line: string): string {
   return line.replaceAll(/\s/gu, '')
 }
 
+// A fence opens with a run of at least three backticks or tildes.
+const FENCE_RUN_RE = /^(?:`{3,}|~{3,})/u
+
+// Shorten a fence's run to the three characters it takes to open one: a closing
+// fence may be written longer than the fence it closes, and the serializer
+// writes it back at the opening fence's length, so the width is layout. This
+// runs before the whitespace goes, so `~~~ ~` keeps its `~` info string instead
+// of reading as a four-tilde run.
+function shortenFenceRun(line: string): string {
+  const run = FENCE_RUN_RE.exec(line)?.[0]
+  return run === undefined ? line : run.slice(0, 3) + line.slice(run.length)
+}
+
 // A GFM delimiter cell is optional colons around a run of dashes.
 const DELIMITER_CELL_RE = /^:?-+:?$/u
 
@@ -63,7 +76,7 @@ function canonicalizeTableRow(line: string): string | undefined {
 function contentLines(text: string): string[] {
   const lines: string[] = []
   for (const line of text.split('\n')) {
-    const content = stripWhitespace(line.replace(CONTAINER_PREFIX_RE, ''))
+    const content = stripWhitespace(shortenFenceRun(line.replace(CONTAINER_PREFIX_RE, '')))
     if (content !== '') lines.push(canonicalizeTableRow(content) ?? content)
   }
   return lines

--- a/packages/core/src/converters/check-roundtrip.ts
+++ b/packages/core/src/converters/check-roundtrip.ts
@@ -1,4 +1,4 @@
-import { CHAR_LINE_FEED } from '../unicode.ts'
+import { CHAR_BACKTICK, CHAR_LINE_FEED, CHAR_TILDE } from '../unicode.ts'
 
 import { markdownToDoc } from './md-to-pm.ts'
 import { docToMarkdown } from './pm-to-md.ts'
@@ -39,17 +39,17 @@ function stripWhitespace(line: string): string {
   return line.replaceAll(/\s/gu, '')
 }
 
-// A fence opens with a run of at least three backticks or tildes.
-const FENCE_RUN_RE = /^(?:`{3,}|~{3,})/u
-
-// Shorten a fence's run to the three characters it takes to open one: a closing
-// fence may be written longer than the fence it closes, and the serializer
-// writes it back at the opening fence's length, so the width is layout. This
-// runs before the whitespace goes, so `~~~ ~` keeps its `~` info string instead
-// of reading as a four-tilde run.
+// Shorten a fence's opening run to the three characters it takes to open one: a
+// closing fence may be written longer than the fence it closes, and the
+// serializer writes it back at the opening fence's length, so the width is
+// layout. This runs before the whitespace goes, so `~~~ ~` keeps its `~` info
+// string instead of reading as a four-tilde run.
 function shortenFenceRun(line: string): string {
-  const run = FENCE_RUN_RE.exec(line)?.[0]
-  return run === undefined ? line : run.slice(0, 3) + line.slice(run.length)
+  const fence = line.charCodeAt(0)
+  if (fence !== CHAR_BACKTICK && fence !== CHAR_TILDE) return line
+  let width = 1
+  while (line.charCodeAt(width) === fence) width++
+  return width > 3 ? line.slice(0, 3) + line.slice(width) : line
 }
 
 // A GFM delimiter cell is optional colons around a run of dashes.


### PR DESCRIPTION
`checkRoundTrip` read a closing fence's width as content, so shortening it to the opening fence's length (the spelling `roundtrip.test.ts` already asserts) was reported as `lossy` even though the document survives. `contentLines` now shortens a fence run to three characters before dropping whitespace, which keeps an info string like `~~~ ~` distinct from a four-character run, and the cases added in #472 move from `LOSSY_CASES` to `NORMALIZING_CASES`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown round-trip comparisons for fenced code blocks.
  * Code fences with longer opening or closing runs are now handled consistently.
  * Preserved code block info strings while normalizing fence comparisons.

* **Tests**
  * Added coverage for Markdown code fences with mismatched lengths.
  * Added performance benchmarks for round-trip checking on sample and large documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->