### PR TITLE
fix: strip the quote marker from a multi-line task's text

### DIFF
--- a/packages/core/src/converters/check-roundtrip.test.ts
+++ b/packages/core/src/converters/check-roundtrip.test.ts
@@ -253,13 +253,12 @@ const NORMALIZING_CASES: string[] = [
 
   // a cell keeps a fence run whose width the bare line would shorten
   '~|\n-|\n\t````',
+
+  // an empty task's lazy line goes back out under the quote's own marker
+  '> - [ ] \nb',
 ]
 
 const LOSSY_CASES: string[] = [
-  // an empty task's trailing space plus a lazy line: the rewritten `>   b`
-  // re-parses as literal text, marker included
-  '> - [ ] \nb',
-
   // a lazy line beside a fence or table lookalike is re-quoted into the quote
   '>2\n```|`\n|-|',
   '>~\n>*|\n-|',

--- a/packages/core/src/converters/md-to-pm.ts
+++ b/packages/core/src/converters/md-to-pm.ts
@@ -624,7 +624,7 @@ function convertTaskItem(
   }
   // Skip the single separating whitespace after `[ ]` / `[x]`
   if (isSpaceChar(text.charCodeAt(taskStart))) taskStart += 1
-  const taskText = text.slice(taskStart, taskEnd)
+  const taskText = readLeafText(cursor, text, taskStart, taskEnd)
   // The checkbox sits on the first line only: the serializer indents the task's
   // continuation lines to the item's own column, not past `[ ] `.
   const paragraph = buildParagraph(nodes, taskText, column)

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -558,6 +558,10 @@ describe('task lists', () => {
     expect(roundtrip('- [ ] line one\n  line two')).toBe('- [ ] line one\n  line two\n')
   })
 
+  it('keeps a soft break in a quoted task', () => {
+    expect(roundtrip('> - [ ] line one\n>   line two')).toBe('> - [ ] line one\n>   line two\n')
+  })
+
   it.fails('keeps a lazy continuation in a task', () => {
     // Same lazy-continuation limitation as bullet lists; the flush line is
     // re-indented to the task's content column on serialize.


### PR DESCRIPTION
`convertTaskItem` sliced the task's source raw, so a `QuoteMark` lezer parks inside the `Task` node stayed in the text: `> - [ ] x` with a `>   b` continuation parsed to `x\n>   b`, marker included. It now reads the text through `readLeafText`, the same way every other leaf block does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversion of quoted task-list items with empty text and soft breaks.
  * Preserved blockquote and task-list formatting during Markdown round trips.
  * Removed stray quote markers and trailing blank lines from converted task text.

* **Tests**
  * Added coverage for preserving formatting in quoted task-list items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->