### PR TITLE
fix: stop the table-row false positive in `checkRoundTrip`

### DIFF
--- a/packages/core/src/converters/check-roundtrip.test.ts
+++ b/packages/core/src/converters/check-roundtrip.test.ts
@@ -240,9 +240,42 @@ const NORMALIZING_CASES: string[] = [
   // a git conflict marker run is a blockquote nest, so `>>>>>>> b` is
   // rewritten as `> > > > > > > b`: same document, different bytes
   '<<<<<<< a\nx\n=======\ny\n>>>>>>> b',
+
+  // a lone dash cell reads as a delimiter row until the pretty-printer pads it
+  '-|\n-|\n`|-',
+
+  // a pipe-less row's text keeps markers the piped spelling shows as cell text
+  '-|\n-|\n\t>#',
+  '#|\n-|\n\t1.\t!',
+
+  // a lone `:-` data cell is a delimiter lookalike only when piped
+  '|#\n-|\n:-',
+
+  // a cell keeps a fence run whose width the bare line would shorten
+  '~|\n-|\n\t````',
 ]
 
-const LOSSY_CASES: string[] = []
+const LOSSY_CASES: string[] = [
+  // an empty task's trailing space plus a lazy line: the rewritten `>   b`
+  // re-parses as literal text, marker included
+  '> - [ ] \nb',
+
+  // a lazy line beside a fence or table lookalike is re-quoted into the quote
+  '>2\n```|`\n|-|',
+  '>~\n>*|\n-|',
+  '>$\n~|\n>|-|',
+  '>\\\n|-\n>|-|',
+
+  // a conflict marker run respaces into a blockquote nest that swallows the
+  // second marker line
+  '>>>>>>>,\n>>>>>>> \t>',
+
+  // an empty ordered item keeps blank lines; the re-indented `~` changes blocks
+  '  1.\n\n\n\t~',
+
+  // CommonMark spec example 312: escalating one-space indents flatten
+  '- a\n - b\n  - c\n   - d\n    - e',
+]
 
 describe('checkRoundTrip', () => {
   it.each(EXACT_CASES)('reports exact for %j', (markdown) => {

--- a/packages/core/src/converters/check-roundtrip.ts
+++ b/packages/core/src/converters/check-roundtrip.ts
@@ -55,29 +55,42 @@ function shortenFenceRun(line: string): string {
 // A GFM delimiter cell is optional colons around a run of dashes.
 const DELIMITER_CELL_RE = /^:?-+:?$/u
 
+// Reduce one cell the way a bare line is reduced: the serializer moves a
+// pipe-less row's text into a piped cell, and only an identical reduction on
+// both spellings keeps them equal.
+function reduceCell(cell: string): string {
+  return stripWhitespace(shortenFenceRun(cell.replace(CONTAINER_PREFIX_RE, '')))
+}
+
 // Reduce a pipe-bearing line to the cell text it carries. Outer pipes are table
-// layout, an empty cell says nothing, and a delimiter row is pure structure: it
-// encodes the column count and the alignment, both of which are node attributes
-// the document comparison covers. A line the serializer never restructures (a
-// paragraph or code line holding pipes) reduces the same way on both sides, so
-// equal lines stay equal.
+// layout, an empty cell says nothing, and a cell of pure delimiter dashes is
+// structure: it encodes the column count and the alignment, both of which are
+// node attributes the document comparison covers. A line the serializer never
+// restructures (a paragraph or code line holding pipes) reduces the same way on
+// both sides, so equal lines stay equal.
 function canonicalizeTableRow(line: string): string | undefined {
   if (!line.includes('|')) return undefined
-  const cells = line.replace(/^\|/u, '').replace(/\|$/u, '').split('|')
-  if (cells.every((cell) => DELIMITER_CELL_RE.test(cell))) return ''
+  const cells = line
+    .replace(/^\s*\|/u, '')
+    .replace(/\|\s*$/u, '')
+    .split('|')
+    .map(reduceCell)
+  if (cells.every((cell) => cell === '' || DELIMITER_CELL_RE.test(cell))) return ''
   return cells.filter((cell) => cell !== '').join('|')
 }
 
 /**
  * The lines of `text` that carry content, each reduced to that content. A line
- * left empty by dropping its markers and whitespace (a blank line, a bare `>`,
- * a list marker whose content is on the next line) carries none and is skipped.
+ * left empty by dropping its markers, whitespace, and table structure (a blank
+ * line, a bare `>`, a list marker whose content is on the next line, a
+ * delimiter row or a lone delimiter cell) carries none and is skipped.
  */
 function contentLines(text: string): string[] {
   const lines: string[] = []
   for (const line of text.split('\n')) {
-    const content = stripWhitespace(shortenFenceRun(line.replace(CONTAINER_PREFIX_RE, '')))
-    if (content !== '') lines.push(canonicalizeTableRow(content) ?? content)
+    const bare = line.replace(CONTAINER_PREFIX_RE, '')
+    const content = canonicalizeTableRow(bare) ?? stripWhitespace(shortenFenceRun(bare))
+    if (content !== '' && !DELIMITER_CELL_RE.test(content)) lines.push(content)
   }
   return lines
 }


### PR DESCRIPTION
Reduce each table cell exactly the way a bare line is reduced, and skip structure-only lines, so five row spellings that round-trip to an equal document stop being reported as `lossy`. Builds on #473, which handled the fence-run half.