### PR TITLE
fix: measure the column a list item's own indentation puts its content at

### DIFF
--- a/packages/core/src/converters/check-roundtrip-spec.test.ts
+++ b/packages/core/src/converters/check-roundtrip-spec.test.ts
@@ -4,8 +4,8 @@ import { expect, it } from 'vitest'
 import { checkRoundTrip } from './check-roundtrip.ts'
 
 // Spec inputs that are genuinely lossy today, pinned like `LOSSY_CASES` and
-// burned down over time. 312 is the escalating-indent list.
-const KNOWN_LOSSY = new Set<number>([312])
+// burned down over time. Every spec example survives the round trip today.
+const KNOWN_LOSSY = new Set<number>()
 
 it.each(commonmark.map((example, index) => [index + 1, example.markdown] as const))(
   'spec example %i round-trips without loss',

--- a/packages/core/src/converters/check-roundtrip.test.ts
+++ b/packages/core/src/converters/check-roundtrip.test.ts
@@ -256,15 +256,16 @@ const NORMALIZING_CASES: string[] = [
 
   // an empty task's lazy line goes back out under the quote's own marker
   '> - [ ] \nb',
-]
 
-const LOSSY_CASES: string[] = [
-  // a lazy line beside a fence or table lookalike is re-quoted into the quote
+  // a delimiter row under a pipe-bearing line stays lazy, so the quote's own
+  // lines keep it out of a table
   '>2\n```|`\n|-|',
   '>~\n>*|\n-|',
   '>$\n~|\n>|-|',
   '>\\\n|-\n>|-|',
+]
 
+const LOSSY_CASES: string[] = [
   // a conflict marker run respaces into a blockquote nest that swallows the
   // second marker line
   '>>>>>>>,\n>>>>>>> \t>',

--- a/packages/core/src/converters/check-roundtrip.test.ts
+++ b/packages/core/src/converters/check-roundtrip.test.ts
@@ -266,15 +266,16 @@ const NORMALIZING_CASES: string[] = [
   '>~\n>*|\n-|',
   '>$\n~|\n>|-|',
   '>\\\n|-\n>|-|',
+
+  // CommonMark spec example 312: escalating one-space indents flatten, and the
+  // lazy line under the last of them keeps the columns that kept it lazy
+  '- a\n - b\n  - c\n   - d\n    - e',
 ]
 
 const LOSSY_CASES: string[] = [
   // a conflict marker run respaces into a blockquote nest that swallows the
   // second marker line
   '>>>>>>>,\n>>>>>>> \t>',
-
-  // CommonMark spec example 312: escalating one-space indents flatten
-  '- a\n - b\n  - c\n   - d\n    - e',
 ]
 
 describe('checkRoundTrip', () => {

--- a/packages/core/src/converters/check-roundtrip.test.ts
+++ b/packages/core/src/converters/check-roundtrip.test.ts
@@ -204,9 +204,12 @@ const NORMALIZING_CASES: string[] = [
   '- a\n\t\t-',
 
   // indentation cannot spell a code block that follows a list, nor one that
-  // opens with a blank line
+  // opens with a blank line. Blank lines do not end the list, so the empty
+  // paragraphs a run of them leaves behind do not put the code block out of
+  // the item's reach either
   ' 33)\n\t1',
   '*\t\t\n\t\t[',
+  '  1.\n\n\n\t~',
 
   // a cell past the delimiter row widens the table instead of dropping
   '| a |\n| --- |\n| b | c |',
@@ -269,9 +272,6 @@ const LOSSY_CASES: string[] = [
   // a conflict marker run respaces into a blockquote nest that swallows the
   // second marker line
   '>>>>>>>,\n>>>>>>> \t>',
-
-  // an empty ordered item keeps blank lines; the re-indented `~` changes blocks
-  '  1.\n\n\n\t~',
 
   // CommonMark spec example 312: escalating one-space indents flatten
   '- a\n - b\n  - c\n   - d\n    - e',

--- a/packages/core/src/converters/md-to-pm.test.ts
+++ b/packages/core/src/converters/md-to-pm.test.ts
@@ -1022,20 +1022,28 @@ describe('sliceColumn', () => {
 
 describe('dedentContinuation', () => {
   it('returns single-line content unchanged', () => {
-    expect(dedentContinuation('hello', 2)).toBe('hello')
+    expect(dedentContinuation('hello', 2, 2)).toBe('hello')
   })
 
   it('returns content unchanged at column 0', () => {
-    expect(dedentContinuation('a\n  b', 0)).toBe('a\n  b')
+    expect(dedentContinuation('a\n  b', 0, 0)).toBe('a\n  b')
   })
 
   it('keeps the first line and dedents the rest', () => {
-    expect(dedentContinuation('one\n    two', 2)).toBe('one\n  two')
+    expect(dedentContinuation('one\n    two', 2, 2)).toBe('one\n  two')
   })
 
   it('strips the full column from each continuation line', () => {
-    expect(dedentContinuation('line one\n  line two\n  line three', 2)).toBe(
+    expect(dedentContinuation('line one\n  line two\n  line three', 2, 2)).toBe(
       'line one\nline two\nline three',
     )
+  })
+
+  it('leaves a line that stops short of the source column', () => {
+    expect(dedentContinuation('one\n    two', 2, 5)).toBe('one\n    two')
+  })
+
+  it('dedents a line that reaches the source column', () => {
+    expect(dedentContinuation('one\n     two', 2, 5)).toBe('one\n   two')
   })
 })

--- a/packages/core/src/converters/md-to-pm.ts
+++ b/packages/core/src/converters/md-to-pm.ts
@@ -124,8 +124,8 @@ function collectBlocks(
 
 /**
  * Append `blocks`, dropping the indented spelling from a code block that lands
- * right after a list: four columns of indentation would put it inside the item
- * above instead of after it, so it can only be written as a fence.
+ * after a list: four columns of indentation would put it inside the item above
+ * instead of after it, so it can only be written as a fence.
  */
 function appendBlocks(
   out: ProseMirrorNode[],
@@ -134,12 +134,7 @@ function appendBlocks(
 ): void {
   for (const block of blocks) {
     const attrs = block.attrs as MeowdownCodeBlockAttrs
-    if (
-      attrs.fenceStyle === 'indented' &&
-      isNodeOfType(block, 'codeBlock') &&
-      out.length > 0 &&
-      isNodeOfType(out[out.length - 1], 'list')
-    ) {
+    if (attrs.fenceStyle === 'indented' && isNodeOfType(block, 'codeBlock') && followsList(out)) {
       out.push(
         nodes.codeBlock(
           { language: attrs.language, fenceStyle: null, fenceLength: attrs.fenceLength },
@@ -150,6 +145,20 @@ function appendBlocks(
     }
     out.push(block)
   }
+}
+
+/**
+ * Whether the blocks written so far end in a list the next one still lands
+ * inside of. The empty paragraphs a blank-line run leaves behind write nothing
+ * but those blank lines, and blank lines do not end a list.
+ */
+function followsList(out: ReadonlyArray<ProseMirrorNode>): boolean {
+  for (let index = out.length - 1; index >= 0; index--) {
+    const block = out[index]
+    if (isNodeOfType(block, 'list')) return true
+    if (!isNodeOfType(block, 'paragraph') || block.content.size > 0) return false
+  }
+  return false
 }
 
 /**

--- a/packages/core/src/converters/md-to-pm.ts
+++ b/packages/core/src/converters/md-to-pm.ts
@@ -75,7 +75,7 @@ export function markdownToDoc(
 
   const tree = gfmBlockOnlyParser.parse(rest)
   const cursor = tree.cursor()
-  const blocks = collectBlocks(nodes, cursor, rest, 0)
+  const blocks = collectBlocks(nodes, cursor, rest, 0, 0)
 
   return nodes.doc(frontmatterBody === undefined ? {} : { frontmatter: frontmatterBody }, blocks)
 }
@@ -109,6 +109,7 @@ function collectBlocks(
   cursor: TreeCursor,
   text: string,
   column: number,
+  sourceColumn: number,
 ): ProseMirrorNode[] {
   const out: ProseMirrorNode[] = []
   if (!cursor.firstChild()) return out
@@ -116,7 +117,7 @@ function collectBlocks(
   do {
     if (previousTo != null) appendGapParagraphs(out, nodes, text, previousTo, cursor.from)
     previousTo = cursor.to
-    appendBlocks(out, nodes, convertBlock(nodes, cursor, text, column))
+    appendBlocks(out, nodes, convertBlock(nodes, cursor, text, column, sourceColumn))
   } while (cursor.nextSibling())
   cursor.parent()
   return out
@@ -187,45 +188,46 @@ function convertBlock(
   cursor: TreeCursor,
   text: string,
   column: number,
+  sourceColumn: number,
 ): ProseMirrorNode[] {
   switch (cursor.type.id) {
     case LEZER_NODE_IDS.ATXHeading1:
-      return [convertHeading(nodes, cursor, text, column, 1, false)]
+      return [convertHeading(nodes, cursor, text, column, sourceColumn, 1, false)]
     case LEZER_NODE_IDS.ATXHeading2:
-      return [convertHeading(nodes, cursor, text, column, 2, false)]
+      return [convertHeading(nodes, cursor, text, column, sourceColumn, 2, false)]
     case LEZER_NODE_IDS.ATXHeading3:
-      return [convertHeading(nodes, cursor, text, column, 3, false)]
+      return [convertHeading(nodes, cursor, text, column, sourceColumn, 3, false)]
     case LEZER_NODE_IDS.ATXHeading4:
-      return [convertHeading(nodes, cursor, text, column, 4, false)]
+      return [convertHeading(nodes, cursor, text, column, sourceColumn, 4, false)]
     case LEZER_NODE_IDS.ATXHeading5:
-      return [convertHeading(nodes, cursor, text, column, 5, false)]
+      return [convertHeading(nodes, cursor, text, column, sourceColumn, 5, false)]
     case LEZER_NODE_IDS.ATXHeading6:
-      return [convertHeading(nodes, cursor, text, column, 6, false)]
+      return [convertHeading(nodes, cursor, text, column, sourceColumn, 6, false)]
     case LEZER_NODE_IDS.SetextHeading1:
-      return [convertHeading(nodes, cursor, text, column, 1, true)]
+      return [convertHeading(nodes, cursor, text, column, sourceColumn, 1, true)]
     case LEZER_NODE_IDS.SetextHeading2:
-      return [convertHeading(nodes, cursor, text, column, 2, true)]
+      return [convertHeading(nodes, cursor, text, column, sourceColumn, 2, true)]
     case LEZER_NODE_IDS.Paragraph:
-      return [convertParagraph(nodes, cursor, text, column)]
+      return [convertParagraph(nodes, cursor, text, column, sourceColumn)]
     case LEZER_NODE_IDS.LinkReference:
-      return [convertParagraph(nodes, cursor, text, column)]
+      return [convertParagraph(nodes, cursor, text, column, sourceColumn)]
     case LEZER_NODE_IDS.CommentBlock:
       // A comment is not rendered output: map it onto the invisible `htmlComment`
       // node so it stays in the document (and round-trips) without reading as
       // body text. Raw HTML / processing-instruction blocks fall through to a
       // paragraph - they can carry content a reader expects to see.
-      return [convertHTMLComment(nodes, cursor, text, column)]
+      return [convertHTMLComment(nodes, cursor, text, column, sourceColumn)]
     case LEZER_NODE_IDS.HTMLBlock:
     case LEZER_NODE_IDS.ProcessingInstructionBlock:
       // The schema has no HTML node, so keep the raw block as literal paragraph
       // text; it survives verbatim through a round-trip.
-      return [convertParagraph(nodes, cursor, text, column)]
+      return [convertParagraph(nodes, cursor, text, column, sourceColumn)]
     case LEZER_NODE_IDS.Blockquote:
       return [convertBlockquote(nodes, cursor, text)]
     case LEZER_NODE_IDS.BulletList:
-      return convertList(nodes, cursor, text, column, 'bullet')
+      return convertList(nodes, cursor, text, column, sourceColumn, 'bullet')
     case LEZER_NODE_IDS.OrderedList:
-      return convertList(nodes, cursor, text, column, 'ordered')
+      return convertList(nodes, cursor, text, column, sourceColumn, 'ordered')
     case LEZER_NODE_IDS.FencedCode:
     case LEZER_NODE_IDS.CodeBlock:
       return [convertCodeBlock(nodes, cursor, text)]
@@ -244,14 +246,14 @@ function convertBlock(
       // the Task in `convertListItem`). The flat-list schema has a single
       // `kind`, so an ordered item cannot also be a task - keep the
       // `[x]` marker as literal paragraph text so it round-trips verbatim.
-      return [convertParagraph(nodes, cursor, text, column)]
+      return [convertParagraph(nodes, cursor, text, column, sourceColumn)]
     default: {
       // Never silently drop a block: an unhandled type keeps its raw source as literal paragraph text. Warn so a
       // missing converter case surfaces instead of losing content quietly.
       const raw = text.slice(cursor.from, cursor.to)
       if (raw.trim() === '') return []
       console.warn(`[meowdown] unsupported lezer block "${cursor.type.name}"`)
-      return [convertParagraph(nodes, cursor, text, column)]
+      return [convertParagraph(nodes, cursor, text, column, sourceColumn)]
     }
   }
 }
@@ -261,6 +263,7 @@ function convertHeading(
   cursor: TreeCursor,
   text: string,
   column: number,
+  sourceColumn: number,
   level: number,
   isSetext: boolean,
 ): ProseMirrorNode {
@@ -303,7 +306,11 @@ function convertHeading(
   // whitespace at either end is the gap around it; a setext heading's text is
   // whole lines and keeps its own spacing - `#\t` is a paragraph line where a
   // bare `#` would be a heading.
-  const raw = dedentContinuation(readLeafText(cursor, text, contentStart, contentEnd), column)
+  const raw = dedentContinuation(
+    readLeafText(cursor, text, contentStart, contentEnd),
+    column,
+    sourceColumn,
+  )
   const content = isSetext ? raw : trimGap(raw)
   // A trailing HeaderMark is the setext underline of a setext heading, or the
   // closing `#` run of an ATX heading (`# foo #`). CommonMark allows either run
@@ -372,6 +379,12 @@ export function measureContentColumn(text: string, from: number): number {
   return col
 }
 
+function measureIndent(line: string): number {
+  let index = 0
+  while (line.charCodeAt(index) === CHAR_SPACE || line.charCodeAt(index) === CHAR_TAB) index++
+  return measureContentColumn(line, index)
+}
+
 /**
  * Drop a line's leading whitespace up to `column`, counting a tab as `4 - col % 4`
  * columns. Whitespace the container never wrote is left alone: a tab that would
@@ -405,17 +418,24 @@ export function sliceColumn(line: string, column: number): string {
  *
  * lezer keeps the indent of a multi-line block's continuation lines inside the
  * source span (its `scrub` pads each line's container prefix to equal-width
- * whitespace to preserve positions). CommonMark and lezer require every
- * continuation line to be indented to the same content `column`, which equals
- * the block's first-line column. The first line is already past its indent, so
- * only lines 2..n are dedented. Returns `content` untouched at column 0 (a
+ * whitespace to preserve positions). The first line is already past its indent,
+ * so only lines 2..n are dedented. Returns `content` untouched at column 0 (a
  * top-level block) or when there is no continuation line.
+ *
+ * `column` is the column the serializer writes the containers' prefixes back at,
+ * and so the only one that may come off. `sourceColumn` is the column the source
+ * indents to, which a list item's own indentation puts further right.
  */
-export function dedentContinuation(content: string, column: number): string {
-  if (column === 0 || !content.includes('\n')) return content
+export function dedentContinuation(content: string, column: number, sourceColumn: number): string {
+  if (sourceColumn === 0 || !content.includes('\n')) return content
   return content
     .split('\n')
-    .map((line, index) => (index === 0 ? line : sliceColumn(line, column)))
+    .map((line, index) => {
+      // A line that stops short of `sourceColumn` carried no container prefix at
+      // all - it is a lazy continuation, and every column on it is its own.
+      if (index === 0 || measureIndent(line) < sourceColumn) return line
+      return sliceColumn(line, column)
+    })
     .join('\n')
 }
 
@@ -502,10 +522,11 @@ function buildParagraph(
   nodes: TypedNodeBuilders,
   content: string,
   column: number,
+  sourceColumn: number,
 ): ProseMirrorNode {
   // An empty string adds no child (the builder skips falsy text), so this also
   // covers the empty-paragraph case.
-  return nodes.paragraph(dedentContinuation(content, column))
+  return nodes.paragraph(dedentContinuation(content, column, sourceColumn))
 }
 
 function convertParagraph(
@@ -513,8 +534,14 @@ function convertParagraph(
   cursor: TreeCursor,
   text: string,
   column: number,
+  sourceColumn: number,
 ): ProseMirrorNode {
-  return buildParagraph(nodes, readLeafText(cursor, text, cursor.from, cursor.to), column)
+  return buildParagraph(
+    nodes,
+    readLeafText(cursor, text, cursor.from, cursor.to),
+    column,
+    sourceColumn,
+  )
 }
 
 /**
@@ -528,8 +555,13 @@ function convertHTMLComment(
   cursor: TreeCursor,
   text: string,
   column: number,
+  sourceColumn: number,
 ): ProseMirrorNode {
-  const content = dedentContinuation(readLeafText(cursor, text, cursor.from, cursor.to), column)
+  const content = dedentContinuation(
+    readLeafText(cursor, text, cursor.from, cursor.to),
+    column,
+    sourceColumn,
+  )
   return nodes.htmlComment({ content })
 }
 
@@ -549,7 +581,7 @@ function convertBlockquote(
       if (cursor.type.id === LEZER_NODE_IDS.QuoteMark) continue
       if (previousTo != null) appendGapParagraphs(content, nodes, text, previousTo, cursor.from)
       previousTo = cursor.to
-      appendBlocks(content, nodes, convertBlock(nodes, cursor, text, 0))
+      appendBlocks(content, nodes, convertBlock(nodes, cursor, text, 0, 0))
     } while (cursor.nextSibling())
     cursor.parent()
   }
@@ -561,13 +593,14 @@ function convertList(
   cursor: TreeCursor,
   text: string,
   column: number,
+  sourceColumn: number,
   kind: 'bullet' | 'ordered',
 ): ProseMirrorNode[] {
   const items: ProseMirrorNode[] = []
   if (cursor.firstChild()) {
     do {
       if (cursor.type.id === LEZER_NODE_IDS.ListItem) {
-        items.push(convertListItem(nodes, cursor, text, column, kind))
+        items.push(convertListItem(nodes, cursor, text, column, sourceColumn, kind))
       }
     } while (cursor.nextSibling())
     cursor.parent()
@@ -612,6 +645,7 @@ function convertTaskItem(
   cursor: TreeCursor,
   text: string,
   column: number,
+  sourceColumn: number,
 ): { checked: boolean; taskMarker: TaskMarker | undefined; paragraph: ProseMirrorNode } {
   let taskStart = cursor.from
   const taskEnd = cursor.to
@@ -636,8 +670,25 @@ function convertTaskItem(
   const taskText = readLeafText(cursor, text, taskStart, taskEnd)
   // The checkbox sits on the first line only: the serializer indents the task's
   // continuation lines to the item's own column, not past `[ ] `.
-  const paragraph = buildParagraph(nodes, taskText, column)
+  const paragraph = buildParagraph(nodes, taskText, column, sourceColumn)
   return { checked, taskMarker, paragraph }
+}
+
+/**
+ * The gap between an item's marker and the content at `contentFrom`. Only
+ * content that opens on the marker's own line measures one; an item whose
+ * content starts on the next line takes the canonical single space, the column
+ * its own continuation lines are indented to.
+ */
+function measureMarkerGap(
+  text: string,
+  contentFrom: number,
+  markTo: number | undefined,
+  markEndColumn: number,
+): number {
+  const onMarkLine = markTo != null && text.lastIndexOf('\n', contentFrom - 1) < markTo
+  const gap = onMarkLine ? measureContentColumn(text, contentFrom) - markEndColumn : 1
+  return gap >= 2 && gap <= 4 ? gap : 1
 }
 
 function convertListItem(
@@ -645,17 +696,22 @@ function convertListItem(
   cursor: TreeCursor,
   text: string,
   column: number,
+  sourceColumn: number,
   kind: 'bullet' | 'ordered',
 ): ProseMirrorNode {
   const content: ProseMirrorNode[] = []
 
   let taskChecked: boolean | undefined
   let taskMarker: TaskMarker | undefined
-  let order: number | undefined
-  let marker: ListMarker | undefined
-  let markWidth = 1
+  let listMark: { marker: ListMarker | undefined; order: number | undefined } | undefined
   let markTo: number | undefined
-  let markEndColumn = 0
+  let markWidth = 1
+  // The columns between these two are the marker plus the up to three columns of
+  // indentation an item may carry on top of the enclosing containers'. The
+  // serializer writes the marker back without that indentation, which is why the
+  // two content columns below differ.
+  const itemColumn = measureContentColumn(text, cursor.from)
+  let markEndColumn = itemColumn + markWidth
   // The gap between the marker and the content. A gap of 5+ is indented code (a
   // different node, so the first child's column would be the code block's), and 1 is
   // the canonical default; only a 2-4 space gap is a faithful, content-preserving
@@ -665,6 +721,7 @@ function convertListItem(
   // on top of whatever the enclosing containers already add. Both the marker and
   // the gap are known once the first block after the mark is reached.
   let contentColumn = column + markWidth + markerGap
+  let sourceContentColumn = sourceColumn + markEndColumn - itemColumn + markerGap
   let sawContent = false
 
   if (cursor.firstChild()) {
@@ -673,9 +730,7 @@ function convertListItem(
       // inside the item, the same way it does inside a paragraph.
       if (cursor.type.id === LEZER_NODE_IDS.QuoteMark) continue
       if (cursor.type.id === LEZER_NODE_IDS.ListMark) {
-        const listMark = readListMark(cursor, text, kind)
-        marker = listMark.marker
-        order = listMark.order
+        listMark = readListMark(cursor, text, kind)
         markWidth = cursor.to - cursor.from
         markTo = cursor.to
         markEndColumn = measureContentColumn(text, cursor.to)
@@ -683,22 +738,22 @@ function convertListItem(
       }
       if (!sawContent) {
         sawContent = true
-        // Only content that opens on the marker's own line measures a gap; an
-        // item whose content starts on the next line takes the canonical single
-        // space, the column its own continuation lines are indented to.
-        const onMarkLine = markTo != null && text.lastIndexOf('\n', cursor.from - 1) < markTo
-        const gap = onMarkLine ? measureContentColumn(text, cursor.from) - markEndColumn : 1
-        markerGap = gap >= 2 && gap <= 4 ? gap : 1
+        markerGap = measureMarkerGap(text, cursor.from, markTo, markEndColumn)
         contentColumn = column + markWidth + markerGap
+        sourceContentColumn = sourceColumn + markEndColumn - itemColumn + markerGap
       }
       if (kind === 'bullet' && cursor.type.id === LEZER_NODE_IDS.Task) {
-        const task = convertTaskItem(nodes, cursor, text, contentColumn)
+        const task = convertTaskItem(nodes, cursor, text, contentColumn, sourceContentColumn)
         taskChecked = task.checked
         taskMarker = task.taskMarker
         content.push(task.paragraph)
         continue
       }
-      appendBlocks(content, nodes, convertBlock(nodes, cursor, text, contentColumn))
+      appendBlocks(
+        content,
+        nodes,
+        convertBlock(nodes, cursor, text, contentColumn, sourceContentColumn),
+      )
     } while (cursor.nextSibling())
     cursor.parent()
   }
@@ -708,13 +763,13 @@ function convertListItem(
   // `+ [ ]` is still a circle task, so collapse only applies when there is no
   // checkbox.
   const isTask = taskChecked != null
-  const collapsed = !isTask && kind === 'bullet' && marker === '+'
+  const collapsed = !isTask && kind === 'bullet' && listMark?.marker === '+'
   const attrs: MeowdownListAttrs = {
     kind: isTask ? 'task' : kind,
-    order: kind === 'ordered' ? (order ?? 1) : null,
+    order: kind === 'ordered' ? (listMark?.order ?? 1) : null,
     checked: taskChecked ?? false,
     collapsed,
-    marker: collapsed ? null : marker,
+    marker: collapsed ? null : listMark?.marker,
     taskMarker,
     markerGap,
   }

--- a/packages/core/src/converters/pm-to-md.ts
+++ b/packages/core/src/converters/pm-to-md.ts
@@ -11,6 +11,7 @@ import { isNodeOfType, type NodeName } from '../extensions/node-names.ts'
 import type { MeowdownTableCellAttrs, TableColumnAlign } from '../extensions/table-column-align.ts'
 import {
   CHAR_ASTERISK,
+  CHAR_BACKSLASH,
   CHAR_BACKTICK,
   CHAR_DIGIT_ONE,
   CHAR_DOLLAR,
@@ -21,6 +22,7 @@ import {
   CHAR_HYPHEN_MINUS,
   CHAR_LESS_THAN,
   CHAR_LINE_FEED,
+  CHAR_PIPE,
   CHAR_PLUS,
   CHAR_RIGHT_PARENTHESIS,
   CHAR_SPACE,
@@ -160,6 +162,7 @@ class MdOut {
   write(text: string, lazyLines = false): void {
     if (text === '') return
     this.emitDeferredBlankLine()
+    let opening = this.linePrefix
     if (this.atLineStart) {
       // `- ` and a paragraph reading `--` make the line `- --`, a thematic
       // break. Leave the marker on a line of its own and indent the text under
@@ -167,7 +170,8 @@ class MdOut {
       if (this.pendingFirst !== null && isThematicBreak(this.pendingFirst + text)) {
         this.breakMarkerLine()
       }
-      this.parts.push(this.pendingFirst ?? this.linePrefix)
+      opening = this.pendingFirst ?? this.linePrefix
+      this.parts.push(opening)
       this.pendingFirst = null
       this.atLineStart = false
     }
@@ -181,10 +185,21 @@ class MdOut {
     // Index loop avoids the `.entries()` iterator allocation - measurable
     // (~7%) on the hot write() path.
     const lazy = lazyLines && this.linePrefix !== ''
+    // A first line with a pipe of its own gets lezer's table parser, which reads
+    // every row from the same column whichever spelling it goes out in. Only
+    // without one can a delimiter row below take the line above out of the
+    // paragraph.
+    const tableRisk = lazy && !hasPipe(lines[0], 0)
+    let base = opening.length
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]
       if (i > 0) {
-        this.parts.push('\n', lazy ? continuationPrefix(line, this.linePrefix) : this.linePrefix)
+        let prefix = lazy ? continuationPrefix(line, this.linePrefix) : this.linePrefix
+        if (tableRisk && opensTable(line, prefix, lines[i - 1], base)) {
+          prefix = lazyIndent(this.linePrefix)
+        }
+        this.parts.push('\n', prefix)
+        base = prefix.length
       }
       if (line !== '') this.parts.push(line)
     }
@@ -486,6 +501,59 @@ function continuationPrefix(line: string, prefix: string): string {
   // it alone and nothing at the far left reads it back as a block: an
   // underline binds to no lazy paragraph, while an opener still opens.
   return !opens && dedentKeepsLine(line, lazy.length) ? '' : lazy
+}
+
+// A GFM delimiter row, minus whatever container markers open its line: optional
+// pipes around cells of dashes with optional colons. Those markers are all `>`
+// or whitespace, which is what lets a line read the same with or without the
+// prefix it will be written behind.
+const DELIMITER_ROW_RE = /^\|?(?:\s*:?-+:?\s*\|)+(?:\s*:?-+:?\s*)?$/u
+const DELIMITER_ROW_MARKERS_RE = /^[>\s]*/u
+
+/**
+ * Whether writing `line` behind `prefix` reads as a delimiter row under
+ * `previous`, the line above it, which ends the paragraph there and starts a
+ * table. Both rows are counted from `previousBase`, the column the line above
+ * ends its own markers at, so a row written without them counts different cells
+ * and the two lines stay one paragraph.
+ */
+function opensTable(line: string, prefix: string, previous: string, previousBase: number): boolean {
+  if (!DELIMITER_ROW_RE.test(line.replace(DELIMITER_ROW_MARKERS_RE, ''))) return false
+  if (!hasPipe(previous, 0)) return false
+  return countTableCells(previous, 0) === countTableCells(prefix + line, previousBase)
+}
+
+function hasPipe(line: string, start: number): boolean {
+  for (let index = start; index < line.length; index++) {
+    const code = line.charCodeAt(index)
+    if (code === CHAR_PIPE) return true
+    if (code === CHAR_BACKSLASH) index++
+  }
+  return false
+}
+
+/**
+ * The cells `line` carries from `start` on. An unescaped pipe closes the cell in
+ * front of it and whitespace alone is no cell, so the outer pipes a row may or
+ * may not carry count for nothing.
+ */
+function countTableCells(line: string, start: number): number {
+  let count = 0
+  let first = true
+  let inCell = false
+  let escaped = false
+  for (let index = start; index < line.length; index++) {
+    const code = line.charCodeAt(index)
+    if (code === CHAR_PIPE && !escaped) {
+      if (!first || inCell) count++
+      first = false
+      inCell = false
+    } else if (escaped || !isSpaceOrTab(code)) {
+      inCell = true
+    }
+    escaped = !escaped && code === CHAR_BACKSLASH
+  }
+  return inCell ? count + 1 : count
 }
 
 /**

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -355,6 +355,12 @@ describe('blockquotes', () => {
   it('keeps a two-item list in a quote', () => {
     expect(roundtrip('> - a\n> - b')).toBe('> - a\n> - b\n')
   })
+
+  it('keeps a delimiter row out of the quote', () => {
+    // Under the quote marker the two lines would read as a table header and
+    // its delimiter row; lazily is the only spelling that keeps them text.
+    expect(roundtrip('> text\n> a|\n-|')).toBe('> text\n> a|\n-|\n')
+  })
 })
 
 describe('bullet lists', () => {

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -394,6 +394,13 @@ describe('bullet lists', () => {
     expect(roundtrip(md)).toBe(md + '\n')
   })
 
+  it('keeps a lazy line under an indented item', () => {
+    // Three columns of indentation put the item's content column at 5, so the
+    // four-column line below it is a lazy continuation, not a nested item; the
+    // columns it keeps are what stop it from becoming one on the way back.
+    expect(roundtrip('   - d\n    - e')).toBe('- d\n      - e\n')
+  })
+
   it('keeps a soft break in a nested item', () => {
     const md = ['- a', '  - x', '', '    line one', '    line two'].join('\n')
     expect(roundtrip(md)).toBe(md + '\n')

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -729,6 +729,12 @@ describe('code blocks', () => {
   it('keeps an indented code block after a paragraph', () => {
     expect(roundtrip('text\n\n    code')).toBe('text\n\n    code\n')
   })
+
+  it('fences a code block a blank-line run leaves after a list', () => {
+    // The blank lines do not end the list, so four columns would still land
+    // inside the item above.
+    expect(roundtrip('  1.\n\n\n    code')).toBe('1.\n\n\n```\ncode\n```\n')
+  })
 })
 
 describe('thematic breaks', () => {

--- a/packages/core/src/unicode.ts
+++ b/packages/core/src/unicode.ts
@@ -20,3 +20,5 @@ export const CHAR_LESS_THAN = 60 /* < */
 export const CHAR_DOLLAR = 36 /* $ */
 export const CHAR_UNDERSCORE = 95 /* _ */
 export const CHAR_DIGIT_ONE = 49 /* 1 */
+export const CHAR_PIPE = 124 /* | */
+export const CHAR_BACKSLASH = 92 /* \ */


### PR DESCRIPTION
A list item may carry up to three columns of indentation of its own, which the converter ignored: it read every item's content column as the container's plus the marker, so a lazy line under ` - b` was dedented as though it had carried a prefix it never had (CommonMark spec example 312). `dedentContinuation` now takes both columns: `column` is what the serializer writes back and the only thing that may come off, while `sourceColumn` decides whether the line was lazy at all.