### PR TITLE
feat: add `resolveWikilink`

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -31,7 +31,7 @@ const markdown = docToMarkdown(editor.state.doc)
 
 [CommonMark](https://commonmark.org/) and [GFM](https://github.github.com/gfm/), plus:
 
-- Wikilinks (`[[target]]`, `[[target|alias]]`)
+- Wikilinks (`[[target]]`; alias forms such as `[[target|alias]]` are the host's to split via `resolveWikilink`)
 - Wiki embeds (`![[path]]`)
 - Tags (`#tag`)
 - Highlight (`==highlight==`)

--- a/packages/core/src/extensions/clipboard/plain-text.test.ts
+++ b/packages/core/src/extensions/clipboard/plain-text.test.ts
@@ -4,11 +4,13 @@ import { describe, expect, it } from 'vitest'
 import { userEvent } from 'vitest/browser'
 
 import { markdownToDoc } from '../../converters/md-to-pm.ts'
-import { setupFixture, type Fixture } from '../../testing/index.ts'
+import { resolveWikilinkAlias, setupFixture, type Fixture } from '../../testing/index.ts'
 import type { MarkMode } from '../mark-mode.ts'
 
 function setupPlainText(mode: MarkMode, markdown: string): Fixture {
-  const fixture = setupFixture({ extensionOptions: { markMode: mode } })
+  const fixture = setupFixture({
+    extensionOptions: { markMode: mode, resolveWikilink: resolveWikilinkAlias },
+  })
   const { editor } = fixture
   fixture.set(markdownToDoc(markdown, { nodes: editor.nodes }))
   return fixture

--- a/packages/core/src/extensions/extension.ts
+++ b/packages/core/src/extensions/extension.ts
@@ -102,9 +102,9 @@ export type EditorExtension = ReturnType<typeof defineEditorExtensionImpl>
 
 /**
  * Options for {@link defineEditorExtension}. Creation-time configuration:
- * `resolveFileLink` and `resolveWikiEmbed` are baked into the editor's parse
- * pipeline, so changing them requires rebuilding the editor; `markMode` is
- * only the initial value.
+ * `resolveFileLink`, `resolveWikiEmbed`, and `resolveWikilink` are baked into
+ * the editor's parse pipeline, so changing them requires rebuilding the
+ * editor; `markMode` is only the initial value.
  */
 export type EditorExtensionOptions = InlineMarkOptions & {
   /**

--- a/packages/core/src/extensions/find.test.ts
+++ b/packages/core/src/extensions/find.test.ts
@@ -2,10 +2,10 @@ import { getSearchStatus } from '@prosekit/extensions/search'
 import { describe, expect, it } from 'vitest'
 import { page } from 'vitest/browser'
 
-import { setupFixture, type Fixture } from '../testing/index.ts'
+import { resolveWikilinkAlias, setupFixture, type Fixture } from '../testing/index.ts'
 
 function setupFind(markdown: string): Fixture {
-  const fixture = setupFixture()
+  const fixture = setupFixture({ extensionOptions: { resolveWikilink: resolveWikilinkAlias } })
   const { n } = fixture
   fixture.set(n.doc(n.paragraph(markdown)))
   return fixture

--- a/packages/core/src/extensions/inline-marks.ts
+++ b/packages/core/src/extensions/inline-marks.ts
@@ -163,7 +163,7 @@ function defineMdTag() {
 }
 
 /**
- * Covers the whole `[[target]]`/`[[target|alias]]` source.
+ * Covers the whole `[[...]]` source.
  */
 function defineMdWikilink() {
   return defineMarkSpec<'mdWikilink', MdWikilinkAttrs>({
@@ -176,7 +176,14 @@ function defineMdWikilink() {
 }
 
 export interface MdWikilinkAttrs {
+  /**
+   * Target passed to click and hover handlers: the bracketed text unless the
+   * host's `resolveWikilink` replaced it.
+   */
   target: string
+  /**
+   * Label shown in place of the source, or `''` to show the target.
+   */
   display: string
 }
 

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
@@ -846,14 +846,6 @@ describe('wikilink resolver', () => {
       "
     `)
   })
-
-  it('uses the bracketed text when the resolver returns undefined', () => {
-    expect(parse('[[Note|My Note]]', { resolveWikilink: () => undefined })).toMatchInlineSnapshot(`
-      "
-      [0, 16] mdPack(key=wikilink) + mdWikilink(target=Note|My Note)
-      "
-    `)
-  })
 })
 
 describe('autolink', () => {

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
@@ -811,6 +811,40 @@ describe('wiki embed', () => {
   })
 })
 
+describe('wikilink resolver', () => {
+  it('passes the parsed target and alias to the resolver', () => {
+    const resolveWikilink = vi.fn(() => undefined)
+    parse('[[Tim MacCaw // Dad|Dad]]', { resolveWikilink })
+    expect(resolveWikilink).toHaveBeenCalledWith({ target: 'Tim MacCaw // Dad', display: 'Dad' })
+  })
+
+  it('writes the resolved display into the mark and keeps the target', () => {
+    expect(parse('[[Tim MacCaw // Dad]]', { resolveWikilink: () => ({ display: 'Tim MacCaw' }) }))
+      .toMatchInlineSnapshot(`
+      "
+      [0, 21] mdPack(key=wikilink) + mdWikilink(target=Tim MacCaw // Dad,display=Tim MacCaw)
+      "
+    `)
+  })
+
+  it('keeps the parsed alias when the resolver returns undefined', () => {
+    expect(parse('[[Note|My Note]]', { resolveWikilink: () => undefined })).toMatchInlineSnapshot(`
+      "
+      [0, 16] mdPack(key=wikilink) + mdWikilink(target=Note,display=My Note)
+      "
+    `)
+  })
+
+  it('lets the resolver override an authored alias', () => {
+    expect(parse('[[Note|My Note]]', { resolveWikilink: () => ({ display: 'Shown' }) }))
+      .toMatchInlineSnapshot(`
+      "
+      [0, 16] mdPack(key=wikilink) + mdWikilink(target=Note,display=Shown)
+      "
+    `)
+  })
+})
+
 describe('autolink', () => {
   it('https', () => {
     expect(parse('visit https://example.com now')).toMatchInlineSnapshot(`

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
@@ -812,13 +812,33 @@ describe('wiki embed', () => {
 })
 
 describe('wikilink resolver', () => {
-  it('passes the parsed target and alias to the resolver', () => {
-    const resolveWikilink = vi.fn(() => undefined)
-    parse('[[Tim MacCaw // Dad|Dad]]', { resolveWikilink })
-    expect(resolveWikilink).toHaveBeenCalledWith({ target: 'Tim MacCaw // Dad', display: 'Dad' })
+  it('keeps a `|` inside the target without a resolver', () => {
+    expect(parse('[[Note|My Note]]')).toMatchInlineSnapshot(`
+      "
+      [0, 16] mdPack(key=wikilink) + mdWikilink(target=Note|My Note)
+      "
+    `)
   })
 
-  it('writes the resolved display into the mark and keeps the target', () => {
+  it('passes the trimmed bracketed text to the resolver', () => {
+    const resolveWikilink = vi.fn(() => undefined)
+    parse('[[  Tim MacCaw // Dad|Dad  ]]', { resolveWikilink })
+    expect(resolveWikilink).toHaveBeenCalledWith({ target: 'Tim MacCaw // Dad|Dad' })
+  })
+
+  it('writes the resolved target and display into the mark', () => {
+    expect(
+      parse('[[Note|My Note]]', {
+        resolveWikilink: () => ({ target: 'Note', display: 'My Note' }),
+      }),
+    ).toMatchInlineSnapshot(`
+      "
+      [0, 16] mdPack(key=wikilink) + mdWikilink(target=Note,display=My Note)
+      "
+    `)
+  })
+
+  it('keeps the bracketed text as the target when only the display is resolved', () => {
     expect(parse('[[Tim MacCaw // Dad]]', { resolveWikilink: () => ({ display: 'Tim MacCaw' }) }))
       .toMatchInlineSnapshot(`
       "
@@ -827,19 +847,10 @@ describe('wikilink resolver', () => {
     `)
   })
 
-  it('keeps the parsed alias when the resolver returns undefined', () => {
+  it('uses the bracketed text when the resolver returns undefined', () => {
     expect(parse('[[Note|My Note]]', { resolveWikilink: () => undefined })).toMatchInlineSnapshot(`
       "
-      [0, 16] mdPack(key=wikilink) + mdWikilink(target=Note,display=My Note)
-      "
-    `)
-  })
-
-  it('lets the resolver override an authored alias', () => {
-    expect(parse('[[Note|My Note]]', { resolveWikilink: () => ({ display: 'Shown' }) }))
-      .toMatchInlineSnapshot(`
-      "
-      [0, 16] mdPack(key=wikilink) + mdWikilink(target=Note,display=Shown)
+      [0, 16] mdPack(key=wikilink) + mdWikilink(target=Note|My Note)
       "
     `)
   })

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.ts
@@ -18,7 +18,7 @@ import {
 } from './reference-links.ts'
 import type { TypedMarkBuilders } from './schema.ts'
 import { parseWikiEmbed, wikiEmbedBasename, type WikiEmbedOptions } from './wiki-embed.ts'
-import { parseWikilink, type WikilinkOptions } from './wikilink.ts'
+import type { WikilinkOptions } from './wikilink.ts'
 
 /**
  * Lookup from Lezer node type id to the ProseMirror mark.
@@ -794,8 +794,8 @@ function walkMath(
 }
 
 /**
- * Special walker for a wikilink `[[target]]`/`[[target|alias]]`. The host's
- * `resolveWikilink` may replace the label; the target is always the source.
+ * Special walker for a wikilink `[[...]]`. The bracketed text is the target
+ * and the label unless the host's `resolveWikilink` replaces either.
  */
 function walkWikilink(
   node: InlineElement,
@@ -805,14 +805,16 @@ function walkWikilink(
   out: MarkChunk[],
   options: WikilinkOptions | undefined,
 ): void {
-  const link = parseWikilink(text.slice(node.from, node.to))
-  const resolution = options?.resolveWikilink?.(link)
-  const display = resolution?.display ?? link.display
+  const source = text.slice(node.from + 2, node.to - 2).trim()
+  const resolution = options?.resolveWikilink?.({ target: source })
 
   emit(out, node.from, node.to, [
     ...parentMarks,
     createUnitPack(marks, out, parentMarks, node.from, { key: 'wikilink' }),
-    marks.mdWikilink.create({ target: link.target, display }),
+    marks.mdWikilink.create({
+      target: resolution?.target ?? source,
+      display: resolution?.display ?? '',
+    }),
   ])
 }
 

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.ts
@@ -18,7 +18,7 @@ import {
 } from './reference-links.ts'
 import type { TypedMarkBuilders } from './schema.ts'
 import { parseWikiEmbed, wikiEmbedBasename, type WikiEmbedOptions } from './wiki-embed.ts'
-import { parseWikilink } from './wikilink.ts'
+import { parseWikilink, type WikilinkOptions } from './wikilink.ts'
 
 /**
  * Lookup from Lezer node type id to the ProseMirror mark.
@@ -107,7 +107,7 @@ export interface FileLinkOptions {
 /**
  * Host options that influence source-backed inline atom parsing.
  */
-export type InlineMarkOptions = FileLinkOptions & WikiEmbedOptions
+export type InlineMarkOptions = FileLinkOptions & WikiEmbedOptions & WikilinkOptions
 
 export interface InlineMarkContext {
   /**
@@ -273,7 +273,7 @@ function walkAtomChild(
   const node = nodes[index]
   switch (node.type) {
     case LEZER_NODE_IDS.Wikilink:
-      walkWikilink(node, parentMarks, text, marks, out)
+      walkWikilink(node, parentMarks, text, marks, out, options)
       return node.to
     case LEZER_NODE_IDS.WikiEmbed:
       walkWikiEmbed(node, parentMarks, text, marks, out, options)
@@ -794,7 +794,8 @@ function walkMath(
 }
 
 /**
- * Special walker for a wikilink `[[target]]`/`[[target|alias]]`.
+ * Special walker for a wikilink `[[target]]`/`[[target|alias]]`. The host's
+ * `resolveWikilink` may replace the label; the target is always the source.
  */
 function walkWikilink(
   node: InlineElement,
@@ -802,13 +803,16 @@ function walkWikilink(
   text: string,
   marks: TypedMarkBuilders,
   out: MarkChunk[],
+  options: WikilinkOptions | undefined,
 ): void {
-  const { target, display } = parseWikilink(text.slice(node.from, node.to))
+  const link = parseWikilink(text.slice(node.from, node.to))
+  const resolution = options?.resolveWikilink?.(link)
+  const display = resolution?.display ?? link.display
 
   emit(out, node.from, node.to, [
     ...parentMarks,
     createUnitPack(marks, out, parentMarks, node.from, { key: 'wikilink' }),
-    marks.mdWikilink.create({ target, display }),
+    marks.mdWikilink.create({ target: link.target, display }),
   ])
 }
 

--- a/packages/core/src/extensions/wikilink-click.test.ts
+++ b/packages/core/src/extensions/wikilink-click.test.ts
@@ -1,27 +1,15 @@
 import { describe, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 
-import { setupFixture, type Fixture } from '../testing/index.ts'
+import { resolveWikilinkAlias, setupFixture, type Fixture } from '../testing/index.ts'
 
 import {
   defineWikilinkClickHandler,
   findWikilinkAt,
   type WikilinkClickHandler,
 } from './wikilink-click.ts'
-import { parseWikilink } from './wikilink.ts'
 
 const pmRoot = page.locate('.ProseMirror')
-
-describe('parseWikilink', () => {
-  it.each([
-    ['[[Note]]', 'Note', ''],
-    ['[[Note|Alias]]', 'Note', 'Alias'],
-    ['[[  Spaced Name  ]]', 'Spaced Name', ''],
-    ['[[Note | My Note]]', 'Note', 'My Note'],
-  ])('parses %s', (input, target, display) => {
-    expect(parseWikilink(input)).toEqual({ target, display })
-  })
-})
 
 describe('findWikilinkAt', () => {
   it('finds the wikilink covering a position', () => {
@@ -117,7 +105,7 @@ describe('wikilink click callback', () => {
 
   it('resolves adjacent wide aliases from their own hidden content holders', async () => {
     const onWikilinkClick = vi.fn<WikilinkClickHandler>()
-    using fixture = setupFixture()
+    using fixture = setupFixture({ extensionOptions: { resolveWikilink: resolveWikilinkAlias } })
     applyClickable(
       fixture,
       '[[Alpha|An alias much wider than its source]][[Beta|Another very wide alias]]',

--- a/packages/core/src/extensions/wikilink-hover.test.ts
+++ b/packages/core/src/extensions/wikilink-hover.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
 
-import { setupFixture } from '../testing/index.ts'
+import { resolveWikilinkAlias, setupFixture } from '../testing/index.ts'
 
 import { defineWikilinkHoverHandler, type WikilinkHoverHandler } from './wikilink-hover.ts'
 
 const pmRoot = page.locate('.ProseMirror')
 
 function applyHoverable(markdown: string, onHoverChange: WikilinkHoverHandler) {
-  const fixture = setupFixture()
+  const fixture = setupFixture({ extensionOptions: { resolveWikilink: resolveWikilinkAlias } })
   fixture.editor.use(defineWikilinkHoverHandler(onHoverChange))
   fixture.set(fixture.n.doc(fixture.n.paragraph(markdown)))
   fixture.editor.commands.setMarkMode('hide')

--- a/packages/core/src/extensions/wikilink-insert-caret.test.ts
+++ b/packages/core/src/extensions/wikilink-insert-caret.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 
-import { getSelectionSnapshot, setupFixture, type Fixture } from '../testing/index.ts'
+import {
+  getSelectionSnapshot,
+  resolveWikilinkAlias,
+  setupFixture,
+  type Fixture,
+} from '../testing/index.ts'
 
 import type { MarkMode } from './mark-mode.ts'
 
@@ -14,7 +19,9 @@ const ALL_MODES: MarkMode[] = ['hide', 'focus', 'show']
 // (the `<a>` tag), exactly the state of a user who typed `A` then opened the
 // wikilink menu.
 function setupAfterA(mode: MarkMode): Fixture {
-  const fixture = setupFixture({ extensionOptions: { markMode: mode } })
+  const fixture = setupFixture({
+    extensionOptions: { markMode: mode, resolveWikilink: resolveWikilinkAlias },
+  })
   const { n } = fixture
   fixture.set(n.doc(n.paragraph('A<a>')))
   fixture.view.focus()

--- a/packages/core/src/extensions/wikilink-resolve.test.ts
+++ b/packages/core/src/extensions/wikilink-resolve.test.ts
@@ -42,13 +42,6 @@ describe('wikilink resolver', () => {
     )
   })
 
-  it('receives the trimmed bracketed text', () => {
-    const resolveWikilink = vi.fn<WikilinkResolver>(() => undefined)
-    using fixture = setup('[[ Tim MacCaw // Dad|Dad ]]', { resolveWikilink })
-    void fixture
-    expect(resolveWikilink).toHaveBeenCalledWith({ target: 'Tim MacCaw // Dad|Dad' })
-  })
-
   it('renders the resolved display as the label', async () => {
     using fixture = setup('see [[Tim MacCaw // Dad]] here')
     void fixture
@@ -60,16 +53,6 @@ describe('wikilink resolver', () => {
     using fixture = setup('[[Tim MacCaw // Dad|Dad]]')
     fixture.editor.use(defineWikilinkClickHandler(onWikilinkClick))
     await expect.element(label).toHaveTextContent('Dad')
-    await userEvent.click(label)
-    expect(onWikilinkClick).toHaveBeenCalledWith(
-      expect.objectContaining({ target: 'Tim MacCaw // Dad' }),
-    )
-  })
-
-  it('reports the bracketed text as the target when only the label is resolved', async () => {
-    const onWikilinkClick = vi.fn<WikilinkClickHandler>()
-    using fixture = setup('[[Tim MacCaw // Dad]]')
-    fixture.editor.use(defineWikilinkClickHandler(onWikilinkClick))
     await userEvent.click(label)
     expect(onWikilinkClick).toHaveBeenCalledWith(
       expect.objectContaining({ target: 'Tim MacCaw // Dad' }),

--- a/packages/core/src/extensions/wikilink-resolve.test.ts
+++ b/packages/core/src/extensions/wikilink-resolve.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+import { page, userEvent } from 'vitest/browser'
+
+import { docToMarkdown } from '../converters/pm-to-md.ts'
+import { setupFixture, type Fixture } from '../testing/index.ts'
+import { getTextblockDisplayText } from '../utils/display-text.ts'
+
+import { defineWikilinkClickHandler, type WikilinkClickHandler } from './wikilink-click.ts'
+import type { WikilinkResolver } from './wikilink.ts'
+
+const pmRoot = page.locate('.ProseMirror')
+const label = pmRoot.getByTestId('wikilink')
+
+// Shows the first ` // ` segment of a bare target and keeps an authored alias.
+const showFirstSegment: WikilinkResolver = (link) => {
+  if (link.display !== '') return
+  const [first] = link.target.split(' // ')
+  return first === link.target ? undefined : { display: first }
+}
+
+function setup(markdown: string, resolveWikilink: WikilinkResolver = showFirstSegment): Fixture {
+  const fixture = setupFixture({ extensionOptions: { markMode: 'hide', resolveWikilink } })
+  const { n } = fixture
+  fixture.set(n.doc(n.paragraph(markdown)))
+  return fixture
+}
+
+describe('wikilink resolver', () => {
+  it('renders the resolved display as the label', async () => {
+    using fixture = setup('see [[Tim MacCaw // Dad]] here')
+    void fixture
+    await expect.element(label).toHaveTextContent('Tim MacCaw')
+  })
+
+  it('keeps the default label when the resolver returns undefined', async () => {
+    using fixture = setup('see [[Tim MacCaw // Dad|Dad]] and [[Note]]')
+    void fixture
+    await expect.element(label.first()).toHaveTextContent('Dad')
+    await expect.element(label.last()).toHaveTextContent('Note')
+  })
+
+  it('receives the parsed target and alias', () => {
+    const resolveWikilink = vi.fn<WikilinkResolver>(() => undefined)
+    using fixture = setup('[[Tim MacCaw // Dad|Dad]]', resolveWikilink)
+    void fixture
+    expect(resolveWikilink).toHaveBeenCalledWith({ target: 'Tim MacCaw // Dad', display: 'Dad' })
+  })
+
+  it('reports the full target on click', async () => {
+    const onWikilinkClick = vi.fn<WikilinkClickHandler>()
+    using fixture = setup('[[Tim MacCaw // Dad]]')
+    fixture.editor.use(defineWikilinkClickHandler(onWikilinkClick))
+    await userEvent.click(label)
+    expect(onWikilinkClick).toHaveBeenCalledWith(
+      expect.objectContaining({ target: 'Tim MacCaw // Dad' }),
+    )
+  })
+
+  it('feeds the resolved display into the display text', () => {
+    using fixture = setup('see [[Tim MacCaw // Dad]] here')
+    expect(getTextblockDisplayText(fixture.doc.child(0))).toBe('see Tim MacCaw here')
+  })
+
+  it('leaves the Markdown source untouched', () => {
+    using fixture = setup('see [[Tim MacCaw // Dad]] here')
+    expect(fixture.doc.textContent).toBe('see [[Tim MacCaw // Dad]] here')
+    expect(docToMarkdown(fixture.doc)).toBe('see [[Tim MacCaw // Dad]] here\n')
+  })
+})

--- a/packages/core/src/extensions/wikilink-resolve.test.ts
+++ b/packages/core/src/extensions/wikilink-resolve.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 
 import { docToMarkdown } from '../converters/pm-to-md.ts'
-import { setupFixture, type Fixture } from '../testing/index.ts'
+import { resolveWikilinkAlias, setupFixture, type Fixture } from '../testing/index.ts'
 import { getTextblockDisplayText } from '../utils/display-text.ts'
 
 import { defineWikilinkClickHandler, type WikilinkClickHandler } from './wikilink-click.ts'
@@ -11,42 +11,62 @@ import type { WikilinkResolver } from './wikilink.ts'
 const pmRoot = page.locate('.ProseMirror')
 const label = pmRoot.getByTestId('wikilink')
 
-// Shows the first ` // ` segment of a bare target and keeps an authored alias.
-const showFirstSegment: WikilinkResolver = (link) => {
-  if (link.display !== '') return
+// Splits `|` like a host would, then shows only the first ` // ` segment of a
+// target that has no alias.
+const resolveSubject: WikilinkResolver = (link) => {
+  const alias = resolveWikilinkAlias(link)
+  if (alias) return alias
   const [first] = link.target.split(' // ')
   return first === link.target ? undefined : { display: first }
 }
 
-function setup(markdown: string, resolveWikilink: WikilinkResolver = showFirstSegment): Fixture {
-  const fixture = setupFixture({ extensionOptions: { markMode: 'hide', resolveWikilink } })
+function setup(
+  markdown: string,
+  options: { resolveWikilink?: WikilinkResolver } = { resolveWikilink: resolveSubject },
+): Fixture {
+  const fixture = setupFixture({ extensionOptions: { markMode: 'hide', ...options } })
   const { n } = fixture
   fixture.set(n.doc(n.paragraph(markdown)))
   return fixture
 }
 
 describe('wikilink resolver', () => {
+  it('uses the bracketed text as the label and the target without a resolver', async () => {
+    const onWikilinkClick = vi.fn<WikilinkClickHandler>()
+    using fixture = setup('[[Note|My Note]]', {})
+    fixture.editor.use(defineWikilinkClickHandler(onWikilinkClick))
+    await expect.element(label).toHaveTextContent('Note|My Note')
+    await userEvent.click(label)
+    expect(onWikilinkClick).toHaveBeenCalledWith(
+      expect.objectContaining({ target: 'Note|My Note' }),
+    )
+  })
+
+  it('receives the trimmed bracketed text', () => {
+    const resolveWikilink = vi.fn<WikilinkResolver>(() => undefined)
+    using fixture = setup('[[ Tim MacCaw // Dad|Dad ]]', { resolveWikilink })
+    void fixture
+    expect(resolveWikilink).toHaveBeenCalledWith({ target: 'Tim MacCaw // Dad|Dad' })
+  })
+
   it('renders the resolved display as the label', async () => {
     using fixture = setup('see [[Tim MacCaw // Dad]] here')
     void fixture
     await expect.element(label).toHaveTextContent('Tim MacCaw')
   })
 
-  it('keeps the default label when the resolver returns undefined', async () => {
-    using fixture = setup('see [[Tim MacCaw // Dad|Dad]] and [[Note]]')
-    void fixture
-    await expect.element(label.first()).toHaveTextContent('Dad')
-    await expect.element(label.last()).toHaveTextContent('Note')
+  it('reports the resolved target on click', async () => {
+    const onWikilinkClick = vi.fn<WikilinkClickHandler>()
+    using fixture = setup('[[Tim MacCaw // Dad|Dad]]')
+    fixture.editor.use(defineWikilinkClickHandler(onWikilinkClick))
+    await expect.element(label).toHaveTextContent('Dad')
+    await userEvent.click(label)
+    expect(onWikilinkClick).toHaveBeenCalledWith(
+      expect.objectContaining({ target: 'Tim MacCaw // Dad' }),
+    )
   })
 
-  it('receives the parsed target and alias', () => {
-    const resolveWikilink = vi.fn<WikilinkResolver>(() => undefined)
-    using fixture = setup('[[Tim MacCaw // Dad|Dad]]', resolveWikilink)
-    void fixture
-    expect(resolveWikilink).toHaveBeenCalledWith({ target: 'Tim MacCaw // Dad', display: 'Dad' })
-  })
-
-  it('reports the full target on click', async () => {
+  it('reports the bracketed text as the target when only the label is resolved', async () => {
     const onWikilinkClick = vi.fn<WikilinkClickHandler>()
     using fixture = setup('[[Tim MacCaw // Dad]]')
     fixture.editor.use(defineWikilinkClickHandler(onWikilinkClick))
@@ -57,13 +77,13 @@ describe('wikilink resolver', () => {
   })
 
   it('feeds the resolved display into the display text', () => {
-    using fixture = setup('see [[Tim MacCaw // Dad]] here')
-    expect(getTextblockDisplayText(fixture.doc.child(0))).toBe('see Tim MacCaw here')
+    using fixture = setup('see [[Tim MacCaw // Dad]] and [[Note|My Note]]')
+    expect(getTextblockDisplayText(fixture.doc.child(0))).toBe('see Tim MacCaw and My Note')
   })
 
   it('leaves the Markdown source untouched', () => {
-    using fixture = setup('see [[Tim MacCaw // Dad]] here')
-    expect(fixture.doc.textContent).toBe('see [[Tim MacCaw // Dad]] here')
-    expect(docToMarkdown(fixture.doc)).toBe('see [[Tim MacCaw // Dad]] here\n')
+    using fixture = setup('see [[Tim MacCaw // Dad|Dad]] here')
+    expect(fixture.doc.textContent).toBe('see [[Tim MacCaw // Dad|Dad]] here')
+    expect(docToMarkdown(fixture.doc)).toBe('see [[Tim MacCaw // Dad|Dad]] here\n')
   })
 })

--- a/packages/core/src/extensions/wikilink.test.ts
+++ b/packages/core/src/extensions/wikilink.test.ts
@@ -4,6 +4,7 @@ import { page, userEvent } from 'vitest/browser'
 import {
   formatSelectionSteps,
   getSelectionSnapshot,
+  resolveWikilinkAlias,
   setupFixture,
   traceKeyAt,
   traceKeySelection,
@@ -46,8 +47,10 @@ describe.each(ALL_MODES)('wikilink rendering in %s mode', (mode) => {
     expect(label.all()).toHaveLength(2)
   })
 
-  it('renders the alias as the label', async () => {
-    using fixture = setupFixture({ extensionOptions: { markMode: mode } })
+  it('renders the label the host resolver returns', async () => {
+    using fixture = setupFixture({
+      extensionOptions: { markMode: mode, resolveWikilink: resolveWikilinkAlias },
+    })
     const { n } = fixture
     fixture.set(n.doc(n.paragraph('see [[Note|My Note]] here')))
     await expect.element(label).toHaveTextContent('My Note')

--- a/packages/core/src/extensions/wikilink.ts
+++ b/packages/core/src/extensions/wikilink.ts
@@ -4,39 +4,39 @@ import type { MarkViewConstructor } from '@prosekit/pm/view'
 import type { MdWikilinkAttrs } from './inline-marks.ts'
 import type { MarkName } from './mark-names.ts'
 
-export interface ParsedWikilink {
-  target: string
-  display: string
-}
-
 /**
- * Splits `[[target]]`/`[[target|alias]]` into its target and display label (the alias, or empty).
+ * What {@link WikilinkResolver} sees for one `[[...]]` wikilink.
  */
-export function parseWikilink(text: string): ParsedWikilink {
-  const inner = text.replace(/^\[\[/, '').replace(/\]\]$/, '')
-  const pipe = inner.indexOf('|')
-  if (pipe < 0) return { target: inner.trim(), display: '' }
-  return { target: inner.slice(0, pipe).trim(), display: inner.slice(pipe + 1).trim() }
+export interface WikilinkPayload {
+  /**
+   * The text between the brackets, trimmed. Meowdown reads no syntax inside
+   * it: an alias form such as `[[target|alias]]` arrives here whole.
+   */
+  target: string
 }
 
 /**
- * A resolved wikilink label.
+ * A resolved wikilink.
  */
 export interface WikilinkResolution {
   /**
-   * Label shown in place of the source. Defaults to the alias, else the target.
+   * Target passed to click and hover handlers. Defaults to the bracketed text.
+   */
+  target?: string
+  /**
+   * Label shown in place of the source. Defaults to the target.
    */
   display?: string
 }
 
 /**
- * Resolves the label of one `[[target]]`/`[[target|alias]]`. Only the label
- * changes: the target, click payloads, and the Markdown source stay as
- * written. Return `undefined` to keep the default label. The resolver
- * participates in the parse cache, so it must be pure: the same link must
- * always return the same result.
+ * Resolves one `[[...]]` wikilink into the target its handlers receive and
+ * the label its chip shows; the Markdown source stays as written. Return
+ * `undefined` to use the bracketed text as both. The resolver participates
+ * in the parse cache, so it must be pure: the same payload must always
+ * return the same result.
  */
-export type WikilinkResolver = (link: ParsedWikilink) => WikilinkResolution | undefined
+export type WikilinkResolver = (link: WikilinkPayload) => WikilinkResolution | undefined
 
 /**
  * Host options for wikilink parsing.
@@ -83,7 +83,7 @@ function createWikilinkMarkView(): MarkViewConstructor {
 }
 
 /**
- * Render `[[target]]`/`[[target|alias]]` as an immutable inline label (a mark
+ * Render `[[...]]` as an immutable inline label (a mark
  * view) standing in for the raw source. The single-caret-stop behavior comes
  * from the shared `defineAtomMarkNavigation` in the editor extension, which
  * treats `mdWikilink` (and `mdImage`) as one unit.

--- a/packages/core/src/extensions/wikilink.ts
+++ b/packages/core/src/extensions/wikilink.ts
@@ -20,6 +20,32 @@ export function parseWikilink(text: string): ParsedWikilink {
 }
 
 /**
+ * A resolved wikilink label.
+ */
+export interface WikilinkResolution {
+  /**
+   * Label shown in place of the source. Defaults to the alias, else the target.
+   */
+  display?: string
+}
+
+/**
+ * Resolves the label of one `[[target]]`/`[[target|alias]]`. Only the label
+ * changes: the target, click payloads, and the Markdown source stay as
+ * written. Return `undefined` to keep the default label. The resolver
+ * participates in the parse cache, so it must be pure: the same link must
+ * always return the same result.
+ */
+export type WikilinkResolver = (link: ParsedWikilink) => WikilinkResolution | undefined
+
+/**
+ * Host options for wikilink parsing.
+ */
+export interface WikilinkOptions {
+  resolveWikilink?: WikilinkResolver
+}
+
+/**
  * Render `mdWikilink` as a non-editable label standing in for the raw source.
  * The source stays in `contentDOM` after the label, hidden by `style.css`
  * (`.md-atom-view-content`); the whole wikilink is one caret stop owned by

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -170,8 +170,8 @@ export {
 } from './extensions/wikilink-hover.ts'
 export { defineWikilinkTrigger } from './extensions/wikilink-trigger.ts'
 export {
-  type ParsedWikilink,
   type WikilinkOptions,
+  type WikilinkPayload,
   type WikilinkResolution,
   type WikilinkResolver,
 } from './extensions/wikilink.ts'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -169,6 +169,12 @@ export {
   type WikilinkHoverHit,
 } from './extensions/wikilink-hover.ts'
 export { defineWikilinkTrigger } from './extensions/wikilink-trigger.ts'
+export {
+  type ParsedWikilink,
+  type WikilinkOptions,
+  type WikilinkResolution,
+  type WikilinkResolver,
+} from './extensions/wikilink.ts'
 export { getIsComposing } from './utils/composition.ts'
 export { getTextblockDisplayText } from './utils/display-text.ts'
 export { formatFileSize } from './utils/format-file-size.ts'

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -11,6 +11,7 @@ import { defineVirtualCaret } from '../extensions/virtual-caret.ts'
 
 import { getSelectionSnapshot } from './selection-snapshot.ts'
 
+export { resolveWikilinkAlias } from './resolve-wikilink-alias.ts'
 export { getSelectionSnapshot } from './selection-snapshot.ts'
 export {
   formatSelectionSteps,

--- a/packages/core/src/testing/resolve-wikilink-alias.ts
+++ b/packages/core/src/testing/resolve-wikilink-alias.ts
@@ -1,0 +1,10 @@
+import type { WikilinkResolver } from '../extensions/wikilink.ts'
+
+/**
+ * A host resolver that splits `[[target|alias]]` into its target and label.
+ */
+export const resolveWikilinkAlias: WikilinkResolver = ({ target }) => {
+  const pipe = target.indexOf('|')
+  if (pipe < 0) return
+  return { target: target.slice(0, pipe).trim(), display: target.slice(pipe + 1).trim() }
+}

--- a/packages/core/src/utils/display-text.test.ts
+++ b/packages/core/src/utils/display-text.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { setupFixture } from '../testing/index.ts'
+import { resolveWikilinkAlias, setupFixture } from '../testing/index.ts'
 
 import { getTextblockDisplayText } from './display-text.ts'
 
@@ -13,7 +13,7 @@ describe('getTextblockDisplayText', () => {
   })
 
   it('replaces a wikilink with its display text, falling back to the target', () => {
-    using fixture = setupFixture()
+    using fixture = setupFixture({ extensionOptions: { resolveWikilink: resolveWikilinkAlias } })
     const { n } = fixture
     fixture.set(n.doc(n.heading({ level: 1 }, 'see [[target|shown]] and [[bare]]')))
     expect(getTextblockDisplayText(fixture.doc.child(0))).toBe('see shown and bare')

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -62,7 +62,7 @@ Common `MeowdownEditor` props:
 | `mode`                                                                                                        | `'focus'` (default), `'show'`, or `'hide'`: how much Markdown syntax stays in view |
 | `searchQuery` / `onSearchChange`                                                                              | Find in document, with `EditorHandle.findNext()` / `findPrevious()`                |
 | `onWikilinkClick` / `onLinkClick` / `onTagClick` / `onImageClick` / `onFileClick`                             | Click handling for the rendered atoms                                              |
-| `resolveImageUrl` / `resolveWikiEmbed` / `resolveFileLink` / `resolveFileInfo`                                | Resolve and classify local content                                                 |
+| `resolveImageUrl` / `resolveWikiEmbed` / `resolveWikilink` / `resolveFileLink` / `resolveFileInfo`            | Resolve and classify local content                                                 |
 | `onFilePaste`                                                                                                 | Persist pasted or dropped files                                                    |
 | `onSlashMenuSearch` / `onTagSearch` / `onWikilinkSearch` / `onSelectionMenuSearch`                            | Search menus for `/`, `#`, `[[`, and selection commands                            |
 | `readOnly` / `placeholder` / `blockHandle` / `caretGlide` / `embedPaste` / `linkPaste` / `bulletAfterHeading` | Behavior toggles                                                                   |

--- a/packages/react/src/components/editor.test.tsx
+++ b/packages/react/src/components/editor.test.tsx
@@ -9,6 +9,8 @@ import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 import { page, userEvent } from 'vitest/browser'
 
+import { resolveWikilinkAlias } from '../testing/resolve-wikilink-alias.ts'
+
 import { MeowdownEditor } from './editor.tsx'
 import type { EditorHandle } from './types.ts'
 
@@ -217,13 +219,13 @@ describe('MeowdownEditor', () => {
     await expect.element(pmRoot).toHaveTextContent('![[ambiguous.png]]')
   })
 
-  it('renders a resolved wikilink label and keeps an authored alias', async () => {
+  it('resolves wikilink targets and labels through the host resolver', async () => {
     await render(
       <MeowdownEditor
         mode="hide"
         initialMarkdown="[[Tim MacCaw // Dad]] [[Tim MacCaw // Dad|Dad]]"
-        resolveWikilink={({ target, display }) => {
-          return display === '' ? { display: target.split(' // ')[0] } : undefined
+        resolveWikilink={(link) => {
+          return resolveWikilinkAlias(link) ?? { display: link.target.split(' // ')[0] }
         }}
       />,
     )

--- a/packages/react/src/components/editor.test.tsx
+++ b/packages/react/src/components/editor.test.tsx
@@ -217,6 +217,21 @@ describe('MeowdownEditor', () => {
     await expect.element(pmRoot).toHaveTextContent('![[ambiguous.png]]')
   })
 
+  it('renders a resolved wikilink label and keeps an authored alias', async () => {
+    await render(
+      <MeowdownEditor
+        mode="hide"
+        initialMarkdown="[[Tim MacCaw // Dad]] [[Tim MacCaw // Dad|Dad]]"
+        resolveWikilink={({ target, display }) => {
+          return display === '' ? { display: target.split(' // ')[0] } : undefined
+        }}
+      />,
+    )
+    const labels = pmRoot.getByTestId('wikilink')
+    await expect.element(labels.first()).toHaveTextContent('Tim MacCaw')
+    await expect.element(labels.last()).toHaveTextContent('Dad')
+  })
+
   it('embeds a pasted YouTube link by default', async () => {
     const ref = createRef<EditorHandle>()
     await render(<MeowdownEditor handleRef={ref} resolveImageUrl={(src) => src} />)

--- a/packages/react/src/components/editor.tsx
+++ b/packages/react/src/components/editor.tsx
@@ -198,10 +198,12 @@ export interface EditorProps {
   resolveWikiEmbed?: WikiEmbedResolver
 
   /**
-   * Resolves the label shown on a `[[target]]`/`[[target|alias]]` chip. Return
-   * `undefined` to keep the default (the alias, else the target). Only the
-   * label changes: clicks still report the target and the markdown text is
-   * untouched. Must be pure and is read once when the editor is created.
+   * Resolves a `[[...]]` wikilink into the target its click and hover
+   * handlers receive and the label its chip shows. Meowdown reads no syntax
+   * inside the brackets, so an alias form such as `[[target|alias]]` is
+   * split here by the host. Return `undefined` to use the bracketed text as
+   * both; the markdown text is untouched either way. Must be pure and is
+   * read once when the editor is created.
    */
   resolveWikilink?: WikilinkResolver
 

--- a/packages/react/src/components/editor.tsx
+++ b/packages/react/src/components/editor.tsx
@@ -17,6 +17,7 @@ import type {
   TagClickHandler,
   WikiEmbedResolver,
   WikilinkClickHandler,
+  WikilinkResolver,
 } from '@meowdown/core'
 import type { SelectionJSON } from '@prosekit/core'
 import { clsx } from 'clsx/lite'
@@ -197,6 +198,14 @@ export interface EditorProps {
   resolveWikiEmbed?: WikiEmbedResolver
 
   /**
+   * Resolves the label shown on a `[[target]]`/`[[target|alias]]` chip. Return
+   * `undefined` to keep the default (the alias, else the target). Only the
+   * label changes: clicks still report the target and the markdown text is
+   * untouched. Must be pure and is read once when the editor is created.
+   */
+  resolveWikilink?: WikilinkResolver
+
+  /**
    * Resolves the metadata (file size in bytes) shown on a file pill, directly
    * or as a promise; the pill renders immediately and fills the size in when
    * the promise settles. May be called repeatedly for the same `href`, so
@@ -362,6 +371,7 @@ export function MeowdownEditor({
   resolveImageUrl,
   resolveFileLink,
   resolveWikiEmbed,
+  resolveWikilink,
   resolveFileInfo,
   onFileClick,
   onFilePaste,
@@ -498,6 +508,7 @@ export function MeowdownEditor({
         resolveImageUrl={resolveImageUrl}
         resolveFileLink={resolveFileLink}
         resolveWikiEmbed={resolveWikiEmbed}
+        resolveWikilink={resolveWikilink}
         resolveFileInfo={resolveFileInfo}
         onFileClick={onFileClick}
         onFilePaste={onFilePaste}

--- a/packages/react/src/components/markdown-view.test.tsx
+++ b/packages/react/src/components/markdown-view.test.tsx
@@ -210,6 +210,19 @@ describe('MarkdownView', () => {
     expect(view.element().querySelector('.md-atom-view')).toBeNull()
   })
 
+  it('renders a resolved wikilink label and reports the full target', async () => {
+    const onWikilinkClick = vi.fn()
+    await renderView('[[Tim MacCaw // Dad]]', {
+      resolveWikilink: ({ target }: { target: string }) => ({ display: target.split(' // ')[0] }),
+      onWikilinkClick,
+    })
+    await expect.element(wikilink).toHaveTextContent('Tim MacCaw')
+    await wikilink.click()
+    expect(onWikilinkClick).toHaveBeenCalledWith(
+      expect.objectContaining({ target: 'Tim MacCaw // Dad' }),
+    )
+  })
+
   it('renders a tweet embed', async () => {
     await renderView('![](https://x.com/jack/status/20)')
     const iframe = view.getByTestId('tweet-embed')

--- a/packages/react/src/components/markdown-view.test.tsx
+++ b/packages/react/src/components/markdown-view.test.tsx
@@ -5,6 +5,8 @@ import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 import { page } from 'vitest/browser'
 
+import { resolveWikilinkAlias } from '../testing/resolve-wikilink-alias.ts'
+
 import { MarkdownView } from './markdown-view.tsx'
 import { ProseKitEditor } from './prosekit-editor.tsx'
 
@@ -34,8 +36,8 @@ describe('MarkdownView', () => {
     await expect.element(wikilink).toHaveTextContent('Reflect Playground 4')
   })
 
-  it('renders a wikilink alias', async () => {
-    await renderView('[[target|Alias]]')
+  it('renders the label the host resolver splits from an alias', async () => {
+    await renderView('[[target|Alias]]', { resolveWikilink: resolveWikilinkAlias })
     await expect.element(wikilink).toHaveTextContent('Alias')
   })
 

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -139,8 +139,8 @@ export interface MarkdownViewProps {
    */
   resolveWikiEmbed?: WikiEmbedResolver
   /**
-   * Resolve the label shown on a wikilink chip. Must be pure; return
-   * `undefined` to keep the default (the alias, else the target).
+   * Resolve a `[[...]]` wikilink into its target and chip label; the bracketed
+   * text is both by default. Must be pure.
    */
   resolveWikilink?: WikilinkResolver
   /**

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -32,6 +32,7 @@ import {
   type ReferenceDefinitions,
   type WikiEmbedResolver,
   type WikilinkClickHandler,
+  type WikilinkResolver,
 } from '@meowdown/core'
 import type { DOMOutputSpec } from '@prosekit/pm/model'
 import { Mark, type Node as ProseMirrorNode } from '@prosekit/pm/model'
@@ -138,6 +139,11 @@ export interface MarkdownViewProps {
    */
   resolveWikiEmbed?: WikiEmbedResolver
   /**
+   * Resolve the label shown on a wikilink chip. Must be pure; return
+   * `undefined` to keep the default (the alias, else the target).
+   */
+  resolveWikilink?: WikilinkResolver
+  /**
    * Resolve metadata shown on a file pill.
    */
   resolveFileInfo?: FileInfoResolver
@@ -173,6 +179,7 @@ interface RenderContext {
   resolveImageUrl?: (src: string) => string | undefined
   resolveFileLink?: FileLinkResolver
   resolveWikiEmbed?: WikiEmbedResolver
+  resolveWikilink?: WikilinkResolver
   resolveFileInfo?: FileInfoResolver
   onWikilinkClick?: WikilinkClickHandler
   onLinkClick?: LinkClickHandler
@@ -668,6 +675,7 @@ function renderInline(node: ProseMirrorNode, context: RenderContext): ReactNode 
     {
       resolveFileLink: context.resolveFileLink,
       resolveWikiEmbed: context.resolveWikiEmbed,
+      resolveWikilink: context.resolveWikilink,
     },
     {
       referenceDefinitions: context.referenceDefinitions,
@@ -795,6 +803,7 @@ export function MarkdownView({
   resolveImageUrl,
   resolveFileLink,
   resolveWikiEmbed,
+  resolveWikilink,
   resolveFileInfo,
   onWikilinkClick,
   onLinkClick,
@@ -812,6 +821,7 @@ export function MarkdownView({
       resolveImageUrl,
       resolveFileLink,
       resolveWikiEmbed,
+      resolveWikilink,
       resolveFileInfo,
       onWikilinkClick: interactive ? onWikilinkClick : undefined,
       onLinkClick: interactive ? onLinkClick : undefined,
@@ -832,6 +842,7 @@ export function MarkdownView({
     resolveImageUrl,
     resolveFileLink,
     resolveWikiEmbed,
+    resolveWikilink,
     resolveFileInfo,
     onWikilinkClick,
     onLinkClick,

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -25,6 +25,7 @@ import {
   type TypedEditor,
   type WikiEmbedResolver,
   type WikilinkClickHandler,
+  type WikilinkResolver,
 } from '@meowdown/core'
 import { clamp } from '@ocavue/utils'
 import { createEditor, union, type SelectionJSON } from '@prosekit/core'
@@ -218,6 +219,11 @@ export interface ProseKitEditorProps {
   resolveWikiEmbed?: WikiEmbedResolver
 
   /**
+   * Resolves wikilink chip labels. Read once on mount; see `EditorProps.resolveWikilink`.
+   */
+  resolveWikilink?: WikilinkResolver
+
+  /**
    * Resolves the size shown on a file pill. See `EditorProps.resolveFileInfo`.
    */
   resolveFileInfo?: FileViewOptions['resolveFileInfo']
@@ -338,6 +344,7 @@ export function ProseKitEditor({
   resolveImageUrl,
   resolveFileLink,
   resolveWikiEmbed,
+  resolveWikilink,
   resolveFileInfo,
   onFileClick,
   onFilePaste,
@@ -363,6 +370,7 @@ export function ProseKitEditor({
     const baseExtension: EditorExtension = defineEditorExtension({
       resolveFileLink,
       resolveWikiEmbed,
+      resolveWikilink,
       markMode,
     })
     const extension = union(baseExtension, defineCodeBlockView())

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -219,7 +219,7 @@ export interface ProseKitEditorProps {
   resolveWikiEmbed?: WikiEmbedResolver
 
   /**
-   * Resolves wikilink chip labels. Read once on mount; see `EditorProps.resolveWikilink`.
+   * Resolves wikilink targets and labels. Read once on mount; see `EditorProps.resolveWikilink`.
    */
   resolveWikilink?: WikilinkResolver
 

--- a/packages/react/src/components/wikilink-hover-card.test.tsx
+++ b/packages/react/src/components/wikilink-hover-card.test.tsx
@@ -6,6 +6,7 @@ import { render } from 'vitest-browser-react'
 import { page } from 'vitest/browser'
 
 import { hover, unhover } from '../testing/mouse.ts'
+import { resolveWikilinkAlias } from '../testing/resolve-wikilink-alias.ts'
 
 import { MeowdownEditor } from './editor.tsx'
 import type { EditorHandle } from './types.ts'
@@ -44,6 +45,7 @@ describe('WikilinkHoverCard', () => {
     await render(
       <MeowdownEditor
         initialMarkdown="[[Alpha|A wide alias]][[Beta|Another wide alias]]"
+        resolveWikilink={resolveWikilinkAlias}
         blockHandle={false}
       >
         <HostPreviewCard />

--- a/packages/react/src/testing/resolve-wikilink-alias.ts
+++ b/packages/react/src/testing/resolve-wikilink-alias.ts
@@ -1,0 +1,10 @@
+import type { WikilinkResolver } from '@meowdown/core'
+
+/**
+ * A host resolver that splits `[[target|alias]]` into its target and label.
+ */
+export const resolveWikilinkAlias: WikilinkResolver = ({ target }) => {
+  const pipe = target.indexOf('|')
+  if (pipe < 0) return
+  return { target: target.slice(0, pipe).trim(), display: target.slice(pipe + 1).trim() }
+}


### PR DESCRIPTION
Adds a pure, creation-time `resolveWikilink` hook (core option plus `MeowdownEditor` and `MarkdownView` props) that resolves a `[[...]]` wikilink into the target its handlers receive and the label its chip shows, leaving the Markdown source untouched. Breaking: meowdown no longer splits `[[target|alias]]` itself, so a host that uses the alias syntax must split it in `resolveWikilink`.