### PR TITLE
test: replay the CommonMark spec

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,6 +55,7 @@
     "@types/hast": "^3.0.5",
     "@types/mdast": "^4.0.4",
     "@vitest/browser-playwright": "^4.1.10",
+    "commonmark.json": "^0.31.0",
     "dedent": "^1.7.2",
     "diffable-html-snapshot": "^0.3.0",
     "fast-check": "^4.9.0",

--- a/packages/core/src/converters/check-roundtrip-spec.test.ts
+++ b/packages/core/src/converters/check-roundtrip-spec.test.ts
@@ -1,0 +1,20 @@
+import { commonmark } from 'commonmark.json'
+import { expect, it } from 'vitest'
+
+import { checkRoundTrip } from './check-roundtrip.ts'
+
+// Spec inputs that are genuinely lossy today, pinned like `LOSSY_CASES` and
+// burned down over time. 312 is the escalating-indent list.
+const KNOWN_LOSSY = new Set<number>([312])
+
+it.each(commonmark.map((example, index) => [index + 1, example.markdown] as const))(
+  'spec example %i round-trips without loss',
+  (number, markdown) => {
+    const fidelity = checkRoundTrip(markdown)
+    if (KNOWN_LOSSY.has(number)) {
+      expect(fidelity).toBe('lossy')
+    } else {
+      expect(fidelity).not.toBe('lossy')
+    }
+  },
+)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: ^4.1.10
         version: 4.1.10(playwright@1.62.1)(vite@8.2.1)(vitest@4.1.10)
+      commonmark.json:
+        specifier: ^0.31.0
+        version: 0.31.0
       dedent:
         specifier: ^1.7.2
         version: 1.7.2
@@ -2003,6 +2006,9 @@ packages:
   comment-parser@1.4.8:
     resolution: {integrity: sha512-rKZTGo4fzKYna8UcL0isTg5wkBNla7bxTypLwZQXjIdi++IdP1OJ41rI5Mti3/jltkPujbu4i9LIARYA+zpotQ==}
     engines: {node: '>= 12.0.0'}
+
+  commonmark.json@0.31.0:
+    resolution: {integrity: sha512-AJFKhaVtIDQwoaLJhe8TtwKkCq6cJUF8U7ZoU0dHKZn4bnMTXFBmkFFU0R4vneUdXM32gWkwsyfVXsu7ikBORQ==}
 
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
@@ -5683,6 +5689,8 @@ snapshots:
   comment-parser@1.4.7: {}
 
   comment-parser@1.4.8: {}
+
+  commonmark.json@0.31.0: {}
 
   compare-versions@6.1.1: {}
 


### PR DESCRIPTION
Replay the 652 CommonMark spec examples through `checkRoundTrip`, pinning the one genuinely lossy example so it burns down as the converters improve.