### PR TITLE
fix: match slash menu headings from the `h1`-`h4` shorthand

### DIFF
--- a/packages/react/src/components/slash-menu.test.tsx
+++ b/packages/react/src/components/slash-menu.test.tsx
@@ -51,6 +51,35 @@ describe('SlashMenu', () => {
     await expect.element(menu.getByText('Heading 1')).not.toBeVisible()
   })
 
+  it('matches "Heading 3" from the /h3 shorthand', async () => {
+    await render(<ProseKitEditor />)
+    await pmRoot.click()
+    await userEvent.keyboard('/h3')
+    await expect.element(menu.getByText('Heading 3', { exact: true })).toBeVisible()
+    await expect.element(menu.getByText('Heading 1', { exact: true })).not.toBeVisible()
+    await expect.element(menu.getByText('Heading 4', { exact: true })).not.toBeVisible()
+  })
+
+  it('matches "Heading 1" from the /h1 shorthand', async () => {
+    await render(<ProseKitEditor />)
+    await pmRoot.click()
+    await userEvent.keyboard('/h1')
+    await expect.element(menu.getByText('Heading 1', { exact: true })).toBeVisible()
+    await expect.element(menu.getByText('Heading 3', { exact: true })).not.toBeVisible()
+  })
+
+  it('applies the heading selected through the /h3 shorthand', async () => {
+    const ref = createRef<EditorHandle>()
+    await render(<ProseKitEditor ref={ref} />)
+    await pmRoot.click()
+    await userEvent.keyboard('/h3')
+    await menu.getByText('Heading 3', { exact: true }).click()
+
+    await expect.element(pmRoot.locate('h3')).toBeInTheDocument()
+    await userEvent.keyboard('Hello')
+    expect(ref.current?.getMarkdown()).toBe('### Hello\n')
+  })
+
   it('inserts a table when Enter selects a normal single-slash command', async () => {
     const ref = createRef<EditorHandle>()
     await render(<ProseKitEditor ref={ref} />)

--- a/packages/react/src/components/slash-menu.tsx
+++ b/packages/react/src/components/slash-menu.tsx
@@ -185,21 +185,25 @@ export function SlashMenu({
               />
               <SlashMenuItem
                 label="Heading 1"
+                keywords={['h1']}
                 kbd="#"
                 onSelect={() => editor.commands.setHeading({ level: 1 })}
               />
               <SlashMenuItem
                 label="Heading 2"
+                keywords={['h2']}
                 kbd="##"
                 onSelect={() => editor.commands.setHeading({ level: 2 })}
               />
               <SlashMenuItem
                 label="Heading 3"
+                keywords={['h3']}
                 kbd="###"
                 onSelect={() => editor.commands.setHeading({ level: 3 })}
               />
               <SlashMenuItem
                 label="Heading 4"
+                keywords={['h4']}
                 kbd="####"
                 onSelect={() => editor.commands.setHeading({ level: 4 })}
               />


### PR DESCRIPTION
Typing `/h3` in the slash menu matched nothing, because the item filter is a contiguous substring match and `h3` is not a substring of `heading3`. Give the four heading items an `h1`-`h4` keyword, which feeds the match value without ever being displayed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shorthand search keywords for Heading 1–4 slash-menu items, allowing users to quickly find headings with commands such as `/h1` and `/h3`.
  * Selecting a heading from the filtered slash menu applies the corresponding heading level and Markdown formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->