### PR TITLE
test: reduce the number of fuzz samples for WebKit

### DIFF
--- a/packages/core/src/converters/check-roundtrip-fuzz.test.ts
+++ b/packages/core/src/converters/check-roundtrip-fuzz.test.ts
@@ -1,4 +1,5 @@
 import { createStringPicker } from '@meowdown/vitest/random'
+import { isWebKit } from '@prosekit/core'
 import { it } from 'vitest'
 import { requestGC } from 'vitest-browser-commands/playwright'
 
@@ -7,7 +8,8 @@ import { checkRoundTrip } from './check-roundtrip.ts'
 // Use a fixed seed from the environment variable for reproducibility, or fallback to a random seed
 const SEED = Number.parseInt(import.meta.env.VITE_FUZZ_SEED || '') || Date.now()
 
-const NUM_SAMPLES = 100_000
+// Reduce the number of samples for WebKit browsers due to memory issues.
+const NUM_SAMPLES = isWebKit ? 10_000 : 100_000
 
 /// keep-sorted
 const TOKENS_NEWLINE: readonly string[] = ['\n']
@@ -143,7 +145,7 @@ function isLossy(input: string): boolean {
 for (const [minLength, maxLength] of RANGES) {
   for (const { name, pool } of POOLS) {
     it(
-      `finds no lossy input (minLength=${minLength}, maxLength=${maxLength}, pool=${name})`,
+      `finds no lossy input (minLength=${minLength}, maxLength=${maxLength}, pool=${name} samples=${NUM_SAMPLES})`,
       { timeout: 60_000 },
       async () => {
         const pickString = createStringPicker(SEED, minLength, maxLength, pool)

--- a/packages/core/src/converters/check-roundtrip-fuzz.test.ts
+++ b/packages/core/src/converters/check-roundtrip-fuzz.test.ts
@@ -8,8 +8,8 @@ import { checkRoundTrip } from './check-roundtrip.ts'
 // Use a fixed seed from the environment variable for reproducibility, or fallback to a random seed
 const SEED = Number.parseInt(import.meta.env.VITE_FUZZ_SEED || '') || Date.now()
 
-// Reduce the number of samples for WebKit browsers due to memory issues.
-const NUM_SAMPLES = isWebKit ? 1_000 : 100_000
+// Reduce the number of samples for WebKit due to memory issues.
+const NUM_SAMPLES = isWebKit ? 2_000 : 100_000
 
 /// keep-sorted
 const TOKENS_NEWLINE: readonly string[] = ['\n']

--- a/packages/core/src/converters/check-roundtrip-fuzz.test.ts
+++ b/packages/core/src/converters/check-roundtrip-fuzz.test.ts
@@ -9,7 +9,7 @@ import { checkRoundTrip } from './check-roundtrip.ts'
 const SEED = Number.parseInt(import.meta.env.VITE_FUZZ_SEED || '') || Date.now()
 
 // Reduce the number of samples for WebKit browsers due to memory issues.
-const NUM_SAMPLES = isWebKit ? 10_000 : 100_000
+const NUM_SAMPLES = isWebKit ? 1_000 : 100_000
 
 /// keep-sorted
 const TOKENS_NEWLINE: readonly string[] = ['\n']


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted round-trip fuzz testing to use fewer samples in WebKit environments, improving test stability while retaining broader coverage elsewhere.
  * Test output now identifies the sample count used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->