### PR TITLE
ci: migrate from pnpm/action-setup to pnpm/setup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,16 +10,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install pnpm
-      uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-
-    - name: Setup node
-      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+    - name: Setup pnpm and Node.js
+      uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2
       with:
-        node-version: ${{ inputs.node-version }}
-        cache: pnpm
-        registry-url: 'https://registry.npmjs.org'
-
-    - name: Install
-      run: pnpm install
-      shell: bash
+        runtime: node@${{ inputs.node-version }}
+        cache: true


### PR DESCRIPTION
## Summary

Migrates the shared composite setup action from the older `pnpm/action-setup` + `actions/setup-node` + `pnpm install` flow to a single [`pnpm/setup`](https://github.com/pnpm/setup) step (pinned to v2).

`packageManager` is already `pnpm@11.22.0`, which is compatible with `pnpm/setup@v2`.


### Notes

- Dropped `registry-url` from the former setup-node step.
- OIDC publish workflows remain in use and should be unaffected.

## Test plan

- [ ] Confirm CI workflows that use `.github/actions/setup` pass (install, cache, Node version).
- [ ] Spot-check that pnpm and Node resolve as expected on a workflow run.
- [ ] Confirm publish/release workflows that rely on OIDC still succeed.
