### PR TITLE
fix: fence a code block a blank-line run leaves after a list

### DIFF
--- a/packages/core/src/converters/check-roundtrip.test.ts
+++ b/packages/core/src/converters/check-roundtrip.test.ts
@@ -207,9 +207,11 @@ const NORMALIZING_CASES: string[] = [
   '- a\n\t\t-',
 
   // indentation cannot spell a code block that follows a list, nor one that
-  // opens with a blank line
+  // opens with a blank line. Blank lines do not end the list, so the empty
+  // paragraphs a run of them leaves behind keep the code block in reach too
   ' 33)\n\t1',
   '*\t\t\n\t\t[',
+  '  1.\n\n\n\t~',
 
   // a cell past the delimiter row widens the table instead of dropping
   '| a |\n| --- |\n| b | c |',
@@ -269,9 +271,6 @@ const NORMALIZING_CASES: string[] = [
   // a conflict marker run respaces into a blockquote nest that swallows the
   // second marker line
   '>>>>>>>,\n>>>>>>> \t>',
-
-  // an empty ordered item keeps blank lines; the re-indented `~` changes blocks
-  '  1.\n\n\n\t~',
 
   // CommonMark spec example 312: escalating one-space indents flatten
   '- a\n - b\n  - c\n   - d\n    - e',

--- a/packages/core/src/converters/md-to-pm.ts
+++ b/packages/core/src/converters/md-to-pm.ts
@@ -124,8 +124,8 @@ function collectBlocks(
 
 /**
  * Append `blocks`, dropping the indented spelling from a code block that lands
- * right after a list: four columns of indentation would put it inside the item
- * above instead of after it, so it can only be written as a fence.
+ * after a list: four columns of indentation would put it inside the item above
+ * instead of after it, so it can only be written as a fence.
  */
 function appendBlocks(
   out: ProseMirrorNode[],
@@ -134,12 +134,7 @@ function appendBlocks(
 ): void {
   for (const block of blocks) {
     const attrs = block.attrs as MeowdownCodeBlockAttrs
-    if (
-      attrs.fenceStyle === 'indented' &&
-      isNodeOfType(block, 'codeBlock') &&
-      out.length > 0 &&
-      isNodeOfType(out[out.length - 1], 'list')
-    ) {
+    if (attrs.fenceStyle === 'indented' && isNodeOfType(block, 'codeBlock') && followsList(out)) {
       out.push(
         nodes.codeBlock(
           { language: attrs.language, fenceStyle: null, fenceLength: attrs.fenceLength },
@@ -150,6 +145,13 @@ function appendBlocks(
     }
     out.push(block)
   }
+}
+
+// Blank lines do not end a list, so the empty paragraphs a run of them leaves behind do not either.
+function followsList(out: ReadonlyArray<ProseMirrorNode>): boolean {
+  let last = out.length - 1
+  while (last >= 0 && isNodeOfType(out[last], 'paragraph') && out[last].content.size === 0) last--
+  return last >= 0 && isNodeOfType(out[last], 'list')
 }
 
 /**

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -729,6 +729,12 @@ describe('code blocks', () => {
   it('keeps an indented code block after a paragraph', () => {
     expect(roundtrip('text\n\n    code')).toBe('text\n\n    code\n')
   })
+
+  it('fences a code block a blank-line run leaves after a list', () => {
+    // The blank lines do not end the list, so four columns would still land
+    // inside the item above.
+    expect(roundtrip('  1.\n\n\n    code')).toBe('1.\n\n\n```\ncode\n```\n')
+  })
 })
 
 describe('thematic breaks', () => {


### PR DESCRIPTION
`appendBlocks` already drops the indented spelling from a code block that lands right after a list, but it only looked at the block immediately before it. A run of blank lines leaves empty gap paragraphs in between, and blank lines do not end a list, so `    code` still landed inside the item above. It now looks past those empty paragraphs.