### PR TITLE
fix: draw the virtual caret at the start of the line after a line break

### DIFF
--- a/packages/core/src/extensions/caret-rect.ts
+++ b/packages/core/src/extensions/caret-rect.ts
@@ -35,10 +35,8 @@ export function findNativeCaretRect(view: EditorView): CaretRect | undefined {
 // all.
 export function isAfterLineBreak(state: EditorState, pos: number): boolean {
   const $pos = state.doc.resolve(pos)
-  return (
-    $pos.parentOffset > 0 &&
-    $pos.parent.textBetween($pos.parentOffset - 1, $pos.parentOffset) === '\n'
-  )
+  const { parentOffset, parent } = $pos
+  return parentOffset > 0 && parent.textBetween(parentOffset - 1, parentOffset) === '\n'
 }
 
 // coordsAtPos with the side biased toward a visible neighbor. Every position

--- a/packages/core/src/extensions/caret-rect.ts
+++ b/packages/core/src/extensions/caret-rect.ts
@@ -1,3 +1,4 @@
+import type { EditorState } from '@prosekit/pm/state'
 import type { EditorView } from '@prosekit/pm/view'
 
 import { tryCoordsAtPos, type CaretCoords } from '../utils/caret-coords.ts'
@@ -28,6 +29,18 @@ export function findNativeCaretRect(view: EditorView): CaretRect | undefined {
   return { left: rect.left, top: rect.top, height: rect.height }
 }
 
+// A position right after a literal newline starts a soft line. Every engine
+// measures the collapsed native range there against the line before: Gecko
+// reports that line's end, WebKit one character cell past it, Blink no rect at
+// all.
+export function isAfterLineBreak(state: EditorState, pos: number): boolean {
+  const $pos = state.doc.resolve(pos)
+  return (
+    $pos.parentOffset > 0 &&
+    $pos.parent.textBetween($pos.parentOffset - 1, $pos.parentOffset) === '\n'
+  )
+}
+
 // coordsAtPos with the side biased toward a visible neighbor. Every position
 // touching a hidden run shares one visual point (the run has zero width), so
 // when the head itself measures flat we probe from the run's far ends instead.
@@ -36,10 +49,7 @@ export function findCoordsCaretRect(view: EditorView): CaretRect | undefined {
   const head = state.selection.head
   const runBefore = getHiddenRunBefore(state, head)
   const runAfter = getHiddenRunAfter(state, head)
-  const $head = state.doc.resolve(head)
-  const afterLineBreak =
-    $head.parentOffset > 0 &&
-    $head.parent.textBetween($head.parentOffset - 1, $head.parentOffset) === '\n'
+  const afterLineBreak = isAfterLineBreak(state, head)
   const preferredBeforeSide: boolean = runBefore == null && !afterLineBreak
   // `side` picks which neighbor to measure: -1 the character before the
   // position, 1 the character after it.

--- a/packages/core/src/extensions/caret-rect.ts
+++ b/packages/core/src/extensions/caret-rect.ts
@@ -1,7 +1,7 @@
-import type { EditorState } from '@prosekit/pm/state'
 import type { EditorView } from '@prosekit/pm/view'
 
 import { tryCoordsAtPos, type CaretCoords } from '../utils/caret-coords.ts'
+import { isAfterLineBreak } from '../utils/is-after-line-break.ts'
 
 import { getHiddenRunAfter, getHiddenRunBefore } from './hidden-run.ts'
 import { ATOM_SOURCE_MARK_NAMES } from './mark-names.ts'
@@ -29,16 +29,6 @@ export function findNativeCaretRect(view: EditorView): CaretRect | undefined {
   return { left: rect.left, top: rect.top, height: rect.height }
 }
 
-// A position right after a literal newline starts a soft line. Every engine
-// measures the collapsed native range there against the line before: Gecko
-// reports that line's end, WebKit one character cell past it, Blink no rect at
-// all.
-export function isAfterLineBreak(state: EditorState, pos: number): boolean {
-  const $pos = state.doc.resolve(pos)
-  const { parentOffset, parent } = $pos
-  return parentOffset > 0 && parent.textBetween(parentOffset - 1, parentOffset) === '\n'
-}
-
 // coordsAtPos with the side biased toward a visible neighbor. Every position
 // touching a hidden run shares one visual point (the run has zero width), so
 // when the head itself measures flat we probe from the run's far ends instead.
@@ -47,6 +37,10 @@ export function findCoordsCaretRect(view: EditorView): CaretRect | undefined {
   const head = state.selection.head
   const runBefore = getHiddenRunBefore(state, head)
   const runAfter = getHiddenRunAfter(state, head)
+  // A position right after a literal newline starts a soft line. Every engine
+  // measures the collapsed native range there against the line before: Gecko
+  // reports that line's end, WebKit one character cell past it, Blink no rect at
+  // all.
   const afterLineBreak = isAfterLineBreak(state, head)
   const preferredBeforeSide: boolean = runBefore == null && !afterLineBreak
   // `side` picks which neighbor to measure: -1 the character before the

--- a/packages/core/src/extensions/virtual-caret-line-break.test.ts
+++ b/packages/core/src/extensions/virtual-caret-line-break.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it, vi } from 'vitest'
+import { page } from 'vitest/browser'
+
+import { setupFixture, type Fixture } from '../testing/index.ts'
+
+import { findNativeCaretRect } from './caret-rect.ts'
+
+const caret = page.getByTestId('virtual-caret')
+const pmRoot = page.locate('.ProseMirror')
+const codeBlock = pmRoot.locate('pre code')
+const codeToken = codeBlock.locate('[class*="tok-"]').first()
+const paragraph = pmRoot.locate('p').first()
+
+const RUST = ['let y = {', '    let x = 3;', '    x + 1', '};'].join('\n')
+// `let a = 1;` ends in a punctuation token and `let b = 2;` opens with a
+// keyword token, so highlighting leaves the newline alone in its own DOM text
+// node. Without a language the same text is a single text node.
+const TWO_STATEMENTS = ['let a = 1;', 'let b = 2;'].join('\n')
+const WRAPPING = 'wrapping '.repeat(30).trim()
+
+// WebKit floors the native rect's `left` to an integer, so the drawn caret can
+// sit up to a pixel left of the glyph edge it hugs.
+const X_TOLERANCE = 2
+
+function measureCaretPoint(): { x: number; centerY: number } {
+  const box = caret.element().getBoundingClientRect()
+  return { x: box.left + box.width / 2, centerY: box.top + box.height / 2 }
+}
+
+/**
+ * The client box of the single character at `index`, read from a DOM range.
+ * The reference is the rendered glyph itself, so it holds whatever the engine
+ * does with fonts, line boxes, and highlight spans.
+ */
+function measureCharacter(root: Element, index: number): DOMRect {
+  const walker = root.ownerDocument.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+  let remaining = index
+  for (let node = walker.nextNode(); node != null; node = walker.nextNode()) {
+    const text = node as Text
+    if (remaining < text.data.length) {
+      const range = text.ownerDocument.createRange()
+      range.setStart(text, remaining)
+      range.setEnd(text, remaining + 1)
+      return range.getBoundingClientRect()
+    }
+    remaining -= text.data.length
+  }
+  throw new Error(`character index ${index} is past the end of the text`)
+}
+
+/**
+ * The caret hugs `edge` of the character at `index`, on that character's line.
+ */
+async function expectCaretAtCharacter(
+  root: () => Element,
+  index: number,
+  edge: 'left' | 'right',
+): Promise<void> {
+  await expect.element(caret).toBeVisible()
+  await vi.waitFor(() => {
+    const glyph = measureCharacter(root(), index)
+    const point = measureCaretPoint()
+    expect(Math.abs(point.x - glyph[edge])).toBeLessThan(X_TOLERANCE)
+    expect(point.centerY).toBeGreaterThan(glyph.top)
+    expect(point.centerY).toBeLessThan(glyph.bottom)
+  })
+}
+
+/**
+ * The caret sits on an empty line: at the left edge of the block's text, and
+ * vertically clear of the neighbouring lines. `above` and `below` are character
+ * indices on the lines that bracket it, `undefined` when the empty line is
+ * first or last.
+ */
+async function expectCaretOnEmptyLine(
+  root: () => Element,
+  { left, above, below }: { left: number; above?: number; below?: number },
+): Promise<void> {
+  await expect.element(caret).toBeVisible()
+  await vi.waitFor(() => {
+    const element = root()
+    const point = measureCaretPoint()
+    expect(Math.abs(point.x - measureCharacter(element, left).left)).toBeLessThan(X_TOLERANCE)
+    if (above != null) {
+      expect(point.centerY).toBeGreaterThan(measureCharacter(element, above).bottom)
+    }
+    if (below != null) {
+      expect(point.centerY).toBeLessThan(measureCharacter(element, below).top)
+    }
+  })
+}
+
+function markCursor(text: string, offset: number): string {
+  return `${text.slice(0, offset)}<a>${text.slice(offset)}`
+}
+
+describe('virtual caret at a code block line break', () => {
+  function setupCode(language: string, text: string, offset: number): Fixture {
+    const fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.codeBlock({ language }, markCursor(text, offset))))
+    fixture.view.focus()
+    return fixture
+  }
+
+  it('draws at the end of the line before the break', async () => {
+    using fixture = setupCode('rust', RUST, 34)
+    void fixture
+    await expect.element(codeToken).toBeInTheDocument()
+    await expectCaretAtCharacter(() => codeBlock.element(), 33, 'right')
+  })
+
+  it('draws at the start of the line after the break', async () => {
+    using fixture = setupCode('rust', RUST, 35)
+    void fixture
+    await expect.element(codeToken).toBeInTheDocument()
+    await expectCaretAtCharacter(() => codeBlock.element(), 35, 'left')
+  })
+
+  it('draws at the start of an indented line after the break', async () => {
+    using fixture = setupCode('rust', RUST, 25)
+    void fixture
+    await expect.element(codeToken).toBeInTheDocument()
+    await expectCaretAtCharacter(() => codeBlock.element(), 25, 'left')
+  })
+
+  it('draws at the start of a line whose first token opens a highlight span', async () => {
+    using fixture = setupCode('rust', TWO_STATEMENTS, 11)
+    void fixture
+    await expect.element(codeToken).toBeInTheDocument()
+    await expectCaretAtCharacter(() => codeBlock.element(), 11, 'left')
+  })
+
+  it('draws at the start of a line in an unhighlighted code block', async () => {
+    using fixture = setupCode('', TWO_STATEMENTS, 11)
+    void fixture
+    await expectCaretAtCharacter(() => codeBlock.element(), 11, 'left')
+  })
+
+  it('draws the two sides of one break at two different points', async () => {
+    using before = setupCode('rust', RUST, 34)
+    await expect.element(codeToken).toBeInTheDocument()
+    await expect.element(caret).toBeVisible()
+    const endOfLine = measureCaretPoint()
+
+    const { n } = before
+    before.set(n.doc(n.codeBlock({ language: 'rust' }, markCursor(RUST, 35))))
+    await expect.element(caret).toBeVisible()
+    await vi.waitFor(() => {
+      const startOfNextLine = measureCaretPoint()
+      expect(startOfNextLine.centerY).toBeGreaterThan(endOfLine.centerY)
+      expect(startOfNextLine.x).toBeLessThan(endOfLine.x)
+    })
+  })
+})
+
+describe('virtual caret on an empty line', () => {
+  function setupCode(text: string, offset: number): Fixture {
+    const fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.codeBlock(markCursor(text, offset))))
+    fixture.view.focus()
+    return fixture
+  }
+
+  it('draws on an empty line between two code lines', async () => {
+    using fixture = setupCode('aaa\n\nbbb', 4)
+    void fixture
+    await expectCaretOnEmptyLine(() => codeBlock.element(), { left: 0, above: 0, below: 5 })
+  })
+
+  it('draws at the start of the line after an empty line', async () => {
+    using fixture = setupCode('aaa\n\nbbb', 5)
+    void fixture
+    await expectCaretAtCharacter(() => codeBlock.element(), 5, 'left')
+  })
+
+  it('draws on the empty last line of a code block', async () => {
+    using fixture = setupCode('let x = 1;\n', 11)
+    void fixture
+    await expectCaretOnEmptyLine(() => codeBlock.element(), { left: 0, above: 0 })
+  })
+
+  it('draws on the empty first line of a code block', async () => {
+    using fixture = setupCode('\nfoo', 0)
+    void fixture
+    await expectCaretOnEmptyLine(() => codeBlock.element(), { left: 1, below: 1 })
+  })
+})
+
+describe('virtual caret at a paragraph soft line break', () => {
+  function setupParagraph(text: string, offset: number): Fixture {
+    const fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph(markCursor(text, offset))))
+    fixture.view.focus()
+    return fixture
+  }
+
+  it('draws at the end of the line before a soft break', async () => {
+    using fixture = setupParagraph('first line\nsecond line', 10)
+    void fixture
+    await expectCaretAtCharacter(() => paragraph.element(), 9, 'right')
+  })
+
+  it('draws at the start of the line after a soft break', async () => {
+    using fixture = setupParagraph('first line\nsecond line', 11)
+    void fixture
+    await expectCaretAtCharacter(() => paragraph.element(), 11, 'left')
+  })
+
+  it('draws on an empty soft line', async () => {
+    using fixture = setupParagraph('aaa\n\nbbb', 4)
+    void fixture
+    await expectCaretOnEmptyLine(() => paragraph.element(), { left: 0, above: 0, below: 5 })
+  })
+})
+
+describe('virtual caret at a soft wrap boundary', () => {
+  /**
+   * The first character index whose glyph box sits on the second visual line.
+   */
+  function findFirstWrapIndex(root: Element): number {
+    const firstTop = measureCharacter(root, 0).top
+    for (let index = 1; index < WRAPPING.length; index++) {
+      if (measureCharacter(root, index).top > firstTop + 1) return index
+    }
+    throw new Error('the paragraph did not wrap')
+  }
+
+  function setupWrappingParagraph(): Fixture {
+    const fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph(markCursor(WRAPPING, 0))))
+    fixture.view.focus()
+    return fixture
+  }
+
+  // A soft wrap carries no newline, so the line-break rule must not reach it.
+  // The two visual points at a wrap are both defensible and the engines
+  // disagree about which to use, so the contract is that the native
+  // measurement still decides.
+  it('keeps the native measurement where a soft wrap offers two points', async () => {
+    using fixture = setupWrappingParagraph()
+    const { n } = fixture
+    const index = findFirstWrapIndex(paragraph.element())
+    fixture.set(n.doc(n.paragraph(markCursor(WRAPPING, index))))
+    await expect.element(caret).toBeVisible()
+    await vi.waitFor(() => {
+      const nativeRect = findNativeCaretRect(fixture.view)
+      expect(nativeRect).toBeDefined()
+      if (nativeRect == null) return
+      const point = measureCaretPoint()
+      expect(Math.abs(point.x - nativeRect.left)).toBeLessThan(X_TOLERANCE)
+      expect(Math.abs(point.centerY - (nativeRect.top + nativeRect.height / 2))).toBeLessThan(1)
+    })
+  })
+})

--- a/packages/core/src/extensions/virtual-caret.ts
+++ b/packages/core/src/extensions/virtual-caret.ts
@@ -35,7 +35,6 @@ function measureCaretRect(
   view: EditorView,
   nativeRect: CaretRect | undefined,
 ): CaretRect | undefined {
-  if (isAfterLineBreak(view.state, view.state.selection.head)) nativeRect = undefined
   const rect = nativeRect ?? findCoordsCaretRect(view)
   if (rect != null) return stretchCaretRect(rect)
   return findAtomCaretRect(view)
@@ -139,7 +138,8 @@ class VirtualCaretView implements PluginView {
       return
     }
 
-    const nativeRect = findNativeCaretRect(view)
+    const skipNativeCaretRect = isAfterLineBreak(view.state, view.state.selection.head)
+    const nativeRect = skipNativeCaretRect ? undefined : findNativeCaretRect(view)
 
     // Use the native rect if it exists and the last input modality was touch.
     // This ensures that we can render the drag magnifier on touch devices.

--- a/packages/core/src/extensions/virtual-caret.ts
+++ b/packages/core/src/extensions/virtual-caret.ts
@@ -5,12 +5,12 @@ import type { EditorView } from '@prosekit/pm/view'
 
 import { forceReflow } from '../utils/force-reflow.ts'
 import { getIsTouchInput, onIsTouchInputChange } from '../utils/input-modality.ts'
+import { isAfterLineBreak } from '../utils/is-after-line-break.ts'
 
 import {
   findAtomCaretRect,
   findCoordsCaretRect,
   findNativeCaretRect,
-  isAfterLineBreak,
   type CaretRect,
 } from './caret-rect.ts'
 import { getCaretTail, type CaretTail } from './hidden-run.ts'

--- a/packages/core/src/extensions/virtual-caret.ts
+++ b/packages/core/src/extensions/virtual-caret.ts
@@ -10,6 +10,7 @@ import {
   findAtomCaretRect,
   findCoordsCaretRect,
   findNativeCaretRect,
+  isAfterLineBreak,
   type CaretRect,
 } from './caret-rect.ts'
 import { getCaretTail, type CaretTail } from './hidden-run.ts'
@@ -34,6 +35,7 @@ function measureCaretRect(
   view: EditorView,
   nativeRect: CaretRect | undefined,
 ): CaretRect | undefined {
+  if (isAfterLineBreak(view.state, view.state.selection.head)) nativeRect = undefined
   const rect = nativeRect ?? findCoordsCaretRect(view)
   if (rect != null) return stretchCaretRect(rect)
   return findAtomCaretRect(view)

--- a/packages/core/src/utils/is-after-line-break.ts
+++ b/packages/core/src/utils/is-after-line-break.ts
@@ -1,0 +1,7 @@
+import type { EditorState } from '@prosekit/pm/state'
+
+export function isAfterLineBreak(state: EditorState, pos: number): boolean {
+  const $pos = state.doc.resolve(pos)
+  const { parentOffset, parent } = $pos
+  return parentOffset > 0 && parent.textBetween(parentOffset - 1, parentOffset) === '\n'
+}

--- a/packages/react/src/components/wikilink-menu.test.tsx
+++ b/packages/react/src/components/wikilink-menu.test.tsx
@@ -1,12 +1,12 @@
 import '../testing/index.ts'
 
+import { waitForAnimationFrame } from '@meowdown/vitest/helpers'
 import { canUseRegexLookbehind } from '@prosekit/core'
 import { createRef, type RefObject } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 import { page, userEvent } from 'vitest/browser'
 
-import { waitForAnimationFrame } from '@meowdown/vitest/helpers'
 import { MeowdownEditor } from './editor.tsx'
 import { ProseKitEditor } from './prosekit-editor.tsx'
 import type { EditorHandle, WikilinkItem } from './types.ts'
@@ -36,12 +36,12 @@ async function pressInsertShortcut(): Promise<void> {
  * Walk the caret `count` characters to the right and confirm it arrived.
  */
 async function pressArrowRight(ref: RefObject<EditorHandle | null>, count: number): Promise<void> {
-  let getPos = () => {
+  const getPos = () => {
     return ref.current?.getSelection().head ?? 0
   }
-  let startPos = getPos()
-  let targetPos = startPos + count
-  let maxRetries = 10 // ArrowRight event could be dropped outright, so we retry
+  const startPos = getPos()
+  const targetPos = startPos + count
+  const maxRetries = 10 // ArrowRight event could be dropped outright, so we retry
   for (let press = 0; press < count + maxRetries; press++) {
     await waitForAnimationFrame()
     if (getPos() >= targetPos) break

--- a/packages/react/src/components/wikilink-menu.test.tsx
+++ b/packages/react/src/components/wikilink-menu.test.tsx
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 import { page, userEvent } from 'vitest/browser'
 
+import { waitForAnimationFrame } from '@meowdown/vitest/helpers'
 import { MeowdownEditor } from './editor.tsx'
 import { ProseKitEditor } from './prosekit-editor.tsx'
 import type { EditorHandle, WikilinkItem } from './types.ts'
@@ -31,24 +32,23 @@ async function pressInsertShortcut(): Promise<void> {
   await userEvent.keyboard('{ControlOrMeta>}{Shift>}K{/Shift}{/ControlOrMeta}')
 }
 
-// A synthetic ArrowRight sent while the editor is mid-update is occasionally
-// dropped outright: the DOM selection does not move, and no amount of waiting
-// recovers it. Measured at roughly one press in a hundred on WebKit and
-// Firefox, never on Chromium, and never in a bare contenteditable driven the
-// same way, so it belongs to the editor's update cycle rather than to key
-// delivery. A few spare presses absorb it.
-const ARROW_RETRIES = 5
-
 /**
  * Walk the caret `count` characters to the right and confirm it arrived.
  */
 async function pressArrowRight(ref: RefObject<EditorHandle | null>, count: number): Promise<void> {
-  const target = (ref.current?.getSelection().head ?? 0) + count
-  for (let press = 0; press < count + ARROW_RETRIES; press++) {
-    if (ref.current?.getSelection().head === target) break
-    await userEvent.keyboard('{ArrowRight}')
+  let getPos = () => {
+    return ref.current?.getSelection().head ?? 0
   }
-  expect(ref.current?.getSelection().head).toBe(target)
+  let startPos = getPos()
+  let targetPos = startPos + count
+  let maxRetries = 10 // ArrowRight event could be dropped outright, so we retry
+  for (let press = 0; press < count + maxRetries; press++) {
+    await waitForAnimationFrame()
+    if (getPos() >= targetPos) break
+    await userEvent.keyboard('{ArrowRight}')
+    await waitForAnimationFrame()
+  }
+  expect(getPos()).toEqual(targetPos)
 }
 
 describe('WikilinkMenu', () => {

--- a/packages/react/src/components/wikilink-menu.test.tsx
+++ b/packages/react/src/components/wikilink-menu.test.tsx
@@ -1,7 +1,7 @@
 import '../testing/index.ts'
 
 import { canUseRegexLookbehind } from '@prosekit/core'
-import { createRef } from 'react'
+import { createRef, type RefObject } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 import { page, userEvent } from 'vitest/browser'
@@ -29,6 +29,26 @@ const TWO_BRACKETS = '[[[['
 
 async function pressInsertShortcut(): Promise<void> {
   await userEvent.keyboard('{ControlOrMeta>}{Shift>}K{/Shift}{/ControlOrMeta}')
+}
+
+// A synthetic ArrowRight sent while the editor is mid-update is occasionally
+// dropped outright: the DOM selection does not move, and no amount of waiting
+// recovers it. Measured at roughly one press in a hundred on WebKit and
+// Firefox, never on Chromium, and never in a bare contenteditable driven the
+// same way, so it belongs to the editor's update cycle rather than to key
+// delivery. A few spare presses absorb it.
+const ARROW_RETRIES = 5
+
+/**
+ * Walk the caret `count` characters to the right and confirm it arrived.
+ */
+async function pressArrowRight(ref: RefObject<EditorHandle | null>, count: number): Promise<void> {
+  const target = (ref.current?.getSelection().head ?? 0) + count
+  for (let press = 0; press < count + ARROW_RETRIES; press++) {
+    if (ref.current?.getSelection().head === target) break
+    await userEvent.keyboard('{ArrowRight}')
+  }
+  expect(ref.current?.getSelection().head).toBe(target)
 }
 
 describe('WikilinkMenu', () => {
@@ -248,7 +268,7 @@ describe('WikilinkMenu', () => {
     ref.current?.focus()
 
     await userEvent.keyboard(TWO_BRACKETS)
-    await userEvent.keyboard('{ArrowRight}'.repeat('Reading list'.length))
+    await pressArrowRight(ref, 'Reading list'.length)
 
     await vi.waitFor(() => {
       expect(onWikilinkSearch).toHaveBeenLastCalledWith('Reading list')
@@ -276,7 +296,7 @@ describe('WikilinkMenu', () => {
     ref.current?.focus()
 
     await userEvent.keyboard(TWO_BRACKETS)
-    await userEvent.keyboard('{ArrowRight}'.repeat('New project'.length))
+    await pressArrowRight(ref, 'New project'.length)
 
     const createItem = menu.getByText('Create "New project"')
     await expect.element(createItem).toBeVisible()
@@ -297,7 +317,7 @@ describe('WikilinkMenu', () => {
     await userEvent.keyboard(TWO_BRACKETS)
     await expect.element(menu).toBeVisible()
     await userEvent.keyboard('{Escape}')
-    await userEvent.keyboard('{ArrowRight}')
+    await pressArrowRight(ref, 1)
 
     await expect.element(menu).not.toBeVisible()
     expect(ref.current?.getSelection()).toMatchObject({ anchor: 8, head: 8 })

--- a/packages/vitest/src/helpers.ts
+++ b/packages/vitest/src/helpers.ts
@@ -20,3 +20,9 @@ export function isSafari() {
 export function isFirefox() {
   return getBrowserName() === 'firefox'
 }
+
+export function waitForAnimationFrame(): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>()
+  requestAnimationFrame(() => resolve())
+  return promise
+}


### PR DESCRIPTION
The virtual caret drew at the end of the previous line whenever the cursor sat at the start of a soft line (column 0 after a literal `\n`), because `measureCaretRect` preferred the native collapsed-range rect, which Gecko and WebKit measure against the line before. Blink returns no rect there, so Chromium alone reached the `coordsAtPos` fallback that already handles this position. The fix skips the native rect only after a line break, leaving the soft-wrap case, where the native rect is the correct one, untouched.

Also makes the wikilink menu's ArrowRight tests stop flaking: a synthetic arrow key sent while the editor is mid-update is occasionally dropped outright on WebKit and Firefox, so those tests now walk the caret to a checked target instead of assuming one press moves it once.

https://github.com/user-attachments/assets/f8236ee9-2213-4686-b482-f490690ecee9




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual caret positioning immediately after hard line breaks, including empty lines and syntax-highlighted code.
  * Preserved accurate caret placement across paragraph breaks and soft-wrapped lines.

* **Tests**
  * Added browser coverage for caret behavior across line breaks, highlighted code, empty lines, and soft wraps.
  * Improved keyboard navigation test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->