### PR TITLE
fix: keep the caret out of list marker

### DIFF
--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -387,6 +387,16 @@
     margin-top: 0.25em;
   }
 
+  /* A caret must never land inside the marker. iOS trackpad mode otherwise
+   * bounces between the marker and the previous block on every touch move
+   * (WebKit accepts an empty non-editable block as a caret position; UIKit
+   * then pushes the caret back out). `-webkit-user-select` is the one Safari
+   * honors and the one that inherits to the task checkbox. */
+  .ProseMirror .prosemirror-flat-list > .list-marker {
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
   /* The bullet dot is painted as a radial-gradient on the (1lh square)
    * `.list-marker` box, so the dot and, when collapsed, its halo always share one
    * center (a separate halo element drifts by a sub-pixel). Override prosekit's

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -581,6 +581,14 @@
     border-top: 1px solid var(--meowdown-hr);
   }
 
+  /* The wrapper is the non-editable box prosemirror-view gives a leaf node;
+   * without this a caret can land beside the `<hr>` inside it, which iOS
+   * trackpad mode then bounces out of on every touch move. */
+  .ProseMirror .prosekit-horizontal-rule {
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
   /* ---------------------------------------------------------------------------
    * Tables
    * ------------------------------------------------------------------------- */

--- a/packages/react/src/components/code-block-view.module.css
+++ b/packages/react/src/components/code-block-view.module.css
@@ -50,6 +50,7 @@
   top: 0.5rem;
   right: 0.5rem;
   z-index: 1;
+  -webkit-user-select: none;
   user-select: none;
   opacity: 0;
   pointer-events: none;


### PR DESCRIPTION
On iOS, dragging the caret in trackpad mode across a list marker bounced the selection between the marker and the previous block on every touch move: WebKit accepts the empty non-editable marker as a caret position and UIKit pushes it back out. Make `.list-marker` `user-select: none` so no caret position exists inside it; marker clicks (task checkbox, bullet fold) are unaffected because the event target does not change. The second commit gives the same guard to the `horizontalRule` wrapper and adds the `-webkit-` prefix Safari needs on the code block toolbar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved caret behavior on iOS trackpads by preventing cursor placement inside list markers and beside horizontal rules.
  * Prevented unintended text selection in code block toolbars on WebKit browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->