### PR TITLE
fix: keep the link popover root mounted so open animations play

### DIFF
--- a/packages/core/src/extensions/get-link-unit-at.ts
+++ b/packages/core/src/extensions/get-link-unit-at.ts
@@ -103,7 +103,14 @@ export function getLinkUnitAt(state: EditorState, pos: number): LinkUnit | undef
   switch (attrs.key) {
     // A bare autolink is its own visible text.
     case 'link-bare':
-      return { state, form: 'bare', unit: unitRange, text: unitRange, href: attrs.data.href, title: '' }
+      return {
+        state,
+        form: 'bare',
+        unit: unitRange,
+        text: unitRange,
+        href: attrs.data.href,
+        title: '',
+      }
 
     // An angle autolink's visible text is its interior: the grammar fixes the
     // hidden `<`/`>` at one character each.

--- a/packages/core/src/extensions/get-link-unit-at.ts
+++ b/packages/core/src/extensions/get-link-unit-at.ts
@@ -7,6 +7,8 @@ import { isMarkOfType, type MarkName } from './mark-names.ts'
 import { getMarkRangeAt } from './mark-range.ts'
 
 interface LinkUnitBase {
+  state: EditorState
+
   /**
    * Whole inline link, reference link, or autolink range.
    */
@@ -101,13 +103,13 @@ export function getLinkUnitAt(state: EditorState, pos: number): LinkUnit | undef
   switch (attrs.key) {
     // A bare autolink is its own visible text.
     case 'link-bare':
-      return { form: 'bare', unit: unitRange, text: unitRange, href: attrs.data.href, title: '' }
+      return { state, form: 'bare', unit: unitRange, text: unitRange, href: attrs.data.href, title: '' }
 
     // An angle autolink's visible text is its interior: the grammar fixes the
     // hidden `<`/`>` at one character each.
     case 'link-angle': {
       const text = { from: unit.from + 1, to: unit.to - 1 }
-      return { form: 'angle', unit: unitRange, text, href: attrs.data.href, title: '' }
+      return { state, form: 'angle', unit: unitRange, text, href: attrs.data.href, title: '' }
     }
 
     // A reference link's href/title live in its definition, so only its
@@ -116,6 +118,7 @@ export function getLinkUnitAt(state: EditorState, pos: number): LinkUnit | undef
       const linkText = getMarkRangeAt(state, pos, 'mdLinkText')
       const text = linkText == null ? unitRange : { from: linkText.from + 1, to: linkText.to }
       return {
+        state,
         form: 'reference',
         unit: unitRange,
         text,
@@ -135,6 +138,7 @@ export function getLinkUnitAt(state: EditorState, pos: number): LinkUnit | undef
 
       const label = { from: unit.from + 1, to: closeBracket }
       return {
+        state,
         form: 'inline',
         unit: unitRange,
         text: label,

--- a/packages/core/src/extensions/link-commands.ts
+++ b/packages/core/src/extensions/link-commands.ts
@@ -63,8 +63,8 @@ function getVisibleText(state: EditorState, range: PositionRange): string {
 /**
  * Get a link's plain visible text.
  */
-export function getLinkText(state: EditorState, link: LinkUnit): string {
-  return getVisibleText(state, link.text)
+export function getLinkText(link: LinkUnit): string {
+  return getVisibleText(link.state, link.text)
 }
 
 /**
@@ -158,7 +158,7 @@ export function updateLink(attrs: LinkAttrs): Command {
 
     const href = normalizeHref(attrs.href ?? link.href)
     const title = attrs.title ?? link.title
-    const text = attrs.text ?? getLinkText(state, link)
+    const text = attrs.text ?? getLinkText(link)
     const replacingUnit = attrs.text !== undefined || link.form !== 'inline'
 
     if (dispatch) {
@@ -183,7 +183,7 @@ export function removeLink(): Command {
     const link = getLinkUnitAt(state, state.selection.from)
     if (!link || link.form === 'reference') return false
     if (dispatch) {
-      const text = getLinkText(state, link)
+      const text = getLinkText(link)
       // Keep authored label Markdown intact when it cannot immediately become
       // an autolink again; otherwise keep the text verbatim and opt it out of
       // autolinking with an invisible trailing magic comment.
@@ -232,7 +232,7 @@ function openLinkEdit(onLinkEdit: LinkEditHandler): Command {
         } = link
         dispatch(state.tr.setSelection(TextSelection.create(state.doc, from, to)).scrollIntoView())
         view.focus()
-        onLinkEdit({ from, to, link, text: getLinkText(state, link) })
+        onLinkEdit({ from, to, link, text: getLinkText(link) })
       }
       return true
     }

--- a/packages/react/src/components/link-menu.test.tsx
+++ b/packages/react/src/components/link-menu.test.tsx
@@ -155,7 +155,7 @@ describe('LinkMenu', () => {
     // Focus the document first; `clipboard.writeText` rejects otherwise.
     await pmRoot.click()
     await hover(screen.getByText('Docs'))
-    await expect.element(popover.getByTestId('link-popover-read')).toBeVisible()
+    await expect.element(popover.getByTestId('link-popover-info')).toBeVisible()
     await popover.getByRole('button', { name: 'Copy link' }).click()
     await vi.waitFor(() => {
       expect(onLinkCopy).toHaveBeenCalledWith({ href: 'https://example.com' })
@@ -173,7 +173,7 @@ describe('LinkMenu', () => {
     )
     const link = screen.getByText(label)
     await hover(link)
-    await expect.element(popover.getByTestId('link-popover-read')).toBeVisible()
+    await expect.element(popover.getByTestId('link-popover-info')).toBeVisible()
 
     const linkRect = link.element().getBoundingClientRect()
     const popRect = popover.element().getBoundingClientRect()
@@ -193,7 +193,7 @@ describe('LinkMenu', () => {
     await render(<MeowdownEditor initialMarkdown="see <https://www.example.com> here" />)
     const link = pmRoot.getByText('https://www.example.com')
     await hover(link)
-    await expect.element(popover.getByTestId('link-popover-read')).toBeVisible()
+    await expect.element(popover.getByTestId('link-popover-info')).toBeVisible()
 
     const linkRect = link.element().getBoundingClientRect()
     const popRect = popover.element().getBoundingClientRect()
@@ -216,7 +216,7 @@ describe('LinkMenu', () => {
     await pmRoot.getByText('park the caret here').click()
     const link = pmRoot.getByText('https://www.example.com')
     await hover(link)
-    await expect.element(popover.getByTestId('link-popover-read')).toBeVisible()
+    await expect.element(popover.getByTestId('link-popover-info')).toBeVisible()
 
     const linkRect = link.element().getBoundingClientRect()
     const popRect = popover.element().getBoundingClientRect()
@@ -416,7 +416,7 @@ describe('LinkMenu', () => {
     const label = screen.getByText('Docs')
 
     await hover(label)
-    await expect.element(popover.getByTestId('link-popover-read')).toBeVisible()
+    await expect.element(popover.getByTestId('link-popover-info')).toBeVisible()
     await expect.element(popover.locate('a')).toHaveAttribute('href', 'https://example.com')
     await expect.element(popover.getByRole('button', { name: 'Edit link' })).not.toBeInTheDocument()
     await expect

--- a/packages/react/src/components/link-menu.tsx
+++ b/packages/react/src/components/link-menu.tsx
@@ -439,8 +439,8 @@ export function LinkMenu({
   }, [closeInfo])
 
   const handleEditRemove = useCallback(() => {
-      editor.commands.removeLink()
-      closeEdit()
+    editor.commands.removeLink()
+    closeEdit()
   }, [editor, closeEdit])
 
   const handleEditSubmit = useCallback(

--- a/packages/react/src/components/link-menu.tsx
+++ b/packages/react/src/components/link-menu.tsx
@@ -504,10 +504,6 @@ export function LinkMenu({
 
   const editing = edit != null && !readOnly
 
-  // While closed the popover renders nothing, but its root must stay mounted:
-  // Base UI plays the open transition only when `open` flips on a mounted
-  // root, and a root that mounts with `open` already true skips
-  // `[data-starting-style]`, so the popup would appear without animation.
   return (
     <LinkPopover
       anchor={anchor}

--- a/packages/react/src/components/link-menu.tsx
+++ b/packages/react/src/components/link-menu.tsx
@@ -392,13 +392,13 @@ export function LinkMenu({
   readOnly = false,
 }: LinkMenuProps): ReactNode {
   const editor: TypedEditor = useEditor<EditorExtension>()
-  const [hit, setHit] = useState<LinkUnit>()
-  const [edit, setEdit] = useState<LinkEditOptions>()
+  const [hit, setHit] = useState<LinkUnit | undefined >()
+  const [edit, setEdit] = useState<LinkEditOptions | undefined>()
   const [editOpen, setEditOpen] = useState(false)
   // The link whose info the read popup shows. It outlives `hit` until the
   // close animation finishes, so the popup keeps its content while fading
   // out.
-  const [displayedRead, setDisplayedRead] = useState<LinkUnit>()
+  const [displayedRead, setDisplayedRead] = useState<LinkUnit | undefined>()
   const overPopupRef = useRef(false)
 
   const linkHoverExtension = useMemo(

--- a/packages/react/src/components/link-menu.tsx
+++ b/packages/react/src/components/link-menu.tsx
@@ -439,6 +439,15 @@ export function LinkMenu({
     closeInfo()
   }, [closeInfo])
 
+  const mutable = displayedLink != null && !readOnly && displayedLink.form !== 'reference'
+
+  const linkText = useMemo(() => (displayedLink ? getLinkText(displayedLink) : ''), [displayedLink])
+
+  const canUseTitle = useMemo(
+    () => displayedLink != null && mutable && isLinkTextForHref(linkText, displayedLink.href),
+    [displayedLink, mutable, linkText],
+  )
+
   const editLink = useCallback(() => {
     if (!displayedLink) return
     selectLinkUnit(editor, displayedLink)
@@ -446,11 +455,11 @@ export function LinkMenu({
       from: displayedLink.unit.from,
       to: displayedLink.unit.to,
       link: displayedLink,
-      text: getLinkText(displayedLink),
+      text: linkText,
     })
     setEditOpen(true)
     closeInfo()
-  }, [displayedLink, editor, closeInfo])
+  }, [displayedLink, editor, linkText, closeInfo])
 
   const removeLink = useCallback(() => {
     if (!displayedLink) return
@@ -458,6 +467,15 @@ export function LinkMenu({
     editor.commands.removeLink()
     closeInfo()
   }, [displayedLink, editor, closeInfo])
+
+  const handleUseTitle = useMemo(() => {
+    if (!canUseTitle || !displayedLink) return
+    return (title: string) => {
+      selectLinkUnit(editor, displayedLink)
+      editor.commands.updateLink({ text: title })
+      closeInfo()
+    }
+  }, [canUseTitle, displayedLink, editor, closeInfo])
 
   const previewState = useLinkPreview(displayedLink?.href, resolveLinkPreview)
   const range = edit ? (edit.link?.text ?? edit) : displayedLink?.text
@@ -499,10 +517,6 @@ export function LinkMenu({
       />
     )
   } else if (displayedLink) {
-    const mutable = !readOnly && displayedLink.form !== 'reference'
-    const text = getLinkText(displayedLink)
-    const canUseTitle = mutable && isLinkTextForHref(text, displayedLink.href)
-
     content = (
       <LinkInfoContent
         href={displayedLink.href}
@@ -511,15 +525,7 @@ export function LinkMenu({
         onLinkCopy={onLinkCopy}
         onEdit={mutable ? editLink : undefined}
         onRemove={mutable ? removeLink : undefined}
-        onUseTitle={
-          canUseTitle
-            ? (title) => {
-                selectLinkUnit(editor, displayedLink)
-                editor.commands.updateLink({ text: title })
-                closeInfo()
-              }
-            : undefined
-        }
+        onUseTitle={handleUseTitle}
       />
     )
   }

--- a/packages/react/src/components/link-menu.tsx
+++ b/packages/react/src/components/link-menu.tsx
@@ -395,6 +395,9 @@ export function LinkMenu({
   const [hit, setHit] = useState<LinkUnit>()
   const [edit, setEdit] = useState<LinkEditOptions>()
   const [editOpen, setEditOpen] = useState(false)
+  // The link whose info the read popup shows. It outlives `hit` until the
+  // close animation finishes, so the popup keeps its content while fading
+  // out.
   const [displayedRead, setDisplayedRead] = useState<LinkUnit>()
   const overPopupRef = useRef(false)
 
@@ -434,6 +437,8 @@ export function LinkMenu({
     closeRead()
   }, [closeRead])
 
+  // The link currently requesting the read popup: the one under the pointer,
+  // or tapped on touch. `undefined` asks an open popup to close.
   const requestedRead = hit
   const previewState = useLinkPreview(displayedRead?.href, resolveLinkPreview)
   const range = edit ? (edit.link?.text ?? edit) : displayedRead?.text
@@ -442,48 +447,39 @@ export function LinkMenu({
     return getVirtualElementFromRange(editor.view, range)
   }, [range, editor])
 
-  if (edit && !readOnly) {
-    return (
-      <LinkPopover
-        anchor={anchor}
-        open={editOpen}
-        onClose={closeEdit}
-        onCloseComplete={() => {
-          setEdit(undefined)
-          editor.focus()
-        }}
-      >
-        <LinkEditContent
-          edit={edit}
-          resolveLinkPreview={resolveLinkPreview}
-          onRemove={
-            edit.link
-              ? () => {
-                  editor.commands.removeLink()
-                  closeEdit()
-                }
-              : undefined
-          }
-          onSubmit={(text, href) => {
-            if (edit.link) {
-              // An unchanged label passes no `text`: passing it rebuilds the
-              // whole unit and strips authored Markdown like `[**Docs**](...)`.
-              editor.commands.updateLink({
-                text: text === edit.text ? undefined : text,
-                href,
-                title: edit.link.title,
-              })
-            } else {
-              editor.commands.insertLink({ text, href })
-            }
-            closeEdit()
-          }}
-        />
-      </LinkPopover>
-    )
-  }
+  const editing = edit != null && !readOnly
 
-  if (displayedRead) {
+  let content: ReactNode
+  if (editing) {
+    content = (
+      <LinkEditContent
+        edit={edit}
+        resolveLinkPreview={resolveLinkPreview}
+        onRemove={
+          edit.link
+            ? () => {
+                editor.commands.removeLink()
+                closeEdit()
+              }
+            : undefined
+        }
+        onSubmit={(text, href) => {
+          if (edit.link) {
+            // An unchanged label passes no `text`: passing it rebuilds the
+            // whole unit and strips authored Markdown like `[**Docs**](...)`.
+            editor.commands.updateLink({
+              text: text === edit.text ? undefined : text,
+              href,
+              title: edit.link.title,
+            })
+          } else {
+            editor.commands.insertLink({ text, href })
+          }
+          closeEdit()
+        }}
+      />
+    )
+  } else if (displayedRead) {
     const mutable = !readOnly && displayedRead.form !== 'reference'
     const text = getLinkText(editor.view.state, displayedRead)
     const canUseTitle = mutable && isLinkTextForHref(text, displayedRead.href)
@@ -504,38 +500,53 @@ export function LinkMenu({
       closeRead()
     }
 
-    return (
-      <LinkPopover
-        anchor={anchor}
-        open={requestedRead !== undefined}
-        onClose={closeRead}
-        onCloseComplete={() => {
-          if (!requestedRead) setDisplayedRead(undefined)
-        }}
-        onPopupHover={(over) => {
-          overPopupRef.current = over
-        }}
-      >
-        <LinkInfoContent
-          href={displayedRead.href}
-          previewState={previewState}
-          onLinkClick={onLinkClick}
-          onLinkCopy={onLinkCopy}
-          onEdit={mutable ? editLink : undefined}
-          onRemove={mutable ? removeLink : undefined}
-          onUseTitle={
-            canUseTitle
-              ? (title) => {
-                  selectLinkUnit(editor, displayedRead)
-                  editor.commands.updateLink({ text: title })
-                  closeRead()
-                }
-              : undefined
-          }
-        />
-      </LinkPopover>
+    content = (
+      <LinkInfoContent
+        href={displayedRead.href}
+        previewState={previewState}
+        onLinkClick={onLinkClick}
+        onLinkCopy={onLinkCopy}
+        onEdit={mutable ? editLink : undefined}
+        onRemove={mutable ? removeLink : undefined}
+        onUseTitle={
+          canUseTitle
+            ? (title) => {
+                selectLinkUnit(editor, displayedRead)
+                editor.commands.updateLink({ text: title })
+                closeRead()
+              }
+            : undefined
+        }
+      />
     )
   }
 
-  return null
+  // While closed the popover renders nothing, but its root must stay mounted:
+  // Base UI plays the open transition only when `open` flips on a mounted
+  // root, and a root that mounts with `open` already true skips
+  // `[data-starting-style]`, so the popup would appear without animation.
+  return (
+    <LinkPopover
+      anchor={anchor}
+      open={editing ? editOpen : requestedRead !== undefined}
+      onClose={editing ? closeEdit : closeRead}
+      onCloseComplete={() => {
+        if (editing) {
+          setEdit(undefined)
+          editor.focus()
+        } else if (!requestedRead) {
+          setDisplayedRead(undefined)
+        }
+      }}
+      onPopupHover={
+        editing
+          ? undefined
+          : (over) => {
+              overPopupRef.current = over
+            }
+      }
+    >
+      {content}
+    </LinkPopover>
+  )
 }

--- a/packages/react/src/components/link-menu.tsx
+++ b/packages/react/src/components/link-menu.tsx
@@ -443,10 +443,6 @@ export function LinkMenu({
 
   const linkText = useMemo(() => (displayedLink ? getLinkText(displayedLink) : ''), [displayedLink])
 
-  const canUseTitle = useMemo(
-    () => displayedLink != null && mutable && isLinkTextForHref(linkText, displayedLink.href),
-    [displayedLink, mutable, linkText],
-  )
 
   const editLink = useCallback(() => {
     if (!displayedLink) return
@@ -469,13 +465,13 @@ export function LinkMenu({
   }, [displayedLink, editor, closeInfo])
 
   const handleUseTitle = useMemo(() => {
-    if (!canUseTitle || !displayedLink) return
+    if (!displayedLink || !mutable ||!isLinkTextForHref(linkText, displayedLink.href)) return
     return (title: string) => {
       selectLinkUnit(editor, displayedLink)
       editor.commands.updateLink({ text: title })
       closeInfo()
     }
-  }, [canUseTitle, displayedLink, editor, closeInfo])
+  }, [displayedLink, editor, closeInfo, linkText, mutable])
 
   const previewState = useLinkPreview(displayedLink?.href, resolveLinkPreview)
   const range = edit ? (edit.link?.text ?? edit) : displayedLink?.text

--- a/packages/react/src/components/link-menu.tsx
+++ b/packages/react/src/components/link-menu.tsx
@@ -392,15 +392,10 @@ export function LinkMenu({
   readOnly = false,
 }: LinkMenuProps): ReactNode {
   const editor: TypedEditor = useEditor<EditorExtension>()
-  // Whether a link is under the pointer, or tapped on touch. Turning `false`
-  // asks an open info popup to close.
   const [infoOpen, setInfoOpen] = useState(false)
-  // The link whose info the popup shows. It stays after `infoOpen` turns
-  // false until the close animation finishes, so the popup keeps its content
-  // while fading out.
+  const [editOpen, setEditOpen] = useState(false)
   const [link, setLink] = useState<LinkUnit | undefined>()
   const [edit, setEdit] = useState<LinkEditOptions | undefined>()
-  const [editOpen, setEditOpen] = useState(false)
   const isPointerOverPopupRef = useRef(false)
 
   const linkHoverExtension = useMemo(

--- a/packages/react/src/components/link-menu.tsx
+++ b/packages/react/src/components/link-menu.tsx
@@ -243,7 +243,7 @@ function LinkInfoContent({
   if (previewState.status === 'resolved') {
     const { preview } = previewState
     return (
-      <div data-testid="link-popover-read">
+      <div data-testid="link-popover-info">
         <div className={styles.Preview}>
           <div className={styles.Icon}>
             <PreviewIcon key={preview.iconSrc} preview={preview} />
@@ -276,7 +276,7 @@ function LinkInfoContent({
   }
 
   return (
-    <div data-testid="link-popover-read">
+    <div data-testid="link-popover-info">
       <div className={styles.Row}>
         <LinkAnchor href={href} className={styles.Url} onLinkClick={onLinkClick}>
           {href}
@@ -392,24 +392,23 @@ export function LinkMenu({
   readOnly = false,
 }: LinkMenuProps): ReactNode {
   const editor: TypedEditor = useEditor<EditorExtension>()
-  // REVIEW: rename "hit" to "hoveredLink"
-  const [hit, setHit] = useState<LinkUnit | undefined >()
-  const [edit, setEdit] = useState<LinkEditOptions | undefined>()
-  const [editOpen, setEditOpen] = useState(false)
-  // The link whose info the read popup shows. It outlives `hit` until the
+  // The link under the pointer, or tapped on touch. `undefined` asks an open
+  // info popup to close.
+  const [hoveredLink, setHoveredLink] = useState<LinkUnit | undefined>()
+  // The link whose info the popup shows. It outlives `hoveredLink` until the
   // close animation finishes, so the popup keeps its content while fading
   // out.
-  // REVIEW: rename "displayedRead" to "displayedLink". Also move this useState right after const [hit, setHit] = useState<LinkUnit | undefined >() so that these two LinkUnit states are next to each other.
-  const [displayedRead, setDisplayedRead] = useState<LinkUnit | undefined>()
+  const [displayedLink, setDisplayedLink] = useState<LinkUnit | undefined>()
+  const [edit, setEdit] = useState<LinkEditOptions | undefined>()
+  const [editOpen, setEditOpen] = useState(false)
   const overPopupRef = useRef(false)
 
   const linkHoverExtension = useMemo(
     () =>
-      // REVIEW: use {} and add "return"
       defineLinkHoverHandler(
         (nextHit) => {
-          setHit(nextHit?.payload)
-          if (nextHit) setDisplayedRead(nextHit.payload)
+          setHoveredLink(nextHit?.payload)
+          if (nextHit) setDisplayedLink(nextHit.payload)
         },
         { canLeave: () => !overPopupRef.current },
       ),
@@ -424,27 +423,44 @@ export function LinkMenu({
         : defineLinkEditKeymap((options) => {
             setEdit(options)
             setEditOpen(true)
-            setHit(undefined)
+            setHoveredLink(undefined)
           }),
     [readOnly],
   )
   useExtension(linkEditExtension)
 
-  const closeRead = useCallback(() => {
+  const closeInfo = useCallback(() => {
     overPopupRef.current = false
-    setHit(undefined)
+    setHoveredLink(undefined)
   }, [])
 
   const closeEdit = useCallback(() => {
     setEditOpen(false)
-    closeRead()
-  }, [closeRead])
+    closeInfo()
+  }, [closeInfo])
 
-  // The link currently requesting the read popup: the one under the pointer,
-  // or tapped on touch. `undefined` asks an open popup to close.
-  const requestedRead = hit
-  const previewState = useLinkPreview(displayedRead?.href, resolveLinkPreview)
-  const range = edit ? (edit.link?.text ?? edit) : displayedRead?.text
+  const editLink = useCallback(() => {
+    if (!displayedLink) return
+    selectLinkUnit(editor, displayedLink)
+    setEdit({
+      from: displayedLink.unit.from,
+      to: displayedLink.unit.to,
+      link: displayedLink,
+      text: getLinkText(editor.view.state, displayedLink),
+    })
+    setEditOpen(true)
+    closeInfo()
+  }, [displayedLink, editor, closeInfo])
+
+  const removeLink = useCallback(() => {
+    if (!displayedLink) return
+    selectLinkUnit(editor, displayedLink)
+    editor.commands.removeLink()
+    closeInfo()
+  }, [displayedLink, editor, closeInfo])
+
+  const previewState = useLinkPreview(displayedLink?.href, resolveLinkPreview)
+  const range = edit ? (edit.link?.text ?? edit) : displayedLink?.text
   const anchor: VirtualElement | undefined = useMemo(() => {
     if (!range) return
     return getVirtualElementFromRange(editor.view, range)
@@ -482,30 +498,14 @@ export function LinkMenu({
         }}
       />
     )
-  } else if (displayedRead) {
-    const mutable = !readOnly && displayedRead.form !== 'reference'
-    const text = getLinkText(editor.view.state, displayedRead)
-    const canUseTitle = mutable && isLinkTextForHref(text, displayedRead.href)
-    const editLink = () => {
-      selectLinkUnit(editor, displayedRead)
-      setEdit({
-        from: displayedRead.unit.from,
-        to: displayedRead.unit.to,
-        link: displayedRead,
-        text,
-      })
-      setEditOpen(true)
-      closeRead()
-    }
-    const removeLink = () => {
-      selectLinkUnit(editor, displayedRead)
-      editor.commands.removeLink()
-      closeRead()
-    }
+  } else if (displayedLink) {
+    const mutable = !readOnly && displayedLink.form !== 'reference'
+    const text = getLinkText(editor.view.state, displayedLink)
+    const canUseTitle = mutable && isLinkTextForHref(text, displayedLink.href)
 
     content = (
       <LinkInfoContent
-        href={displayedRead.href}
+        href={displayedLink.href}
         previewState={previewState}
         onLinkClick={onLinkClick}
         onLinkCopy={onLinkCopy}
@@ -514,9 +514,9 @@ export function LinkMenu({
         onUseTitle={
           canUseTitle
             ? (title) => {
-                selectLinkUnit(editor, displayedRead)
+                selectLinkUnit(editor, displayedLink)
                 editor.commands.updateLink({ text: title })
-                closeRead()
+                closeInfo()
               }
             : undefined
         }
@@ -531,14 +531,14 @@ export function LinkMenu({
   return (
     <LinkPopover
       anchor={anchor}
-      open={editing ? editOpen : requestedRead !== undefined}
-      onClose={editing ? closeEdit : closeRead}
+      open={editing ? editOpen : hoveredLink !== undefined}
+      onClose={editing ? closeEdit : closeInfo}
       onCloseComplete={() => {
         if (editing) {
           setEdit(undefined)
           editor.focus()
-        } else if (!requestedRead) {
-          setDisplayedRead(undefined)
+        } else if (!hoveredLink) {
+          setDisplayedLink(undefined)
         }
       }}
       onPopupHover={

--- a/packages/react/src/components/link-menu.tsx
+++ b/packages/react/src/components/link-menu.tsx
@@ -392,25 +392,25 @@ export function LinkMenu({
   readOnly = false,
 }: LinkMenuProps): ReactNode {
   const editor: TypedEditor = useEditor<EditorExtension>()
-  // The link under the pointer, or tapped on touch. `undefined` asks an open
-  // info popup to close.
-  const [hoveredLink, setHoveredLink] = useState<LinkUnit | undefined>()
-  // The link whose info the popup shows. It outlives `hoveredLink` until the
-  // close animation finishes, so the popup keeps its content while fading
-  // out.
-  const [displayedLink, setDisplayedLink] = useState<LinkUnit | undefined>()
+  // Whether a link is under the pointer, or tapped on touch. Turning `false`
+  // asks an open info popup to close.
+  const [infoOpen, setInfoOpen] = useState(false)
+  // The link whose info the popup shows. It stays after `infoOpen` turns
+  // false until the close animation finishes, so the popup keeps its content
+  // while fading out.
+  const [link, setLink] = useState<LinkUnit | undefined>()
   const [edit, setEdit] = useState<LinkEditOptions | undefined>()
   const [editOpen, setEditOpen] = useState(false)
-  const overPopupRef = useRef(false)
+  const isPointerOverPopupRef = useRef(false)
 
   const linkHoverExtension = useMemo(
     () =>
       defineLinkHoverHandler(
         (nextHit) => {
-          setHoveredLink(nextHit?.payload)
-          if (nextHit) setDisplayedLink(nextHit.payload)
+          setInfoOpen(nextHit != null)
+          if (nextHit) setLink(nextHit.payload)
         },
-        { canLeave: () => !overPopupRef.current },
+        { canLeave: () => !isPointerOverPopupRef.current },
       ),
     [],
   )
@@ -423,15 +423,19 @@ export function LinkMenu({
         : defineLinkEditKeymap((options) => {
             setEdit(options)
             setEditOpen(true)
-            setHoveredLink(undefined)
+            setInfoOpen(false)
           }),
     [readOnly],
   )
   useExtension(linkEditExtension)
 
+  const handlePointerHover = useCallback((over: boolean) => {
+    isPointerOverPopupRef.current = over
+  }, [])
+
   const closeInfo = useCallback(() => {
-    overPopupRef.current = false
-    setHoveredLink(undefined)
+    isPointerOverPopupRef.current = false
+    setInfoOpen(false)
   }, [])
 
   const closeEdit = useCallback(() => {
@@ -439,42 +443,41 @@ export function LinkMenu({
     closeInfo()
   }, [closeInfo])
 
-  const mutable = displayedLink != null && !readOnly && displayedLink.form !== 'reference'
+  const mutable = link != null && !readOnly && link.form !== 'reference'
 
-  const linkText = useMemo(() => (displayedLink ? getLinkText(displayedLink) : ''), [displayedLink])
-
+  const linkText = useMemo(() => (link ? getLinkText(link) : ''), [link])
 
   const editLink = useCallback(() => {
-    if (!displayedLink) return
-    selectLinkUnit(editor, displayedLink)
+    if (!link) return
+    selectLinkUnit(editor, link)
     setEdit({
-      from: displayedLink.unit.from,
-      to: displayedLink.unit.to,
-      link: displayedLink,
+      from: link.unit.from,
+      to: link.unit.to,
+      link,
       text: linkText,
     })
     setEditOpen(true)
     closeInfo()
-  }, [displayedLink, editor, linkText, closeInfo])
+  }, [link, editor, linkText, closeInfo])
 
   const removeLink = useCallback(() => {
-    if (!displayedLink) return
-    selectLinkUnit(editor, displayedLink)
+    if (!link) return
+    selectLinkUnit(editor, link)
     editor.commands.removeLink()
     closeInfo()
-  }, [displayedLink, editor, closeInfo])
+  }, [link, editor, closeInfo])
 
   const handleUseTitle = useMemo(() => {
-    if (!displayedLink || !mutable ||!isLinkTextForHref(linkText, displayedLink.href)) return
+    if (!link || !mutable || !isLinkTextForHref(linkText, link.href)) return
     return (title: string) => {
-      selectLinkUnit(editor, displayedLink)
+      selectLinkUnit(editor, link)
       editor.commands.updateLink({ text: title })
       closeInfo()
     }
-  }, [displayedLink, editor, closeInfo, linkText, mutable])
+  }, [link, editor, closeInfo, linkText, mutable])
 
-  const previewState = useLinkPreview(displayedLink?.href, resolveLinkPreview)
-  const range = edit ? (edit.link?.text ?? edit) : displayedLink?.text
+  const previewState = useLinkPreview(link?.href, resolveLinkPreview)
+  const range = edit ? (edit.link?.text ?? edit) : link?.text
   const anchor: VirtualElement | undefined = useMemo(() => {
     if (!range) return
     return getVirtualElementFromRange(editor.view, range)
@@ -512,10 +515,10 @@ export function LinkMenu({
         }}
       />
     )
-  } else if (displayedLink) {
+  } else if (link) {
     content = (
       <LinkInfoContent
-        href={displayedLink.href}
+        href={link.href}
         previewState={previewState}
         onLinkClick={onLinkClick}
         onLinkCopy={onLinkCopy}
@@ -533,23 +536,17 @@ export function LinkMenu({
   return (
     <LinkPopover
       anchor={anchor}
-      open={editing ? editOpen : hoveredLink !== undefined}
+      open={editing ? editOpen : infoOpen}
       onClose={editing ? closeEdit : closeInfo}
       onCloseComplete={() => {
         if (editing) {
           setEdit(undefined)
           editor.focus()
-        } else if (!hoveredLink) {
-          setDisplayedLink(undefined)
+        } else if (!infoOpen) {
+          setLink(undefined)
         }
       }}
-      onPopupHover={
-        editing
-          ? undefined
-          : (over) => {
-              overPopupRef.current = over
-            }
-      }
+      onPopupHover={handlePointerHover}
     >
       {content}
     </LinkPopover>

--- a/packages/react/src/components/link-menu.tsx
+++ b/packages/react/src/components/link-menu.tsx
@@ -443,6 +443,33 @@ export function LinkMenu({
     closeInfo()
   }, [closeInfo])
 
+  const handleEditRemove = useMemo(() => {
+    if (!edit?.link) return
+    return () => {
+      editor.commands.removeLink()
+      closeEdit()
+    }
+  }, [edit, editor, closeEdit])
+
+  const handleEditSubmit = useCallback(
+    (text: string, href: string) => {
+      if (!edit) return
+      if (edit.link) {
+        // An unchanged label passes no `text`: passing it rebuilds the
+        // whole unit and strips authored Markdown like `[**Docs**](...)`.
+        editor.commands.updateLink({
+          text: text === edit.text ? undefined : text,
+          href,
+          title: edit.link.title,
+        })
+      } else {
+        editor.commands.insertLink({ text, href })
+      }
+      closeEdit()
+    },
+    [edit, editor, closeEdit],
+  )
+
   const mutable = link != null && !readOnly && link.form !== 'reference'
 
   const linkText = useMemo(() => (link ? getLinkText(link) : ''), [link])
@@ -485,50 +512,6 @@ export function LinkMenu({
 
   const editing = edit != null && !readOnly
 
-  let content: ReactNode
-  if (editing) {
-    content = (
-      <LinkEditContent
-        edit={edit}
-        resolveLinkPreview={resolveLinkPreview}
-        onRemove={
-          edit.link
-            ? () => {
-                editor.commands.removeLink()
-                closeEdit()
-              }
-            : undefined
-        }
-        onSubmit={(text, href) => {
-          if (edit.link) {
-            // An unchanged label passes no `text`: passing it rebuilds the
-            // whole unit and strips authored Markdown like `[**Docs**](...)`.
-            editor.commands.updateLink({
-              text: text === edit.text ? undefined : text,
-              href,
-              title: edit.link.title,
-            })
-          } else {
-            editor.commands.insertLink({ text, href })
-          }
-          closeEdit()
-        }}
-      />
-    )
-  } else if (link) {
-    content = (
-      <LinkInfoContent
-        href={link.href}
-        previewState={previewState}
-        onLinkClick={onLinkClick}
-        onLinkCopy={onLinkCopy}
-        onEdit={mutable ? editLink : undefined}
-        onRemove={mutable ? removeLink : undefined}
-        onUseTitle={handleUseTitle}
-      />
-    )
-  }
-
   // While closed the popover renders nothing, but its root must stay mounted:
   // Base UI plays the open transition only when `open` flips on a mounted
   // root, and a root that mounts with `open` already true skips
@@ -548,7 +531,24 @@ export function LinkMenu({
       }}
       onPopupHover={handlePointerHover}
     >
-      {content}
+      {editing ? (
+        <LinkEditContent
+          edit={edit}
+          resolveLinkPreview={resolveLinkPreview}
+          onRemove={handleEditRemove}
+          onSubmit={handleEditSubmit}
+        />
+      ) : link ? (
+        <LinkInfoContent
+          href={link.href}
+          previewState={previewState}
+          onLinkClick={onLinkClick}
+          onLinkCopy={onLinkCopy}
+          onEdit={mutable ? editLink : undefined}
+          onRemove={mutable ? removeLink : undefined}
+          onUseTitle={handleUseTitle}
+        />
+      ) : undefined}
     </LinkPopover>
   )
 }

--- a/packages/react/src/components/link-menu.tsx
+++ b/packages/react/src/components/link-menu.tsx
@@ -443,13 +443,10 @@ export function LinkMenu({
     closeInfo()
   }, [closeInfo])
 
-  const handleEditRemove = useMemo(() => {
-    if (!edit?.link) return
-    return () => {
+  const handleEditRemove = useCallback(() => {
       editor.commands.removeLink()
       closeEdit()
-    }
-  }, [edit, editor, closeEdit])
+  }, [editor, closeEdit])
 
   const handleEditSubmit = useCallback(
     (text: string, href: string) => {

--- a/packages/react/src/components/link-menu.tsx
+++ b/packages/react/src/components/link-menu.tsx
@@ -446,7 +446,7 @@ export function LinkMenu({
       from: displayedLink.unit.from,
       to: displayedLink.unit.to,
       link: displayedLink,
-      text: getLinkText(editor.view.state, displayedLink),
+      text: getLinkText(displayedLink),
     })
     setEditOpen(true)
     closeInfo()
@@ -500,7 +500,7 @@ export function LinkMenu({
     )
   } else if (displayedLink) {
     const mutable = !readOnly && displayedLink.form !== 'reference'
-    const text = getLinkText(editor.view.state, displayedLink)
+    const text = getLinkText(displayedLink)
     const canUseTitle = mutable && isLinkTextForHref(text, displayedLink.href)
 
     content = (

--- a/packages/react/src/components/link-menu.tsx
+++ b/packages/react/src/components/link-menu.tsx
@@ -392,17 +392,20 @@ export function LinkMenu({
   readOnly = false,
 }: LinkMenuProps): ReactNode {
   const editor: TypedEditor = useEditor<EditorExtension>()
+  // REVIEW: rename "hit" to "hoveredLink"
   const [hit, setHit] = useState<LinkUnit | undefined >()
   const [edit, setEdit] = useState<LinkEditOptions | undefined>()
   const [editOpen, setEditOpen] = useState(false)
   // The link whose info the read popup shows. It outlives `hit` until the
   // close animation finishes, so the popup keeps its content while fading
   // out.
+  // REVIEW: rename "displayedRead" to "displayedLink". Also move this useState right after const [hit, setHit] = useState<LinkUnit | undefined >() so that these two LinkUnit states are next to each other.
   const [displayedRead, setDisplayedRead] = useState<LinkUnit | undefined>()
   const overPopupRef = useRef(false)
 
   const linkHoverExtension = useMemo(
     () =>
+      // REVIEW: use {} and add "return"
       defineLinkHoverHandler(
         (nextHit) => {
           setHit(nextHit?.payload)


### PR DESCRIPTION
`LinkMenu` mounted a `Popover.Root` only while a popup was showing, so the root's first render already had `open` true and Base UI never applied `[data-starting-style]`: the read and edit popups appeared without their open animation, while the close animation still played. Keep one root mounted for both info and edit content, which restores the open animation and turns the info-to-edit switch into an in-place content swap instead of a remount. Also document the `hoveredLink` / `displayedLink` state pair.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved link popovers for smoother switching between link information and editing.
  - Link hover and edit interactions are now more consistent, including shared popup tracking.
  - Preserved unchanged Markdown link labels during editing.
  - Added more reliable handling for closing, removing, submitting edits, and applying preview titles.

- **Tests**
  - Updated link menu coverage for standard links, reference links, and edge-case popover positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->