### PR TITLE
docs(website): pass `resolveLinkPreview` to the home demo

### DIFF
--- a/website/src/home/home-demo.tsx
+++ b/website/src/home/home-demo.tsx
@@ -14,6 +14,7 @@ import {
   handleWikilinkClick,
   resolveFileInfo,
   resolveFileLink,
+  resolveLinkPreview,
   searchNotes,
   searchTags,
   uploadAndTrackFile,
@@ -87,6 +88,7 @@ export function HomeDemo() {
               onFileClick={handleFileClick}
               onImageClick={handleImageClick}
               onLinkClick={handleLinkClick}
+              resolveLinkPreview={resolveLinkPreview}
               onTagClick={handleTagClick}
               onWikilinkClick={handleWikilinkClick}
               onExitBoundary={handleExitBoundary}


### PR DESCRIPTION
The home demo now passes the demo `resolveLinkPreview`, so hovering a link shows the same rich preview card as the playground.