### PR TITLE
fix: match link popups to hover cards

### DIFF
--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -101,6 +101,12 @@
     /* highlighted/hovered row in those menus */
     --meowdown-popover-hover-bg: light-dark(oklch(0.967 0 0), oklch(0.274 0.005 286));
 
+    /* link and wiki-link hover card surface */
+    --meowdown-hover-card-border: var(--meowdown-border);
+    --meowdown-hover-card-radius: 0.75rem;
+    --meowdown-hover-card-shadow:
+      0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+
     /* destructive menu items */
     --meowdown-danger: light-dark(oklch(0.637 0.208 25), oklch(0.711 0.166 22));
 

--- a/packages/react/src/components/link-menu.module.css
+++ b/packages/react/src/components/link-menu.module.css
@@ -2,6 +2,13 @@
   display: block;
   z-index: 50;
   width: min(20rem, calc(100vw - 1rem));
+  transition-property: top, left, right, bottom, transform;
+  transition-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+  transition-duration: 350ms;
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
 }
 
 .Popup {
@@ -10,12 +17,33 @@
   box-sizing: border-box;
   width: 100%;
   overflow: hidden;
+  outline: none;
   font-size: 0.875rem;
   color: var(--meowdown-text);
-  border: 1px solid var(--meowdown-border);
-  border-radius: 0.5rem;
+  border: 1px solid var(--meowdown-hover-card-border);
+  border-radius: var(--meowdown-hover-card-radius);
   background: var(--meowdown-popover-bg);
-  box-shadow: 0 8px 28px rgb(0 0 0 / 0.16);
+  box-shadow: var(--meowdown-hover-card-shadow);
+  transform-origin: var(--transform-origin);
+  transition:
+    opacity 150ms ease,
+    transform 150ms ease;
+
+  &[data-closed] {
+    transition:
+      opacity 100ms ease,
+      transform 100ms ease;
+  }
+
+  &[data-starting-style],
+  &[data-ending-style] {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
 }
 
 .Row,

--- a/packages/react/src/components/link-menu.tsx
+++ b/packages/react/src/components/link-menu.tsx
@@ -91,20 +91,27 @@ function selectLinkUnit(editor: TypedEditor, link: LinkUnit): void {
 
 function LinkPopover({
   anchor,
+  open,
   onClose,
+  onCloseComplete,
   onPopupHover,
   children,
 }: {
   anchor?: VirtualElement
+  open: boolean
   onClose: () => void
+  onCloseComplete?: () => void
   onPopupHover?: (over: boolean) => void
   children: ReactNode
 }) {
   return (
     <Popover.Root
-      open
+      open={open}
       onOpenChange={(open) => {
         if (!open) onClose()
+      }}
+      onOpenChangeComplete={(open) => {
+        if (!open) onCloseComplete?.()
       }}
     >
       <Popover.Portal>
@@ -387,13 +394,18 @@ export function LinkMenu({
   const [onLink, setOnLink] = useState(false)
   const [overPopup, setOverPopup] = useState(false)
   const [edit, setEdit] = useState<LinkEditOptions>()
+  const [editOpen, setEditOpen] = useState(false)
+  const [displayedRead, setDisplayedRead] = useState<LinkUnit>()
   const hoverOpen = useDelayedFlag(onLink || overPopup)
 
   const linkHoverExtension = useMemo(
     () =>
       defineLinkHoverHandler((hit) => {
         setOnLink(!!hit)
-        if (hit) setHover(hit.payload)
+        if (hit) {
+          setHover(hit.payload)
+          setDisplayedRead(hit.payload)
+        }
       }),
     [],
   )
@@ -403,6 +415,7 @@ export function LinkMenu({
     () =>
       defineLinkTapHandler(({ link }) => {
         setTap(link)
+        setDisplayedRead(link)
         setOnLink(false)
         setHover(undefined)
       }),
@@ -416,6 +429,7 @@ export function LinkMenu({
         ? null
         : defineLinkEditKeymap((options) => {
             setEdit(options)
+            setEditOpen(true)
             setTap(undefined)
           }),
     [readOnly],
@@ -430,14 +444,13 @@ export function LinkMenu({
   }, [])
 
   const closeEdit = useCallback(() => {
-    setEdit(undefined)
+    setEditOpen(false)
     closeRead()
-    editor.focus()
-  }, [editor, closeRead])
+  }, [closeRead])
 
-  const readLink = tap ?? (hoverOpen ? hover : undefined)
-  const previewState = useLinkPreview(readLink?.href, resolveLinkPreview)
-  const range = edit ? (edit.link?.text ?? edit) : readLink?.text
+  const requestedRead = tap ?? (hoverOpen ? hover : undefined)
+  const previewState = useLinkPreview(displayedRead?.href, resolveLinkPreview)
+  const range = edit ? (edit.link?.text ?? edit) : displayedRead?.text
   const anchor: VirtualElement | undefined = useMemo(() => {
     if (!range) return
     return getVirtualElementFromRange(editor.view, range)
@@ -445,7 +458,15 @@ export function LinkMenu({
 
   if (edit && !readOnly) {
     return (
-      <LinkPopover anchor={anchor} onClose={closeEdit}>
+      <LinkPopover
+        anchor={anchor}
+        open={editOpen}
+        onClose={closeEdit}
+        onCloseComplete={() => {
+          setEdit(undefined)
+          editor.focus()
+        }}
+      >
         <LinkEditContent
           edit={edit}
           resolveLinkPreview={resolveLinkPreview}
@@ -470,25 +491,39 @@ export function LinkMenu({
     )
   }
 
-  if (readLink) {
-    const mutable = !readOnly && readLink.form !== 'reference'
-    const text = getLinkText(editor.view.state, readLink)
-    const canUseTitle = mutable && isLinkTextForHref(text, readLink.href)
+  if (displayedRead) {
+    const mutable = !readOnly && displayedRead.form !== 'reference'
+    const text = getLinkText(editor.view.state, displayedRead)
+    const canUseTitle = mutable && isLinkTextForHref(text, displayedRead.href)
     const editLink = () => {
-      selectLinkUnit(editor, readLink)
-      setEdit({ from: readLink.unit.from, to: readLink.unit.to, link: readLink, text })
+      selectLinkUnit(editor, displayedRead)
+      setEdit({
+        from: displayedRead.unit.from,
+        to: displayedRead.unit.to,
+        link: displayedRead,
+        text,
+      })
+      setEditOpen(true)
       closeRead()
     }
     const removeLink = () => {
-      selectLinkUnit(editor, readLink)
+      selectLinkUnit(editor, displayedRead)
       editor.commands.removeLink()
       closeRead()
     }
 
     return (
-      <LinkPopover anchor={anchor} onClose={closeRead} onPopupHover={setOverPopup}>
+      <LinkPopover
+        anchor={anchor}
+        open={requestedRead !== undefined}
+        onClose={closeRead}
+        onCloseComplete={() => {
+          if (!requestedRead) setDisplayedRead(undefined)
+        }}
+        onPopupHover={setOverPopup}
+      >
         <LinkInfoContent
-          href={readLink.href}
+          href={displayedRead.href}
           previewState={previewState}
           onLinkClick={onLinkClick}
           onLinkCopy={onLinkCopy}
@@ -497,7 +532,7 @@ export function LinkMenu({
           onUseTitle={
             canUseTitle
               ? (title) => {
-                  selectLinkUnit(editor, readLink)
+                  selectLinkUnit(editor, displayedRead)
                   editor.commands.updateLink({ text: title })
                   closeRead()
                 }

--- a/packages/react/src/components/wikilink-hover-card.module.css
+++ b/packages/react/src/components/wikilink-hover-card.module.css
@@ -15,12 +15,10 @@
   max-height: min(12rem, calc(100vh - 1rem));
   outline: none;
   pointer-events: none;
-  border: 1px solid var(--meowdown-border);
-  border-radius: 0.75rem;
+  border: 1px solid var(--meowdown-hover-card-border);
+  border-radius: var(--meowdown-hover-card-radius);
   background: var(--meowdown-popover-bg);
-  box-shadow:
-    0 10px 15px -3px rgb(0 0 0 / 0.1),
-    0 4px 6px -4px rgb(0 0 0 / 0.1);
+  box-shadow: var(--meowdown-hover-card-shadow);
   transform-origin: var(--transform-origin);
   transition:
     opacity 150ms ease,

--- a/packages/react/src/hooks/use-delayed-flag.ts
+++ b/packages/react/src/hooks/use-delayed-flag.ts
@@ -3,13 +3,13 @@ import { useEffect, useRef, useState } from 'react'
 /**
  * Delay before the flag opens, in ms.
  */
-const OPEN_DELAY = 400
+const OPEN_DELAY = 300
 
 /**
  * Grace before the flag closes, in ms. The window lets a pointer travel from
  *  the hovered link onto the popover it anchors.
  */
-const CLOSE_DELAY = 300
+const CLOSE_DELAY = 100
 
 /**
  * Mirrors `value` into a boolean that flips true `openDelay`ms after `value`


### PR DESCRIPTION
## Summary

- share hover-card border, radius, and shadow tokens between link and wiki-link previews
- match backlink preview dwell, position glide, and scale/fade enter and exit motion
- retain link and edit popup content until the close animation completes
- respect reduced-motion preferences

## Verification

- pnpm lint
- pnpm typecheck
- pnpm --filter @meowdown/react build
- pnpm test --run packages/react/src/components/link-menu.test.tsx (Chromium, 21 tests)
- MEOWDOWN_TEST_BROWSER=webkit pnpm test --run packages/react/src/components/link-menu.test.tsx (WebKit, 21 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Link menus and wiki-link hover cards now support customizable borders, corner radius, and shadows through theme settings.
  - Added smooth open, close, and repositioning animations with reduced-motion support.

- **Improvements**
  - Hover cards open 100 ms faster and close 200 ms faster.
  - Link popovers now maintain the displayed link reliably during hover, tap, and editing interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->