### PR TITLE
fix: hide the native caret in `noLink` units

### DIFF
--- a/packages/core/src/extensions/autolink.test.ts
+++ b/packages/core/src/extensions/autolink.test.ts
@@ -49,3 +49,18 @@ describe('autolink rendering', () => {
     await expect.element(pmRoot.getByRole('link', { name: 'google.com' })).toBeInTheDocument()
   })
 })
+
+describe('noLink unit', () => {
+  // The address text is the pack's direct child, so the pack must be a real
+  // inline box: WebKit resolves the caret color from the text's parent
+  // element renderer, and a `display: contents` parent has none, painting the
+  // native caret fallback-black over the transparent virtual-caret setup.
+  it('renders the unlinked address inside an inline box', async () => {
+    using fixture = setupFixture()
+    const { n } = fixture
+    fixture.set(n.doc(n.paragraph('go to www.example.com<!-- {"noLink":true} --> now')))
+    const address = pmRoot.getByText('www.example.com')
+    await expect.element(address).toBeInTheDocument()
+    expect(getComputedStyle(address.element()).display).toBe('inline')
+  })
+})

--- a/packages/core/src/extensions/autolink.test.ts
+++ b/packages/core/src/extensions/autolink.test.ts
@@ -51,16 +51,16 @@ describe('autolink rendering', () => {
 })
 
 describe('noLink unit', () => {
-  // The address text is the pack's direct child, so the pack must be a real
-  // inline box: WebKit resolves the caret color from the text's parent
-  // element renderer, and a `display: contents` parent has none, painting the
-  // native caret fallback-black over the transparent virtual-caret setup.
-  it('renders the unlinked address inside an inline box', async () => {
+  // WebKit resolves the caret color from the renderer of the text's parent
+  // element; a boxless (`display: contents`) parent has none, so the native
+  // caret paints fallback black over the transparent virtual-caret setup and
+  // Safari shows a second caret beside the virtual one.
+  it('keeps the unlinked address inside an element with a layout box', async () => {
     using fixture = setupFixture()
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('go to www.example.com<!-- {"noLink":true} --> now')))
     const address = pmRoot.getByText('www.example.com')
     await expect.element(address).toBeInTheDocument()
-    expect(getComputedStyle(address.element()).display).toBe('inline')
+    expect(address.element().getClientRects().length).toBeGreaterThan(0)
   })
 })

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -761,6 +761,17 @@
     display: contents;
   }
 
+  /* The `noLink` unit is the one pack whose visible text has no inner mark
+   * element. WebKit resolves the caret color from the text's parent element
+   * renderer, and `display: contents` has none: the native caret then paints
+   * fallback black, ignoring `caret-color: transparent`, and doubles the
+   * virtual caret. A plain inline box (not an atomic inline-block) restores
+   * caret-color resolution without changing wrapping or decoration
+   * propagation. */
+  .ProseMirror .md-pack[data-key='noLink'] {
+    display: inline;
+  }
+
   /* Hidden syntax keeps a real zero-width inline box (font-size: 0) instead of
    * leaving the box tree (display: none): the caret, click hit-testing, native
    * deletion, and scrolling all assume the text has a box. letter-spacing is


### PR DESCRIPTION
In a `noLink` unit the address text sits directly under the `display: contents` pack span, and WebKit resolves the caret color from that parent's renderer, so the native caret paints fallback black and doubles the virtual caret in Safari. A plain inline box on this one pack restores `caret-color: transparent` without changing wrapping.

https://github.com/user-attachments/assets/7909e85b-2269-4783-a07a-0517ec2622f6

Closes https://github.com/prosekit/meowdown/issues/521 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where unlinked inline text could display a duplicate or incorrectly colored caret in WebKit-based browsers.
  - Unlinked addresses now render correctly as inline text.

- **Chores**
  - Updated supporting development and website tooling dependencies.
  - Refined workspace package release handling.

- **Tests**
  - Added coverage for correct rendering of unlinked addresses.
  - Reformatted and maintained existing test coverage without changing expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->