### PR TITLE
docs(website): throttle leading updates

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,7 @@
     "@floating-ui/dom": "^1.8.0",
     "@lezer/highlight": "^1.2.3",
     "@meowdown/markdown": "workspace:^",
-    "@ocavue/utils": "^1.7.0",
+    "@ocavue/utils": "^1.8.0",
     "@prosekit/core": "^0.13.2",
     "@prosekit/extensions": "^0.18.2",
     "@prosekit/pm": "^0.1.19",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@base-ui/react": "^1.7.0",
     "@meowdown/core": "workspace:*",
-    "@ocavue/utils": "^1.7.0",
+    "@ocavue/utils": "^1.8.0",
     "@prosekit/core": "^0.13.2",
     "@prosekit/pm": "^0.1.19",
     "@prosekit/react": "^0.8.2",

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@ocavue/tsconfig": "^0.7.1",
-    "@ocavue/utils": "^1.7.0",
+    "@ocavue/utils": "^1.8.0",
     "@prosekit/pm": "^0.1.19",
     "@vitest/browser-playwright": "^5.0.0",
     "pure-rand": "^8.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,8 @@ importers:
         specifier: workspace:^
         version: link:../markdown
       '@ocavue/utils':
-        specifier: ^1.7.0
-        version: 1.7.0
+        specifier: ^1.8.0
+        version: 1.8.0
       '@prosekit/core':
         specifier: ^0.13.2
         version: 0.13.2(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
@@ -220,8 +220,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@ocavue/utils':
-        specifier: ^1.7.0
-        version: 1.7.0
+        specifier: ^1.8.0
+        version: 1.8.0
       '@prosekit/core':
         specifier: ^0.13.2
         version: 0.13.2(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
@@ -296,8 +296,8 @@ importers:
         specifier: ^0.7.1
         version: 0.7.1
       '@ocavue/utils':
-        specifier: ^1.7.0
-        version: 1.7.0
+        specifier: ^1.8.0
+        version: 1.8.0
       '@prosekit/pm':
         specifier: ^0.1.19
         version: 0.1.19
@@ -347,8 +347,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/react
       '@ocavue/utils':
-        specifier: ^1.7.0
-        version: 1.7.0
+        specifier: ^1.8.0
+        version: 1.8.0
       astro:
         specifier: ^7.2.10
         version: 7.2.10(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)
@@ -1413,8 +1413,8 @@ packages:
   '@ocavue/tsconfig@0.7.1':
     resolution: {integrity: sha512-jw1LPUqi/f043s61WOYEWWA6P1ZSSYXR3KJXcNxBXXrxiUXhEAbuEBUmi6Qs8NduIVU3xCkbaYw5BU3UyL3G3A==}
 
-  '@ocavue/utils@1.7.0':
-    resolution: {integrity: sha512-yEk9ATNBjTZTtuVFMB/MAIF6zJBvJ2+lVNQvK2+O+ggEBGTgx2tp27d4FPgmD5bRsNHHP3D0SleQia/bvIeV8w==}
+  '@ocavue/utils@1.8.0':
+    resolution: {integrity: sha512-BD1ro+6Kllkmr/at+o32kvnLrVooUbk9gw3JAPaoAZXx+A5GhZ6Laa+UA38ifhG3vaamx+jcgEwX22BmTSMUVA==}
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
@@ -4899,7 +4899,7 @@ snapshots:
 
   '@aria-ui/core@0.2.1':
     dependencies:
-      '@ocavue/utils': 1.7.0
+      '@ocavue/utils': 1.8.0
       '@zag-js/dom-query': 1.43.3
       alien-signals: 3.2.1
       server-dom-shim: 1.1.0
@@ -6134,7 +6134,7 @@ snapshots:
 
   '@ocavue/tsconfig@0.7.1': {}
 
-  '@ocavue/utils@1.7.0': {}
+  '@ocavue/utils@1.8.0': {}
 
   '@oslojs/encoding@1.1.0': {}
 
@@ -6321,7 +6321,7 @@ snapshots:
 
   '@prosekit/core@0.13.2(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)':
     dependencies:
-      '@ocavue/utils': 1.7.0
+      '@ocavue/utils': 1.8.0
       '@prosekit/pm': 0.1.19
       orderedmap: 2.1.1
       prosemirror-splittable: 1.1.0(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
@@ -6333,7 +6333,7 @@ snapshots:
 
   '@prosekit/extensions@0.18.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.4.3)(@types/hast@3.0.5)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.3)':
     dependencies:
-      '@ocavue/utils': 1.7.0
+      '@ocavue/utils': 1.8.0
       '@prosekit/core': 0.13.2(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       '@prosekit/pm': 0.1.19
       prosemirror-changeset: 2.4.2
@@ -6407,7 +6407,7 @@ snapshots:
       '@aria-ui/elements': 0.1.13
       '@aria-ui/utils': 0.1.7
       '@floating-ui/dom': 1.8.0
-      '@ocavue/utils': 1.7.0
+      '@ocavue/utils': 1.8.0
       '@prosekit/core': 0.13.2(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       '@prosekit/extensions': 0.18.2(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.4.3)(@types/hast@3.0.5)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.3)
       '@prosekit/pm': 0.1.19
@@ -6432,7 +6432,7 @@ snapshots:
 
   '@prosemirror-adapter/core@0.5.5':
     dependencies:
-      '@ocavue/utils': 1.7.0
+      '@ocavue/utils': 1.8.0
       prosemirror-model: 1.25.11
       prosemirror-state: 1.4.4
       prosemirror-view: 1.42.3
@@ -8902,7 +8902,7 @@ snapshots:
 
   prosemirror-drop-indicator@0.1.4:
     dependencies:
-      '@ocavue/utils': 1.7.0
+      '@ocavue/utils': 1.8.0
       prosemirror-model: 1.25.11
       prosemirror-state: 1.4.4
       prosemirror-view: 1.42.3
@@ -8968,7 +8968,7 @@ snapshots:
 
   prosemirror-math@0.2.2:
     dependencies:
-      '@ocavue/utils': 1.7.0
+      '@ocavue/utils': 1.8.0
       prosemirror-enter-rules: 0.1.6
       prosemirror-inputrules: 1.5.1
       prosemirror-model: 1.25.11

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,7 @@
     "@codemirror/view": "^6.43.10",
     "@meowdown/core": "workspace:*",
     "@meowdown/react": "workspace:*",
-    "@ocavue/utils": "^1.7.0",
+    "@ocavue/utils": "^1.8.0",
     "astro": "^7.2.10",
     "astro-theme-toggle": "^0.8.2",
     "astrobook": "^0.13.3",

--- a/website/src/stories/main-editor.tsx
+++ b/website/src/stories/main-editor.tsx
@@ -116,6 +116,7 @@ function MainEditorDemo() {
     const writeSourceText = () => {
       const view = sourceViewRef.current
       const markdown = editorRef.current?.getMarkdown()
+      shareMarkdown(markdown || '')
       if (!view || markdown == null) return
       const patch = computeTextPatch(view.state.doc.toString(), markdown)
       if (!patch) return
@@ -129,14 +130,8 @@ function MainEditorDemo() {
       editorRef.current?.setMarkdown(markdown)
     }
 
-    const pushToSource = throttle(() => {
-      shareMarkdown(editorRef.current?.getMarkdown() ?? '')
-      // A stale trailing tick must never overwrite source text being typed now.
-      if (sourceViewRef.current?.hasFocus) return
-      writeSourceText()
-    }, SYNC_THROTTLE_MS)
-
-    const pullFromSource = throttle(writeRichText, SYNC_THROTTLE_MS)
+    const pushToSource = throttle(writeSourceText, SYNC_THROTTLE_MS, { leading: false })
+    const pullFromSource = throttle(writeRichText, SYNC_THROTTLE_MS, { leading: false })
 
     return {
       handleRichChange: () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shared URL content now stays synchronized with the latest Markdown, including when the source editor is not currently visible.
  * Rich-text changes are now reliably reflected in the source view after updates.
  * Source and rich-text synchronization is throttled more consistently to reduce unnecessary updates and improve editing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->