### PR TITLE
fix: open no HTML block behind a task checkbox

### DIFF
--- a/packages/core/src/converters/check-roundtrip.test.ts
+++ b/packages/core/src/converters/check-roundtrip.test.ts
@@ -258,10 +258,7 @@ const NORMALIZING_CASES: string[] = [
   '> - [ ] \nb',
 
   // a task with an HTML comment in its lazy line
-  '- [ ] <!--\nABC\n-->',
-
-  // a task with an HTML element
-  '- [ ] <div></div>\nABC',
+  '- [ ] <!--\n-',
 ]
 
 const LOSSY_CASES: string[] = [

--- a/packages/core/src/converters/check-roundtrip.test.ts
+++ b/packages/core/src/converters/check-roundtrip.test.ts
@@ -94,6 +94,9 @@ const EXACT_CASES: string[] = [
   // a task's continuation lines align with the item, not with the checkbox
   '- [ ] a\n      b',
 
+  // a task with an HTML comment in its lazy line
+  '- [ ] <!--\n-',
+
   // a nested blockquote's continuation keeps the indent inside the quote
   '- > a\n  >   b',
 
@@ -256,9 +259,6 @@ const NORMALIZING_CASES: string[] = [
 
   // an empty task's lazy line goes back out under the quote's own marker
   '> - [ ] \nb',
-
-  // a task with an HTML comment in its lazy line
-  '- [ ] <!--\n-',
 ]
 
 const LOSSY_CASES: string[] = [

--- a/packages/core/src/converters/check-roundtrip.test.ts
+++ b/packages/core/src/converters/check-roundtrip.test.ts
@@ -258,10 +258,10 @@ const NORMALIZING_CASES: string[] = [
   '> - [ ] \nb',
 
   // a task with an HTML comment in its lazy line
-  '- [x] <!--\nABC\n-->',
+  '- [ ] <!--\nABC\n-->',
 
   // a task with an HTML element
-  '- [x] <div></div>\nABC',
+  '- [ ] <div></div>\nABC',
 ]
 
 const LOSSY_CASES: string[] = [

--- a/packages/core/src/converters/check-roundtrip.test.ts
+++ b/packages/core/src/converters/check-roundtrip.test.ts
@@ -259,6 +259,9 @@ const NORMALIZING_CASES: string[] = [
 
   // a task with an HTML comment in its lazy line
   '- [x] <!--\nABC\n-->',
+
+  // a task with an HTML element
+  '- [x] <div></div>\nABC',
 ]
 
 const LOSSY_CASES: string[] = [

--- a/packages/core/src/converters/check-roundtrip.test.ts
+++ b/packages/core/src/converters/check-roundtrip.test.ts
@@ -256,6 +256,9 @@ const NORMALIZING_CASES: string[] = [
 
   // an empty task's lazy line goes back out under the quote's own marker
   '> - [ ] \nb',
+
+  // a task with an HTML comment in its lazy line
+  '- [x] <!--\nABC\n-->',
 ]
 
 const LOSSY_CASES: string[] = [

--- a/packages/core/src/converters/pm-to-md.ts
+++ b/packages/core/src/converters/pm-to-md.ts
@@ -253,6 +253,11 @@ class MdOut {
     this.deferredBlankPrefix = null
   }
 
+  // A task's `[ ] ` is content of its own, so what follows it opens nothing.
+  get atContentStart(): boolean {
+    return this.atLineStart && !this.pendingFirst?.endsWith('] ')
+  }
+
   /**
    * Run `fn` with `linePrefix` extended by `continuation`.
    * If `firstLine` is given, it replaces the prefix on the NEXT line only -
@@ -547,6 +552,7 @@ const HTML_BLOCK_OPEN = [
  * line round-trips all the same, so one check serves both callers.
  */
 function opensHTMLBlock(text: string): boolean {
+  if (text.charCodeAt(0) !== CHAR_LESS_THAN) return false
   const lineEnd = text.indexOf('\n')
   const line = lineEnd < 0 ? text : text.slice(0, lineEnd)
   for (const pattern of HTML_BLOCK_OPEN) {
@@ -687,7 +693,7 @@ function emitInlineChildren(node: ProseMirrorNode, out: MdOut): void {
   // carries its container markers - there is no lazy continuation to fall back
   // on, so every line keeps the full prefix.
   const first = node.child(0).text
-  const lazy = first == null || first.charCodeAt(0) !== CHAR_LESS_THAN || !opensHTMLBlock(first)
+  const lazy = first == null || !out.atContentStart || !opensHTMLBlock(first)
   for (let i = 0; i < count; i++) {
     const child = node.child(i)
     if (child.isText && child.text) out.write(child.text, lazy)

--- a/packages/core/src/converters/pm-to-md.ts
+++ b/packages/core/src/converters/pm-to-md.ts
@@ -253,11 +253,6 @@ class MdOut {
     this.deferredBlankPrefix = null
   }
 
-  // A task's `[ ] ` is content of its own, so what follows it opens nothing.
-  get atContentStart(): boolean {
-    return this.atLineStart && !this.pendingFirst?.endsWith('] ')
-  }
-
   /**
    * Run `fn` with `linePrefix` extended by `continuation`.
    * If `firstLine` is given, it replaces the prefix on the NEXT line only -
@@ -552,7 +547,6 @@ const HTML_BLOCK_OPEN = [
  * line round-trips all the same, so one check serves both callers.
  */
 function opensHTMLBlock(text: string): boolean {
-  if (text.charCodeAt(0) !== CHAR_LESS_THAN) return false
   const lineEnd = text.indexOf('\n')
   const line = lineEnd < 0 ? text : text.slice(0, lineEnd)
   for (const pattern of HTML_BLOCK_OPEN) {
@@ -693,7 +687,7 @@ function emitInlineChildren(node: ProseMirrorNode, out: MdOut): void {
   // carries its container markers - there is no lazy continuation to fall back
   // on, so every line keeps the full prefix.
   const first = node.child(0).text
-  const lazy = first == null || !out.atContentStart || !opensHTMLBlock(first)
+  const lazy = first == null || first.charCodeAt(0) !== CHAR_LESS_THAN || !opensHTMLBlock(first)
   for (let i = 0; i < count; i++) {
     const child = node.child(i)
     if (child.isText && child.text) out.write(child.text, lazy)

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -562,6 +562,12 @@ describe('task lists', () => {
     expect(roundtrip('> - [ ] line one\n>   line two')).toBe('> - [ ] line one\n>   line two\n')
   })
 
+  it('keeps a comment opener in a task', () => {
+    // The checkbox in front is content of its own, so the `<!--` behind it
+    // opens no HTML block and the line below can still go out lazily.
+    expect(roundtrip('- [ ] <!--\n=')).toBe('- [ ] <!--\n=\n')
+  })
+
   it.fails('keeps a lazy continuation in a task', () => {
     // Same lazy-continuation limitation as bullet lists; the flush line is
     // re-indented to the task's content column on serialize.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed round-trip conversion for task items containing HTML comment openers and lazy continuation lines.
  - Preserved HTML comments and their following content when converting between formats.

- **Tests**
  - Added coverage for task items with HTML comments to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->