### PR TITLE
test: call `requestGC` in the roundtrip fuzz test

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,7 +59,8 @@
     "dedent": "^1.7.2",
     "diffable-html-snapshot": "^0.3.0",
     "tsdown": "^0.23.0-beta.2",
-    "vitest": "^4.1.11"
+    "vitest": "^4.1.11",
+    "vitest-browser-commands": "^0.4.1"
   },
   "publishConfig": {
     "exports": {

--- a/packages/core/src/converters/check-roundtrip-fuzz.test.ts
+++ b/packages/core/src/converters/check-roundtrip-fuzz.test.ts
@@ -1,6 +1,6 @@
 import { createStringPicker } from '@meowdown/vitest/random'
-import { sleep } from '@ocavue/utils'
 import { it } from 'vitest'
+import { requestGC } from 'vitest-browser-commands/playwright'
 
 import { checkRoundTrip } from './check-roundtrip.ts'
 
@@ -155,8 +155,7 @@ for (const [minLength, maxLength] of RANGES) {
             )
           }
           if (sample % 5_000 === 0) {
-            // This might be helpful for GC in WebKit.
-            await sleep(20)
+            await requestGC()
           }
         }
       },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -61,7 +61,7 @@
     "react-dom": "^19.2.8",
     "tsdown": "^0.23.0-beta.2",
     "vitest": "^4.1.11",
-    "vitest-browser-commands": "^0.2.1",
+    "vitest-browser-commands": "^0.4.1",
     "vitest-browser-react": "^2.2.0"
   },
   "publishConfig": {

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -21,7 +21,7 @@
     "@vitest/browser-playwright": "^4.1.11",
     "pure-rand": "^8.4.2",
     "vitest": "^4.1.11",
-    "vitest-browser-commands": "^0.2.1",
+    "vitest-browser-commands": "^0.4.1",
     "vitest-fail-on-console": "^0.10.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,9 @@ importers:
       vitest:
         specifier: ^4.1.11
         version: 4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.2.2)
+      vitest-browser-commands:
+        specifier: ^0.4.1
+        version: 0.4.1(@vitest/browser-playwright@4.1.11)(@vitest/browser@4.1.11)(playwright@1.62.1)(vite@8.2.2)(vitest@4.1.11)
 
   packages/eslint-rules:
     dependencies:
@@ -281,8 +284,8 @@ importers:
         specifier: ^4.1.11
         version: 4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.2.2)
       vitest-browser-commands:
-        specifier: ^0.2.1
-        version: 0.2.1(@vitest/browser-playwright@4.1.11)(vitest@4.1.11)
+        specifier: ^0.4.1
+        version: 0.4.1(@vitest/browser-playwright@4.1.11)(@vitest/browser@4.1.11)(playwright@1.62.1)(vite@8.2.2)(vitest@4.1.11)
       vitest-browser-react:
         specifier: ^2.2.0
         version: 2.2.0(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(vitest@4.1.11)
@@ -308,8 +311,8 @@ importers:
         specifier: ^4.1.11
         version: 4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.2.2)
       vitest-browser-commands:
-        specifier: ^0.2.1
-        version: 0.2.1(@vitest/browser-playwright@4.1.11)(vitest@4.1.11)
+        specifier: ^0.4.1
+        version: 0.4.1(@vitest/browser-playwright@4.1.11)(@vitest/browser@4.1.11)(playwright@1.62.1)(vite@8.2.2)(vitest@4.1.11)
       vitest-fail-on-console:
         specifier: ^0.10.1
         version: 0.10.1(@vitest/utils@4.1.11)(vite@8.2.2)(vitest@4.1.11)
@@ -4679,13 +4682,22 @@ packages:
       vite:
         optional: true
 
-  vitest-browser-commands@0.2.1:
-    resolution: {integrity: sha512-SCA6fjcO8uPLIvkzNzT8i0y+eUHx4hthZR2g7PSzHz01iG3qAm+rjfDuD1ot4taABsXolo1WaDByjKFuQ1IVww==}
+  vitest-browser-commands@0.4.1:
+    resolution: {integrity: sha512-tDDmSe8T//anin03G4sGNSOttozSaiO9105nYh8wh4gv8R5vAxiYvj7faSx+g0yg1jMtKzyQPDbUFoRYwJx7Hg==}
     peerDependencies:
-      '@vitest/browser-playwright': ^4.0.3
-      vitest: ^4.0.3
+      '@vitest/browser': ^4.0.0 || ^5.0.0-beta.7
+      '@vitest/browser-playwright': ^4.0.3 || ^5.0.0-beta.7
+      playwright: '*'
+      vite: '*'
+      vitest: ^4.0.3 || ^5.0.0-beta.7
     peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
       '@vitest/browser-playwright':
+        optional: true
+      playwright:
+        optional: true
+      vite:
         optional: true
       vitest:
         optional: true
@@ -9549,9 +9561,12 @@ snapshots:
     optionalDependencies:
       vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)
 
-  vitest-browser-commands@0.2.1(@vitest/browser-playwright@4.1.11)(vitest@4.1.11):
+  vitest-browser-commands@0.4.1(@vitest/browser-playwright@4.1.11)(@vitest/browser@4.1.11)(playwright@1.62.1)(vite@8.2.2)(vitest@4.1.11):
     optionalDependencies:
+      '@vitest/browser': 4.1.11(vite@8.2.2)(vitest@4.1.11)
       '@vitest/browser-playwright': 4.1.11(playwright@1.62.1)(vite@8.2.2)(vitest@4.1.11)
+      playwright: 1.62.1
+      vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)
       vitest: 4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.2.2)
 
   vitest-browser-react@2.2.0(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(vitest@4.1.11):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,7 @@ minimumReleaseAgeExclude:
   - '@prosemirror-adapter/*'
   - prosemirror-view
   - eslint-plugin-ocavue
+  - vitest-browser-commands@0.4.1
 
 allowBuilds:
   esbuild: false


### PR DESCRIPTION
Update `vitest-browser-commands` to 0.4.1 and replace the `sleep(20)` hack in the roundtrip fuzz test with the new `requestGC()` command, which asks the browser to perform a real garbage collection every 5000 samples. Verified locally on chromium and webkit.