### PR TITLE
test: fail on console calls

### DIFF
--- a/packages/core/src/extensions/tweet.ts
+++ b/packages/core/src/extensions/tweet.ts
@@ -20,7 +20,6 @@ export const matchTweet: EmbedMatcher = (src) => {
   const tweetId = parseTweetId(src)
   if (!tweetId) return
   const theme = prefersDarkColorScheme() ? 'dark' : 'light'
-  console.log('THIS CONSOLE LOG SHOULD NOT BE HERE. THIS IS A TEST')
   return {
     kind: 'tweet',
     key: `tweet:${tweetId}`,

--- a/packages/core/src/extensions/tweet.ts
+++ b/packages/core/src/extensions/tweet.ts
@@ -20,6 +20,7 @@ export const matchTweet: EmbedMatcher = (src) => {
   const tweetId = parseTweetId(src)
   if (!tweetId) return
   const theme = prefersDarkColorScheme() ? 'dark' : 'light'
+  console.log('THIS CONSOLE LOG SHOULD NOT BE HERE. THIS IS A TEST')
   return {
     kind: 'tweet',
     key: `tweet:${tweetId}`,

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -21,7 +21,6 @@
     "@vitest/browser-playwright": "^4.1.11",
     "pure-rand": "^8.4.2",
     "vitest": "^4.1.11",
-    "vitest-browser-commands": "^0.4.1",
-    "vitest-fail-on-console": "^0.10.1"
+    "vitest-browser-commands": "^0.4.1"
   }
 }

--- a/packages/vitest/src/setup-console.ts
+++ b/packages/vitest/src/setup-console.ts
@@ -1,12 +1,80 @@
-import failOnConsole from 'vitest-fail-on-console'
+import { afterEach, beforeEach } from 'vitest'
 
-failOnConsole({
-  shouldFailOnWarn: true,
-  shouldFailOnError: true,
-  // A benign browser artifact: the skipped notifications are delivered on the
-  // next frame. Base UI's popup auto-resize measurements trigger it in tight
-  // viewports.
-  silenceMessage: (message) => {
-    return message.includes('ResizeObserver loop completed with undelivered notifications')
-  },
+/**
+ * Every `console` method that prints something. `clear`, `countReset`,
+ * `groupEnd`, `time` and `timeStamp` are left alone because they never print a
+ * message.
+ */
+const consoleMethods = [
+  'assert',
+  'count',
+  'debug',
+  'dir',
+  'dirxml',
+  'error',
+  'group',
+  'groupCollapsed',
+  'info',
+  'log',
+  'table',
+  'timeEnd',
+  'timeLog',
+  'trace',
+  'warn',
+] as const
+
+type ConsoleMethod = (typeof consoleMethods)[number]
+
+type ConsoleFunction = (...args: unknown[]) => void
+
+// A benign browser artifact: the skipped notifications are delivered on the
+// next frame. Base UI's popup auto-resize measurements trigger it in tight
+// viewports.
+const silencedMessages = ['ResizeObserver loop completed with undelivered notifications']
+
+const consoleObject = console as unknown as Record<ConsoleMethod, ConsoleFunction>
+
+const originalMethods = {} as Record<ConsoleMethod, ConsoleFunction>
+
+const unexpectedCalls: string[] = []
+
+function formatArguments(args: unknown[]): string {
+  return args
+    .map((arg) => {
+      if (typeof arg === 'string') return arg
+      if (arg instanceof Error) return arg.stack || `${arg.name}: ${arg.message}`
+      return String(arg)
+    })
+    .join(' ')
+}
+
+beforeEach(() => {
+  unexpectedCalls.length = 0
+  for (const method of consoleMethods) {
+    originalMethods[method] = consoleObject[method]
+    consoleObject[method] = (...args: unknown[]) => {
+      // `console.assert` only prints when its first argument is falsy.
+      if (method === 'assert') {
+        if (args[0]) return
+        args = ['Assertion failed:', ...args.slice(1)]
+      }
+      const message = formatArguments(args)
+      if (silencedMessages.some((silenced) => message.includes(silenced))) return
+      unexpectedCalls.push(`console.${method}: ${message}`)
+    }
+  }
+})
+
+afterEach(() => {
+  for (const method of consoleMethods) {
+    consoleObject[method] = originalMethods[method]
+  }
+  if (unexpectedCalls.length === 0) return
+  throw new Error(
+    [
+      'Expected the test not to write to the console.',
+      "If the output is expected, mock the method out with `vi.spyOn(console, 'warn')` and assert on it.",
+      ...unexpectedCalls,
+    ].join('\n\n'),
+  )
 })

--- a/packages/vitest/src/setup-console.ts
+++ b/packages/vitest/src/setup-console.ts
@@ -19,27 +19,17 @@ const originalMethods = {} as Record<ConsoleMethod, ConsoleFunction>
 
 const unexpectedCalls: string[] = []
 
-function formatArguments(args: unknown[]): string {
-  return args
-    .map((arg) => {
-      if (typeof arg === 'string') return arg
-      if (arg instanceof Error) return arg.stack || `${arg.name}: ${arg.message}`
-      return String(arg)
-    })
-    .join(' ')
-}
-
 beforeEach(() => {
   unexpectedCalls.length = 0
   for (const method of consoleMethods) {
     originalMethods[method] = consoleObject[method]
     consoleObject[method] = (...args: unknown[]) => {
-      // `console.assert` only prints when its first argument is falsy.
       if (method === 'assert') {
+        // `console.assert` only prints when its first argument is falsy.
         if (args[0]) return
         args = ['Assertion failed:', ...args.slice(1)]
       }
-      const message = formatArguments(args)
+      const message = args.map(String).join(' ')
       if (silencedMessages.some((silenced) => message.includes(silenced))) return
       unexpectedCalls.push(`console.${method}: ${message}`)
     }

--- a/packages/vitest/src/setup-console.ts
+++ b/packages/vitest/src/setup-console.ts
@@ -1,36 +1,17 @@
 import { afterEach, beforeEach } from 'vitest'
 
-/**
- * Every `console` method that prints something. `clear`, `countReset`,
- * `groupEnd`, `time` and `timeStamp` are left alone because they never print a
- * message.
- */
-const consoleMethods = [
-  'assert',
-  'count',
-  'debug',
-  'dir',
-  'dirxml',
-  'error',
-  'group',
-  'groupCollapsed',
-  'info',
-  'log',
-  'table',
-  'timeEnd',
-  'timeLog',
-  'trace',
-  'warn',
-] as const
+const consoleMethods = ['assert', 'debug', 'dir', 'error', 'info', 'log', 'table', 'warn'] as const
 
 type ConsoleMethod = (typeof consoleMethods)[number]
 
 type ConsoleFunction = (...args: unknown[]) => void
 
-// A benign browser artifact: the skipped notifications are delivered on the
-// next frame. Base UI's popup auto-resize measurements trigger it in tight
-// viewports.
-const silencedMessages = ['ResizeObserver loop completed with undelivered notifications']
+const silencedMessages = [
+  // A benign browser artifact: the skipped notifications are delivered on the
+  // next frame. Base UI's popup auto-resize measurements trigger it in tight
+  // viewports.
+  'ResizeObserver loop completed with undelivered notifications',
+]
 
 const consoleObject = console as unknown as Record<ConsoleMethod, ConsoleFunction>
 

--- a/packages/vitest/src/setup-console.ts
+++ b/packages/vitest/src/setup-console.ts
@@ -1,10 +1,4 @@
-import { afterEach, beforeEach } from 'vitest'
-
-const consoleMethods = ['assert', 'debug', 'dir', 'error', 'info', 'log', 'table', 'warn'] as const
-
-type ConsoleMethod = (typeof consoleMethods)[number]
-
-type ConsoleFunction = (...args: unknown[]) => void
+import { afterEach, beforeEach, vi } from 'vitest'
 
 const silencedMessages = [
   // A benign browser artifact: the skipped notifications are delivered on the
@@ -13,33 +7,48 @@ const silencedMessages = [
   'ResizeObserver loop completed with undelivered notifications',
 ]
 
-const consoleObject = console as unknown as Record<ConsoleMethod, ConsoleFunction>
-
-const originalMethods = {} as Record<ConsoleMethod, ConsoleFunction>
-
 const unexpectedCalls: string[] = []
+
+function logImplementation(...args: unknown[]) {
+  const message = args.map(String).join(' ')
+  for (const pattern of silencedMessages) {
+    if (message.includes(pattern)) return
+  }
+  unexpectedCalls.push(message)
+}
+
+function assertImplementation(condition: unknown, ...args: unknown[]) {
+  if (condition) return
+  logImplementation(...args)
+}
+
+function spy() {
+  const warn = vi.spyOn(console, 'warn').mockImplementation(logImplementation)
+  const error = vi.spyOn(console, 'error').mockImplementation(logImplementation)
+  const log = vi.spyOn(console, 'log').mockImplementation(logImplementation)
+  const info = vi.spyOn(console, 'info').mockImplementation(logImplementation)
+  const assert = vi.spyOn(console, 'assert').mockImplementation(assertImplementation)
+
+  return () => {
+    warn.mockRestore()
+    error.mockRestore()
+    log.mockRestore()
+    info.mockRestore()
+    assert.mockRestore()
+  }
+}
+
+let restoreSpy: VoidFunction | undefined
 
 beforeEach(() => {
   unexpectedCalls.length = 0
-  for (const method of consoleMethods) {
-    originalMethods[method] = consoleObject[method]
-    consoleObject[method] = (...args: unknown[]) => {
-      if (method === 'assert') {
-        // `console.assert` only prints when its first argument is falsy.
-        if (args[0]) return
-        args = ['Assertion failed:', ...args.slice(1)]
-      }
-      const message = args.map(String).join(' ')
-      if (silencedMessages.some((silenced) => message.includes(silenced))) return
-      unexpectedCalls.push(`console.${method}: ${message}`)
-    }
-  }
+  restoreSpy = spy()
 })
 
 afterEach(() => {
-  for (const method of consoleMethods) {
-    consoleObject[method] = originalMethods[method]
-  }
+  restoreSpy?.()
+  restoreSpy = undefined
+
   if (unexpectedCalls.length === 0) return
   throw new Error(
     [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,9 +313,6 @@ importers:
       vitest-browser-commands:
         specifier: ^0.4.1
         version: 0.4.1(@vitest/browser-playwright@4.1.11)(@vitest/browser@4.1.11)(playwright@1.62.1)(vite@8.2.2)(vitest@4.1.11)
-      vitest-fail-on-console:
-        specifier: ^0.10.1
-        version: 0.10.1(@vitest/utils@4.1.11)(vite@8.2.2)(vitest@4.1.11)
 
   website:
     dependencies:
@@ -2569,10 +2566,6 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
-  chalk@5.6.2:
-    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
 
@@ -4767,13 +4760,6 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
-
-  vitest-fail-on-console@0.10.1:
-    resolution: {integrity: sha512-Xjy2SpgND547qSy0s0zYVnh1G/WyGtdjAbi4PFV8mkYRmTq+6NzRUJYdc08BHrw7HJLpO2kMxHFB8PWn7FOVsg==}
-    peerDependencies:
-      '@vitest/utils': '>=0.26.2'
-      vite: '>=4.5.2'
-      vitest: '>=0.26.2'
 
   vitest@4.1.11:
     resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
@@ -7253,8 +7239,6 @@ snapshots:
 
   chai@6.2.2: {}
 
-  chalk@5.6.2: {}
-
   change-case@5.4.4: {}
 
   character-entities-html4@2.1.0: {}
@@ -9656,13 +9640,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.5(@types/react@19.2.18)
-
-  vitest-fail-on-console@0.10.1(@vitest/utils@4.1.11)(vite@8.2.2)(vitest@4.1.11):
-    dependencies:
-      '@vitest/utils': 4.1.11
-      chalk: 5.6.2
-      vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)
-      vitest: 4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.2.2)
 
   vitest@4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.2.2):
     dependencies:


### PR DESCRIPTION
Replace `vitest-fail-on-console` with an inline setup that fails a test when it writes to the console through any printing `console` method, not only `console.error` and `console.warn`. Split out of https://github.com/prosekit/meowdown/pull/436.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved test handling for console warnings, errors, logs, informational messages, and assertions.
  - Unexpected console output is now collected and reported together after each test.
  - Expected ResizeObserver messages are filtered to reduce false failures.
  - Console behavior is restored after every test to prevent test-to-test interference.
  - Console monitoring coverage is limited to the supported output types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->