### PR TITLE
fix(react): update button and anchor styles in popup components

### DIFF
--- a/packages/react/src/components/link-menu.module.css
+++ b/packages/react/src/components/link-menu.module.css
@@ -61,6 +61,7 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  text-decoration: none;
   color: var(--meowdown-accent);
   cursor: pointer;
 }
@@ -74,6 +75,8 @@
   height: 2rem;
   padding: 0;
   color: var(--meowdown-text);
+  background: transparent;
+  border: 0;
   border-radius: 0.5rem;
   cursor: pointer;
 
@@ -124,6 +127,7 @@
   line-height: 1.3;
   white-space: nowrap;
   text-overflow: ellipsis;
+  text-decoration: none;
   color: var(--meowdown-accent);
 }
 
@@ -284,6 +288,8 @@
   min-height: 2rem;
   padding: 0.375rem 0.625rem;
   font: inherit;
+  background: transparent;
+  border: 0;
   border-radius: 0.5rem;
   cursor: pointer;
 

--- a/packages/react/src/components/pending-replacement-preview.module.css
+++ b/packages/react/src/components/pending-replacement-preview.module.css
@@ -52,7 +52,10 @@
   display: inline-flex;
   align-items: center;
   padding: 0.25rem 0.625rem;
+  font: inherit;
   color: var(--meowdown-text);
+  background: transparent;
+  border: 0;
   border-radius: 0.5rem;
   white-space: nowrap;
   cursor: pointer;
@@ -66,8 +69,10 @@
   display: inline-flex;
   align-items: center;
   padding: 0.25rem 0.625rem;
+  font: inherit;
   color: var(--meowdown-popover-bg);
   background: var(--meowdown-accent);
+  border: 0;
   border-radius: 0.5rem;
   white-space: nowrap;
   cursor: pointer;

--- a/packages/react/src/components/selection-menu.module.css
+++ b/packages/react/src/components/selection-menu.module.css
@@ -49,7 +49,10 @@
   gap: 0.5rem;
   padding: 0.375rem 0.5rem;
   text-align: left;
+  font: inherit;
   color: var(--meowdown-text);
+  background: transparent;
+  border: 0;
   border-radius: 0.5rem;
   cursor: pointer;
 


### PR DESCRIPTION
Buttons and links in the popup components now set their own `border`, `background`, `font`, and `text-decoration`, so they render the same in hosts without a CSS reset (native button chrome and link underlines were showing through in the playground, which loads Tailwind without preflight).