### PR TITLE
fix: open no HTML block behind a task checkbox

### DIFF
--- a/packages/core/src/converters/pm-to-md.ts
+++ b/packages/core/src/converters/pm-to-md.ts
@@ -242,6 +242,11 @@ class MdOut {
     this.deferredBlankPrefix = null
   }
 
+  // A task's `[ ] ` is content of its own, so what follows it opens nothing.
+  get atContentStart(): boolean {
+    return this.atLineStart && !this.pendingFirst?.endsWith('] ')
+  }
+
   /**
    * Run `fn` with `linePrefix` extended by `continuation`.
    * If `firstLine` is given, it replaces the prefix on the NEXT line only -
@@ -552,6 +557,7 @@ const HTML_BLOCK_OPEN = [
  * line round-trips all the same, so one check serves both callers.
  */
 function opensHTMLBlock(text: string): boolean {
+  if (text.charCodeAt(0) !== CHAR_LESS_THAN) return false
   const lineEnd = text.indexOf('\n')
   const line = lineEnd < 0 ? text : text.slice(0, lineEnd)
   return HTML_BLOCK_OPEN.some((pattern) => pattern.test(line))
@@ -685,7 +691,7 @@ function emitInlineChildren(node: ProseMirrorNode, out: MdOut): void {
   // carries its container markers - there is no lazy continuation to fall back
   // on, so every line keeps the full prefix.
   const first = node.child(0).text
-  const lazy = first == null || first.charCodeAt(0) !== CHAR_LESS_THAN || !opensHTMLBlock(first)
+  const lazy = first == null || !out.atContentStart || !opensHTMLBlock(first)
   for (let i = 0; i < count; i++) {
     const child = node.child(i)
     if (child.isText && child.text) out.write(child.text, lazy)

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -568,6 +568,12 @@ describe('task lists', () => {
     expect(roundtrip('> - [ ] line one\n>   line two')).toBe('> - [ ] line one\n>   line two\n')
   })
 
+  it('keeps a comment opener in a task', () => {
+    // The checkbox in front is content of its own, so the `<!--` behind it
+    // opens no HTML block and the line below can still go out lazily.
+    expect(roundtrip('- [ ] <!--\n=')).toBe('- [ ] <!--\n=\n')
+  })
+
   it.fails('keeps a lazy continuation in a task', () => {
     // Same lazy-continuation limitation as bullet lists; the flush line is
     // re-indented to the task's content column on serialize.


### PR DESCRIPTION
`emitInlineChildren` gives up lazy continuations for any leaf whose text starts with an HTML block opener, but inside a task the `[ ] ` in front is content of its own, so `- [ ] <!--` opens nothing. The prefixed continuation line that followed re-parsed as a setext underline; `MdOut.atContentStart` now tells the two apart.