### PR TITLE
fix(react): polish the link editor popover

### DIFF
--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -114,6 +114,11 @@
     /* destructive menu items */
     --meowdown-danger: light-dark(oklch(0.637 0.208 25), oklch(0.711 0.166 22));
 
+    /* text inputs inside floating forms (the link editor): resting border
+     * and focus ring */
+    --meowdown-input-border: color-mix(in oklab, var(--meowdown-text) 15%, transparent);
+    --meowdown-focus-ring: var(--meowdown-accent);
+
     /* empty-block placeholder text */
     --meowdown-placeholder: var(--meowdown-muted);
 

--- a/packages/react/src/components/link-menu.module.css
+++ b/packages/react/src/components/link-menu.module.css
@@ -254,8 +254,8 @@
   gap: 0.25rem;
 
   & > span {
-    font-size: 0.75rem;
-    font-weight: 600;
+    font-size: 0.8125rem;
+    font-weight: 500;
     color: var(--meowdown-muted);
   }
 }
@@ -263,22 +263,40 @@
 .Input {
   box-sizing: border-box;
   width: 100%;
-  padding: 0.5rem 0.625rem;
+  height: 2rem;
+  padding: 0 0.625rem;
   font: inherit;
   color: var(--meowdown-text);
   background: transparent;
-  border: 1px solid var(--meowdown-border);
+  border: 1px solid var(--meowdown-input-border);
   border-radius: 0.5rem;
+  transition:
+    border-color 100ms ease,
+    box-shadow 100ms ease;
+
+  &::placeholder {
+    color: var(--meowdown-placeholder);
+  }
 
   &:focus {
-    outline: 2px solid var(--meowdown-accent);
-    outline-offset: -1px;
+    outline: none;
+    border-color: var(--meowdown-focus-ring);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--meowdown-focus-ring) 50%, transparent);
+  }
+
+  @media (pointer: coarse) {
+    height: 2.75rem;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
   }
 }
 
 .FormActions {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 0.375rem;
   padding-top: 0.125rem;
 }
@@ -288,21 +306,68 @@
   min-height: 2rem;
   padding: 0.375rem 0.625rem;
   font: inherit;
+  font-weight: 500;
   background: transparent;
   border: 0;
   border-radius: 0.5rem;
   cursor: pointer;
+  transition: background-color 100ms ease;
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--meowdown-focus-ring) 50%, transparent);
+  }
 
   @media (pointer: coarse) {
     min-height: 2.75rem;
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
 }
 
 .RemoveButton {
-  color: var(--meowdown-danger, #c33);
+  margin-right: auto;
+  color: var(--meowdown-danger);
+
+  &:hover {
+    background: color-mix(in oklab, var(--meowdown-danger) 10%, transparent);
+  }
 }
 
 .UseTitleButton {
-  margin-left: auto;
   color: var(--meowdown-accent);
+
+  &:hover {
+    background: var(--meowdown-popover-hover-bg);
+  }
+}
+
+.SaveButton {
+  transition:
+    background-color 100ms ease,
+    transform 100ms ease-out;
+
+  &:hover:not(:disabled) {
+    background: color-mix(in oklab, var(--meowdown-accent) 80%, transparent);
+  }
+
+  &:active:not(:disabled) {
+    transform: translateY(1px);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--meowdown-focus-ring) 50%, transparent);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
 }

--- a/packages/react/src/components/link-menu.module.d.css.ts
+++ b/packages/react/src/components/link-menu.module.d.css.ts
@@ -30,5 +30,6 @@ declare const styles = {
   'UseTitleButton': '' as string,
   'RemoveButton': '' as string,
   'UseTitleButton': '' as string,
+  'SaveButton': '' as string,
 } as const;
 export default styles;

--- a/packages/react/src/components/link-menu.test.tsx
+++ b/packages/react/src/components/link-menu.test.tsx
@@ -294,6 +294,46 @@ describe('LinkMenu', () => {
     expect(ref.current?.getMarkdown()).toContain('[Docs](https://example.com)')
   })
 
+  it('takes the destination typed straight after Mod-k on a selection', async () => {
+    const ref = createRef<EditorHandle>()
+    const screen = await render(<MeowdownEditor handleRef={ref} initialMarkdown="Docs" />)
+    await screen.getByText('Docs').click()
+    await userEvent.keyboard('{ControlOrMeta>}a{/ControlOrMeta}')
+    await userEvent.keyboard('{ControlOrMeta>}k{/ControlOrMeta}')
+    await expect.element(popover.getByTestId('link-popover-edit')).toBeVisible()
+    await expect
+      .element(popover.getByRole('button', { name: 'Remove link' }))
+      .not.toBeInTheDocument()
+    await userEvent.keyboard('https://example.com{Enter}')
+    expect(ref.current?.getMarkdown()).toContain('[Docs](https://example.com)')
+  })
+
+  it('keeps Save disabled until the destination is filled', async () => {
+    const ref = createRef<EditorHandle>()
+    const screen = await render(<MeowdownEditor handleRef={ref} initialMarkdown="Docs" />)
+    await screen.getByText('Docs').click()
+    await userEvent.keyboard('{ControlOrMeta>}a{/ControlOrMeta}')
+    await userEvent.keyboard('{ControlOrMeta>}k{/ControlOrMeta}')
+    await expect.element(popover.getByTestId('link-popover-submit')).toBeDisabled()
+    await userEvent.keyboard('{Enter}')
+    await expect.element(popover.getByTestId('link-popover-edit')).toBeVisible()
+    expect(ref.current?.getMarkdown()).toBe('Docs\n')
+    await popover.getByTestId('link-popover-input').fill('https://example.com')
+    await expect.element(popover.getByTestId('link-popover-submit')).toBeEnabled()
+  })
+
+  it('selects the destination when editing an existing link', async () => {
+    const ref = createRef<EditorHandle>()
+    const screen = await render(
+      <MeowdownEditor handleRef={ref} initialMarkdown="[Docs](https://old.test)" />,
+    )
+    await hover(screen.getByText('Docs'))
+    await popover.getByRole('button', { name: 'Edit link' }).click()
+    await expect.element(popover.getByTestId('link-popover-input')).toHaveFocus()
+    await userEvent.keyboard('https://new.test{Enter}')
+    expect(ref.current?.getMarkdown()).toContain('[Docs](https://new.test)')
+  })
+
   it('removes a link from the read preview', async () => {
     const ref = createRef<EditorHandle>()
     const screen = await render(
@@ -402,12 +442,11 @@ describe('LinkMenu', () => {
     expect(resolver).not.toHaveBeenCalledWith('https://ne')
   })
 
-  it('focuses Text on Mod-k and dismisses with Escape', async () => {
+  it('focuses Link on Mod-k and dismisses with Escape', async () => {
     const screen = await render(<MeowdownEditor initialMarkdown="[Docs](https://example.com)" />)
     await screen.getByText('Docs').click()
     await userEvent.keyboard('{ControlOrMeta>}k{/ControlOrMeta}')
-    const textInput = popover.getByTestId('link-popover-text-input')
-    await expect.element(textInput).toHaveFocus()
+    await expect.element(popover.getByTestId('link-popover-input')).toHaveFocus()
     await userEvent.keyboard('{Escape}')
     await expect.element(popover).not.toBeInTheDocument()
   })

--- a/packages/react/src/components/link-menu.tsx
+++ b/packages/react/src/components/link-menu.tsx
@@ -312,7 +312,7 @@ function LinkEditContent({
   const [text, setText] = useState(edit.text)
   const [href, setHref] = useState(edit.link?.href ?? '')
   const [debouncedHref, setDebouncedHref] = useState(href.trim())
-  const textInputRef = useRef<HTMLInputElement>(null)
+  const hrefInputRef = useRef<HTMLInputElement>(null)
   // Preview the URL saving would produce, so a bare `example.com` resolves.
   const previewHref = normalizeHref(debouncedHref)
   const previewState = useLinkPreview(previewHref || undefined, resolveLinkPreview)
@@ -321,6 +321,7 @@ function LinkEditContent({
   // title.
   const canUseTitle =
     !!edit.link && debouncedHref === href.trim() && isLinkTextForHref(text, previewHref)
+  const canSave = text.trim() !== '' && href.trim() !== ''
 
   useEffect(() => {
     const timer = window.setTimeout(() => setDebouncedHref(href.trim()), 400)
@@ -328,25 +329,25 @@ function LinkEditContent({
   }, [href])
 
   useEffect(() => {
-    textInputRef.current?.focus()
+    hrefInputRef.current?.focus()
+    hrefInputRef.current?.select()
   }, [])
 
   return (
     <form
       className={styles.Form}
       data-testid="link-popover-edit"
+      noValidate
       onSubmit={(event) => {
         event.preventDefault()
-        if (text.trim() && href.trim()) onSubmit(text, href)
+        if (canSave) onSubmit(text, href)
       }}
     >
       <label className={styles.Field}>
         <span>Text</span>
         <input
-          ref={textInputRef}
           className={styles.Input}
           value={text}
-          required
           data-testid="link-popover-text-input"
           onChange={(event) => setText(event.target.value)}
         />
@@ -354,10 +355,10 @@ function LinkEditContent({
       <label className={styles.Field}>
         <span>Link</span>
         <input
+          ref={hrefInputRef}
           className={styles.Input}
           value={href}
-          required
-          placeholder="Paste link..."
+          placeholder="Paste link…"
           data-testid="link-popover-input"
           onChange={(event) => setHref(event.target.value)}
         />
@@ -377,7 +378,12 @@ function LinkEditContent({
             Use page title
           </button>
         )}
-        <button type="submit" className={styles.SaveButton} data-testid="link-popover-submit">
+        <button
+          type="submit"
+          className={styles.SaveButton}
+          disabled={!canSave}
+          data-testid="link-popover-submit"
+        >
           Save
         </button>
       </div>
@@ -519,7 +525,7 @@ export function LinkMenu({
         <LinkEditContent
           edit={edit}
           resolveLinkPreview={resolveLinkPreview}
-          onRemove={handleEditRemove}
+          onRemove={edit.link ? handleEditRemove : undefined}
           onSubmit={handleEditSubmit}
         />
       ) : link ? (


### PR DESCRIPTION
The link editor now opens on the Link field (selected when editing an existing link), only offers `Remove link` for an existing link, right-aligns `Save`, and disables it until both fields are filled instead of relying on the native `required` bubble. Inputs get a visible resting border plus a soft focus ring through the new `--meowdown-input-border` / `--meowdown-focus-ring` variables, and the buttons get hover, active, and focus-visible states.

| | Before | After |
| --- | --- | --- |
| Create from a selection (default theme) | ![Before: create link, default theme](https://github.com/user-attachments/assets/ad3cb4ce-9806-4eb2-8b83-63c0696a577c) | ![After: create link, default theme](https://github.com/user-attachments/assets/2f4e8587-605a-452f-a826-c8caa143dc16) |
| Create from a selection (host theme, URL typed) | ![Before: create link, host theme](https://github.com/user-attachments/assets/229ac293-00a4-4a56-83f6-b81925cc2941) | ![After: create link with URL typed, host theme](https://github.com/user-attachments/assets/6644436d-10ab-436e-8686-65fb96e0d57d) |
| Edit an existing link (host theme) | ![Before: edit link, host theme](https://github.com/user-attachments/assets/3ca5ea16-911a-4ff3-8478-27d8745db040) | ![After: edit link, host theme](https://github.com/user-attachments/assets/0e26de50-8e13-4895-8ce7-a936399b535d) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Link editing now places focus on and selects the destination field when opened.
  * Saving remains unavailable until both link text and destination are provided.
  * The “Remove link” action is shown only when editing an existing link.

* **Style**
  * Updated link form fields, buttons, focus indicators, spacing, hover states, and reduced-motion behavior.
  * Added themeable colors for input borders and focus rings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->