### PR TITLE
fix: disable native spellcheck in code, math, and URL source text

### DIFF
--- a/packages/core/src/extensions/html-comment.test.ts
+++ b/packages/core/src/extensions/html-comment.test.ts
@@ -46,6 +46,7 @@ describe('html comment in a mounted editor', () => {
     const element = fixture.dom.querySelector<HTMLElement>('[data-html-comment]')
     expect(element).not.toBeNull()
     expect(getComputedStyle(element as HTMLElement).display).toBe('none')
+    expect(element?.getAttribute('spellcheck')).toBe('false')
     // The raw comment must not read as body text in the editor.
     expect(fixture.dom.textContent).not.toContain('reflect-capture-page-text')
     expect(fixture.dom.textContent).toContain('before')

--- a/packages/core/src/extensions/html-comment.ts
+++ b/packages/core/src/extensions/html-comment.ts
@@ -1,5 +1,7 @@
 import { defineNodeSpec, type Extension } from '@prosekit/core'
 
+import { NON_PROSE_ATTRS } from '../utils/non-prose-attrs.ts'
+
 import type { NodeName } from './node-names.ts'
 
 export interface MeowdownHTMLCommentAttrs {
@@ -50,6 +52,7 @@ export function defineHTMLComment(): HTMLCommentExtension {
       {
         'data-html-comment': (node.attrs as MeowdownHTMLCommentAttrs).content,
         style: 'display: none',
+        ...NON_PROSE_ATTRS,
       },
     ],
     parseDOM: [

--- a/packages/core/src/extensions/image.test.ts
+++ b/packages/core/src/extensions/image.test.ts
@@ -565,6 +565,6 @@ describe('image source spellcheck exemption', () => {
     await expect.element(imageSource).toHaveAttribute('autocorrect', 'off')
     await expect.element(imageSource).toHaveAttribute('autocapitalize', 'off')
     await expect.element(imageSource).toHaveAttribute('writingsuggestions', 'false')
-    expect(imageSource.element().spellcheck).toBe(false)
+    expect(imageSource.element()).toHaveProperty('spellcheck', false)
   })
 })

--- a/packages/core/src/extensions/image.test.ts
+++ b/packages/core/src/extensions/image.test.ts
@@ -554,3 +554,17 @@ describe('image mark view update', () => {
     expect(image2Element).toBe(image1Element)
   })
 })
+
+describe('image source spellcheck exemption', () => {
+  const imageSource = pmRoot.getByTestId('image-source')
+
+  it('renders the image source with spellcheck off', async () => {
+    using fixture = setup('show', '![alt](https://example.com/a.png)')
+    void fixture
+    await expect.element(imageSource).toHaveAttribute('spellcheck', 'false')
+    await expect.element(imageSource).toHaveAttribute('autocorrect', 'off')
+    await expect.element(imageSource).toHaveAttribute('autocapitalize', 'off')
+    await expect.element(imageSource).toHaveAttribute('writingsuggestions', 'false')
+    expect(imageSource.element().spellcheck).toBe(false)
+  })
+})

--- a/packages/core/src/extensions/image.ts
+++ b/packages/core/src/extensions/image.ts
@@ -7,6 +7,8 @@ import {
   type ResizeEndEvent,
 } from '@prosekit/web/resizable'
 
+import { NON_PROSE_ATTRS } from '../utils/non-prose-attrs.ts'
+
 import { listenForTweetHeight, matchEmbed, type EmbedDescriptor } from './embed.ts'
 import type { MdImageAttrs } from './inline-marks.ts'
 import {
@@ -221,6 +223,10 @@ class ImageMarkView implements MarkView {
 
     this.#contentDOM = document.createElement('span')
     this.#contentDOM.className = 'md-image-view-content md-atom-view-content'
+    this.#contentDOM.dataset.testid = 'image-source'
+    for (const [name, value] of Object.entries(NON_PROSE_ATTRS)) {
+      this.#contentDOM.setAttribute(name, value)
+    }
 
     const preview = this.#renderPreview()
     if (preview) {

--- a/packages/core/src/extensions/inline-marks.test.ts
+++ b/packages/core/src/extensions/inline-marks.test.ts
@@ -41,7 +41,7 @@ describe('inline mark spellcheck exemption', () => {
     await expect.element(inlineCode).toHaveAttribute('autocorrect', 'off')
     await expect.element(inlineCode).toHaveAttribute('autocapitalize', 'off')
     await expect.element(inlineCode).toHaveAttribute('writingsuggestions', 'false')
-    expect(inlineCode.element().spellcheck).toBe(false)
+    expect(inlineCode.element()).toHaveProperty('spellcheck', false)
   })
 
   it('renders the link destination with spellcheck off', async () => {
@@ -49,6 +49,6 @@ describe('inline mark spellcheck exemption', () => {
     void fixture
     const uri = pmRoot.getByText('https://example.com')
     await expect.element(uri).toHaveAttribute('spellcheck', 'false')
-    expect(uri.element().spellcheck).toBe(false)
+    expect(uri.element()).toHaveProperty('spellcheck', false)
   })
 })

--- a/packages/core/src/extensions/inline-marks.test.ts
+++ b/packages/core/src/extensions/inline-marks.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'vitest'
+import { page } from 'vitest/browser'
+
+import { setupFixture, type Fixture } from '../testing/index.ts'
 
 import { defineEditorExtension } from './extension.ts'
 import { MARK_NAMES } from './mark-names.ts'
@@ -16,5 +19,36 @@ describe('inline-marks', () => {
     const schema = defineEditorExtension().schema!
     const order = Object.keys(schema.marks)
     expect(order.indexOf('mdPack')).toBeLessThan(order.indexOf('mdImage'))
+  })
+})
+
+describe('inline mark spellcheck exemption', () => {
+  const pmRoot = page.locate('.ProseMirror')
+
+  // An editor showing one paragraph in show mode, so inline source is visible.
+  function setup(text: string): Fixture {
+    const fixture = setupFixture({ extensionOptions: { markMode: 'show' } })
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph(text)))
+    return fixture
+  }
+
+  it('renders inline code with spellcheck off', async () => {
+    using fixture = setup('a `raw code` b')
+    void fixture
+    const inlineCode = pmRoot.locate('code')
+    await expect.element(inlineCode).toHaveAttribute('spellcheck', 'false')
+    await expect.element(inlineCode).toHaveAttribute('autocorrect', 'off')
+    await expect.element(inlineCode).toHaveAttribute('autocapitalize', 'off')
+    await expect.element(inlineCode).toHaveAttribute('writingsuggestions', 'false')
+    expect(inlineCode.element().spellcheck).toBe(false)
+  })
+
+  it('renders the link destination with spellcheck off', async () => {
+    using fixture = setup('[label](https://example.com)')
+    void fixture
+    const uri = pmRoot.getByText('https://example.com')
+    await expect.element(uri).toHaveAttribute('spellcheck', 'false')
+    expect(uri.element().spellcheck).toBe(false)
   })
 })

--- a/packages/core/src/extensions/inline-marks.ts
+++ b/packages/core/src/extensions/inline-marks.ts
@@ -1,5 +1,7 @@
 import { defineMarkSpec, union } from '@prosekit/core'
 
+import { NON_PROSE_ATTRS } from '../utils/non-prose-attrs.ts'
+
 import type { MarkName } from './mark-names.ts'
 
 /**
@@ -87,7 +89,7 @@ function defineMdStrong() {
 function defineMdCode() {
   return defineMarkSpec({
     name: 'mdCode' satisfies MarkName,
-    toDOM: () => ['code', 0],
+    toDOM: () => ['code', { ...NON_PROSE_ATTRS }, 0],
     parseDOM: [{ tag: 'code' }],
   })
 }
@@ -118,7 +120,7 @@ function defineMdLinkUri() {
   return defineMarkSpec({
     name: 'mdLinkUri' satisfies MarkName,
     inclusive: false,
-    toDOM: () => ['span', { class: 'md-link-uri' }, 0],
+    toDOM: () => ['span', { class: 'md-link-uri', ...NON_PROSE_ATTRS }, 0],
     parseDOM: [{ tag: 'span.md-link-uri' }],
   })
 }

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -264,7 +264,13 @@ describe('focus mode', () => {
               ](
             </span>
           </span>
-          <span class="md-link-uri">
+          <span
+            autocapitalize="off"
+            autocorrect="off"
+            class="md-link-uri"
+            spellcheck="false"
+            writingsuggestions="false"
+          >
             <span class="show">
               http://x.test
             </span>
@@ -307,7 +313,13 @@ describe('focus mode', () => {
               ](
             </span>
           </span>
-          <span class="md-link-uri">
+          <span
+            autocapitalize="off"
+            autocorrect="off"
+            class="md-link-uri"
+            spellcheck="false"
+            writingsuggestions="false"
+          >
             <span class="show">
               http://x.test
             </span>
@@ -484,7 +496,13 @@ describe('focus mode', () => {
               ](
             </span>
           </span>
-          <span class="md-link-uri">
+          <span
+            autocapitalize="off"
+            autocorrect="off"
+            class="md-link-uri"
+            spellcheck="false"
+            writingsuggestions="false"
+          >
             <span class="show">
               x
             </span>
@@ -517,7 +535,13 @@ describe('focus mode', () => {
               ](
             </span>
           </span>
-          <span class="md-link-uri">
+          <span
+            autocapitalize="off"
+            autocorrect="off"
+            class="md-link-uri"
+            spellcheck="false"
+            writingsuggestions="false"
+          >
             <span class="show">
               x
             </span>
@@ -720,7 +744,13 @@ describe('focus mode', () => {
           <span class="md-mark">
             ](
           </span>
-          <span class="md-link-uri">
+          <span
+            autocapitalize="off"
+            autocorrect="off"
+            class="md-link-uri"
+            spellcheck="false"
+            writingsuggestions="false"
+          >
             http://x
           </span>
           <span class="md-mark">
@@ -831,7 +861,13 @@ describe('focus mode', () => {
               ](
             </span>
           </span>
-          <span class="md-link-uri">
+          <span
+            autocapitalize="off"
+            autocorrect="off"
+            class="md-link-uri"
+            spellcheck="false"
+            writingsuggestions="false"
+          >
             <span class="show">
               x
             </span>
@@ -858,7 +894,13 @@ describe('focus mode', () => {
           <span class="md-mark">
             ](
           </span>
-          <span class="md-link-uri">
+          <span
+            autocapitalize="off"
+            autocorrect="off"
+            class="md-link-uri"
+            spellcheck="false"
+            writingsuggestions="false"
+          >
             x
           </span>
           <span class="md-mark">
@@ -911,7 +953,13 @@ describe('focus mode', () => {
               ](
             </span>
           </span>
-          <span class="md-link-uri">
+          <span
+            autocapitalize="off"
+            autocorrect="off"
+            class="md-link-uri"
+            spellcheck="false"
+            writingsuggestions="false"
+          >
             <span class="show">
               https://example.com
             </span>
@@ -1044,7 +1092,13 @@ describe('focus mode', () => {
               ](
             </span>
           </span>
-          <span class="md-link-uri">
+          <span
+            autocapitalize="off"
+            autocorrect="off"
+            class="md-link-uri"
+            spellcheck="false"
+            writingsuggestions="false"
+          >
             <span class="show">
               x
             </span>
@@ -1071,7 +1125,13 @@ describe('focus mode', () => {
           <span class="md-mark">
             ](
           </span>
-          <span class="md-link-uri">
+          <span
+            autocapitalize="off"
+            autocorrect="off"
+            class="md-link-uri"
+            spellcheck="false"
+            writingsuggestions="false"
+          >
             y
           </span>
           <span class="md-mark">

--- a/packages/core/src/extensions/mark-mode.test.ts
+++ b/packages/core/src/extensions/mark-mode.test.ts
@@ -1194,7 +1194,14 @@ describe('focus mode', () => {
                 </prosekit-resizable-handle>
               </prosekit-resizable-root>
             </span>
-            <span class="md-image-view-content md-atom-view-content">
+            <span
+              autocapitalize="off"
+              autocorrect="off"
+              class="md-image-view-content md-atom-view-content"
+              data-testid="image-source"
+              spellcheck="false"
+              writingsuggestions="false"
+            >
               ![alt](pic.png)
             </span>
           </span>

--- a/packages/core/src/extensions/math.test.ts
+++ b/packages/core/src/extensions/math.test.ts
@@ -275,6 +275,6 @@ describe('math source spellcheck exemption', () => {
     await expect.element(mathContent).toHaveAttribute('autocorrect', 'off')
     await expect.element(mathContent).toHaveAttribute('autocapitalize', 'off')
     await expect.element(mathContent).toHaveAttribute('writingsuggestions', 'false')
-    expect(mathContent.element().spellcheck).toBe(false)
+    expect(mathContent.element()).toHaveProperty('spellcheck', false)
   })
 })

--- a/packages/core/src/extensions/math.test.ts
+++ b/packages/core/src/extensions/math.test.ts
@@ -197,7 +197,13 @@ describe('math DOM structure', () => {
               data-testid="math-preview"
             >
             </span>
-            <span class="md-math-view-content">
+            <span
+              autocapitalize="off"
+              autocorrect="off"
+              class="md-math-view-content"
+              spellcheck="false"
+              writingsuggestions="false"
+            >
               <span class="md-mark">
                 $
               </span>
@@ -231,7 +237,13 @@ describe('math DOM structure', () => {
               data-testid="math-preview"
             >
             </span>
-            <span class="md-math-view-content">
+            <span
+              autocapitalize="off"
+              autocorrect="off"
+              class="md-math-view-content"
+              spellcheck="false"
+              writingsuggestions="false"
+            >
               <span class="md-mark">
                 <span class="show">
                   $
@@ -252,5 +264,17 @@ describe('math DOM structure', () => {
       </p>
       "
     `)
+  })
+})
+
+describe('math source spellcheck exemption', () => {
+  it('renders the math source with spellcheck off', async () => {
+    using fixture = setup('show', 'A<a> $E=mc^2$ B')
+    void fixture
+    await expect.element(mathContent).toHaveAttribute('spellcheck', 'false')
+    await expect.element(mathContent).toHaveAttribute('autocorrect', 'off')
+    await expect.element(mathContent).toHaveAttribute('autocapitalize', 'off')
+    await expect.element(mathContent).toHaveAttribute('writingsuggestions', 'false')
+    expect(mathContent.element().spellcheck).toBe(false)
   })
 })

--- a/packages/core/src/extensions/math.ts
+++ b/packages/core/src/extensions/math.ts
@@ -4,6 +4,7 @@ import { TextSelection } from '@prosekit/pm/state'
 import type { EditorView, MarkView, ViewMutationRecord } from '@prosekit/pm/view'
 
 import { loadKaTeX, renderMathInto } from '../utils/katex.ts'
+import { NON_PROSE_ATTRS } from '../utils/non-prose-attrs.ts'
 
 import type { MdMathAttrs } from './inline-marks.ts'
 import type { MarkName } from './mark-names.ts'
@@ -44,6 +45,9 @@ class MathMarkView implements MarkView {
 
     this.#contentDOM = document.createElement('span')
     this.#contentDOM.className = 'md-math-view-content'
+    for (const [name, value] of Object.entries(NON_PROSE_ATTRS)) {
+      this.#contentDOM.setAttribute(name, value)
+    }
 
     this.#dom.appendChild(this.#preview)
     this.#dom.appendChild(this.#contentDOM)

--- a/packages/core/src/utils/non-prose-attrs.ts
+++ b/packages/core/src/utils/non-prose-attrs.ts
@@ -1,0 +1,9 @@
+// The spellcheck-family subset of the content attributes CodeMirror 6 sets on
+// its editable DOM:
+// https://github.com/codemirror/view/blob/6.41.0/src/editorview.ts#L525-L528
+export const NON_PROSE_ATTRS = {
+  spellcheck: 'false',
+  autocorrect: 'off',
+  autocapitalize: 'off',
+  writingsuggestions: 'false',
+} as const

--- a/packages/react/src/components/code-block-view.test.tsx
+++ b/packages/react/src/components/code-block-view.test.tsx
@@ -315,3 +315,18 @@ describe('typing over code block selections', () => {
     })
   })
 })
+
+describe('code block spellcheck exemption', () => {
+  const pmRoot = page.locate('.ProseMirror')
+  const editorPre = pmRoot.locate('pre')
+
+  it('keeps the pre exempt while the editor root has spellcheck on', async () => {
+    await render(<ProseKitEditor initialMarkdown={CODE_BLOCK_MD} spellCheck />)
+    await expect.element(pmRoot).toHaveAttribute('spellcheck', 'true')
+    await expect.element(editorPre).toHaveAttribute('spellcheck', 'false')
+    await expect.element(editorPre).toHaveAttribute('autocorrect', 'off')
+    await expect.element(editorPre).toHaveAttribute('autocapitalize', 'off')
+    await expect.element(editorPre).toHaveAttribute('writingsuggestions', 'false')
+    expect(editorPre.element()).toHaveProperty('spellcheck', false)
+  })
+})

--- a/packages/react/src/components/code-block-view.tsx
+++ b/packages/react/src/components/code-block-view.tsx
@@ -19,6 +19,7 @@ import {
 
 import { useBeautifulMermaid } from '../hooks/use-beautiful-mermaid.ts'
 import { useKaTeX } from '../hooks/use-katex.ts'
+import { NON_PROSE_PROPS } from '../utils/non-prose-props.ts'
 
 import styles from './code-block-view.module.css'
 import { CopyButton } from './copy-button.tsx'
@@ -70,7 +71,7 @@ export function CodeBlockView(props: ReactNodeViewProps): ReactElement {
 
   return (
     <div className={styles.Root} data-preview={previewOnly || undefined}>
-      <pre ref={contentRef} data-language={language}></pre>
+      <pre ref={contentRef} data-language={language} {...NON_PROSE_PROPS}></pre>
       {
         /* Skip rendering the toolbar during dragging to improve the performance of rendering the drag preview image in Safari */
         selected ? null : (

--- a/packages/react/src/components/editor.test.tsx
+++ b/packages/react/src/components/editor.test.tsx
@@ -591,3 +591,12 @@ describe('file pill props', () => {
     expect(pmRoot.getByTestId('file-pill').query()).toBeNull()
   })
 })
+
+describe('spellCheck prop', () => {
+  it('applies and updates the spellCheck prop on the editor root', async () => {
+    const screen = await render(<MeowdownEditor spellCheck />)
+    await expect.element(pmRoot).toHaveAttribute('spellcheck', 'true')
+    await screen.rerender(<MeowdownEditor spellCheck={false} />)
+    await expect.element(pmRoot).toHaveAttribute('spellcheck', 'false')
+  })
+})

--- a/packages/react/src/components/markdown-view.test.tsx
+++ b/packages/react/src/components/markdown-view.test.tsx
@@ -422,6 +422,9 @@ function canonicalize(root: Element): string {
     'translate',
     'draggable',
     'spellcheck',
+    'autocorrect',
+    'autocapitalize',
+    'writingsuggestions',
     'tabindex',
     'readonly',
   ])

--- a/packages/react/src/utils/non-prose-props.ts
+++ b/packages/react/src/utils/non-prose-props.ts
@@ -1,0 +1,7 @@
+// React-prop spelling of core's `NON_PROSE_ATTRS`; keep the two in sync.
+export const NON_PROSE_PROPS = {
+  spellCheck: false,
+  autoCorrect: 'off',
+  autoCapitalize: 'off',
+  writingsuggestions: 'false',
+} as const


### PR DESCRIPTION
Native spellcheck previously covered every editable surface, so code blocks, inline code, math source, link URLs, and hidden image size comments collected squiggles, and WebKit's spellcheck-gated smart substitutions could rewrite them. Set `spellcheck`, `autocorrect`, `autocapitalize`, and `writingsuggestions` off on those surfaces, matching CodeMirror's content-DOM defaults, and assert the contract in browser tests.

https://github.com/user-attachments/assets/3b53838e-958b-4c96-8983-1fad0c66f0f2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Disabled spellcheck, autocorrect, autocapitalization, and writing suggestions for non-prose content such as code, links, images, comments, and math.
  * Added support for controlling the editor’s root spellcheck setting through the React `spellCheck` prop.
* **Bug Fixes**
  * Prevented editing aids from interfering with technical content, even when spellcheck is enabled for the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->