### PR TITLE
feat(react): add `CodeBlockView` prop to `MeowdownEditor`

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -66,6 +66,7 @@ Common `MeowdownEditor` props:
 | `onFilePaste`                                                                                                 | Persist pasted or dropped files                                                    |
 | `onSlashMenuSearch` / `onTagSearch` / `onWikilinkSearch` / `onSelectionMenuSearch`                            | Search menus for `/`, `#`, `[[`, and selection commands                            |
 | `readOnly` / `placeholder` / `blockHandle` / `caretGlide` / `embedPaste` / `linkPaste` / `bulletAfterHeading` | Behavior toggles                                                                   |
+| `CodeBlockView`                                                                                               | Custom React node view component for code blocks                                   |
 
 Every prop, callback, and `EditorHandle` method is documented in the [API reference](https://npmx.dev/package-docs/@meowdown%2Freact/).
 

--- a/packages/react/src/components/editor.tsx
+++ b/packages/react/src/components/editor.tsx
@@ -20,6 +20,7 @@ import type {
   WikilinkResolver,
 } from '@meowdown/core'
 import type { SelectionJSON } from '@prosekit/core'
+import type { ReactNodeViewComponent } from '@prosekit/react'
 import { clsx } from 'clsx/lite'
 import {
   useImperativeHandle,
@@ -337,6 +338,13 @@ export interface EditorProps {
   wrapperClassName?: string
 
   /**
+   * React component that renders code blocks in place of the built-in one.
+   * It receives ProseKit's node view props and must render a `contentDOM`
+   * hole for the code text. Read once at mount; later changes are ignored.
+   */
+  CodeBlockView?: ReactNodeViewComponent | undefined
+
+  /**
    * Imperative handle for the editor.
    */
   handleRef?: Ref<EditorHandle>
@@ -394,6 +402,7 @@ export function MeowdownEditor({
   timeFormat,
   editorClassName,
   wrapperClassName,
+  CodeBlockView,
   handleRef,
   children,
 }: EditorProps): ReactElement {
@@ -529,6 +538,7 @@ export function MeowdownEditor({
         onSearchChange={onSearchChange}
         timeFormat={timeFormat}
         editorClassName={editorClassName}
+        CodeBlockView={CodeBlockView}
       >
         {children}
       </ProseKitEditor>

--- a/packages/react/src/components/editor.tsx
+++ b/packages/react/src/components/editor.tsx
@@ -339,10 +339,9 @@ export interface EditorProps {
 
   /**
    * React component that renders code blocks in place of the built-in one.
-   * It receives ProseKit's node view props and must render a `contentDOM`
-   * hole for the code text. Read once at mount; later changes are ignored.
+   * `false` disables the React code block view.
    */
-  CodeBlockView?: ReactNodeViewComponent | undefined
+  CodeBlockView?: ReactNodeViewComponent | false | undefined
 
   /**
    * Imperative handle for the editor.

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -376,7 +376,10 @@ export function ProseKitEditor({
       resolveWikilink,
       markMode,
     })
-    const extension = union(baseExtension, defineCodeBlockView(CodeBlockView))
+    const extension =
+      CodeBlockView === false
+        ? baseExtension
+        : union(baseExtension, defineCodeBlockView(CodeBlockView))
     const editor: TypedEditor = createEditor({ extension })
     if (initialMarkdown) {
       editor.setContent(markdownToDoc(initialMarkdown, { nodes: editor.nodes, frontmatter }))

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -31,7 +31,7 @@ import { clamp } from '@ocavue/utils'
 import { createEditor, union, type SelectionJSON } from '@prosekit/core'
 import type { EditorNode } from '@prosekit/pm/model'
 import { Selection, TextSelection } from '@prosekit/pm/state'
-import { ProseKit } from '@prosekit/react'
+import { ProseKit, type ReactNodeViewComponent } from '@prosekit/react'
 import GithubSlugger from 'github-slugger'
 import {
   useCallback,
@@ -314,6 +314,11 @@ export interface ProseKitEditorProps {
   editorClassName?: string
 
   /**
+   * Component rendering code blocks. See `EditorProps.CodeBlockView`.
+   */
+  CodeBlockView?: ReactNodeViewComponent | undefined
+
+  /**
    * Imperative handle for the editor.
    */
   ref?: Ref<EditorHandle>
@@ -363,6 +368,7 @@ export function ProseKitEditor({
   onSearchChange,
   timeFormat,
   editorClassName,
+  CodeBlockView,
   ref,
   children,
 }: ProseKitEditorProps): ReactElement {
@@ -373,7 +379,7 @@ export function ProseKitEditor({
       resolveWikilink,
       markMode,
     })
-    const extension = union(baseExtension, defineCodeBlockView())
+    const extension = union(baseExtension, defineCodeBlockView(CodeBlockView))
     const editor: TypedEditor = createEditor({ extension })
     if (initialMarkdown) {
       editor.setContent(markdownToDoc(initialMarkdown, { nodes: editor.nodes, frontmatter }))

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -313,10 +313,7 @@ export interface ProseKitEditorProps {
    */
   editorClassName?: string
 
-  /**
-   * Component rendering code blocks. See `EditorProps.CodeBlockView`.
-   */
-  CodeBlockView?: ReactNodeViewComponent | undefined
+  CodeBlockView?: ReactNodeViewComponent | false | undefined
 
   /**
    * Imperative handle for the editor.

--- a/packages/react/src/extensions/code-block-view.ts
+++ b/packages/react/src/extensions/code-block-view.ts
@@ -4,12 +4,12 @@ import { defineReactNodeView, type ReactNodeViewComponent } from '@prosekit/reac
 
 import { CodeBlockView } from '../components/code-block-view.tsx'
 
-export function defineCodeBlockView(): Extension {
+export function defineCodeBlockView(component: ReactNodeViewComponent = CodeBlockView): Extension {
   return union(
     defineReactNodeView({
       name: 'codeBlock',
       contentAs: 'code',
-      component: CodeBlockView satisfies ReactNodeViewComponent,
+      component,
     }),
     // Decorates the code block under the caret; `CodeBlockView` reads it to
     // decide whether the preview shows alone or below the source.

--- a/packages/react/src/extensions/code-block-view.ts
+++ b/packages/react/src/extensions/code-block-view.ts
@@ -4,15 +4,19 @@ import { defineReactNodeView, type ReactNodeViewComponent } from '@prosekit/reac
 
 import { CodeBlockView } from '../components/code-block-view.tsx'
 
-export function defineCodeBlockView(component: ReactNodeViewComponent = CodeBlockView): Extension {
+export function defineCodeBlockView(
+  component: ReactNodeViewComponent | false = CodeBlockView,
+): Extension {
+  // Decorates the code block under the caret; `CodeBlockView` reads it to
+  // decide whether the preview shows alone or below the source.
+  const preview = defineCodeBlockPreviewPlugin()
+  if (!component) return preview
   return union(
     defineReactNodeView({
       name: 'codeBlock',
       contentAs: 'code',
       component,
     }),
-    // Decorates the code block under the caret; `CodeBlockView` reads it to
-    // decide whether the preview shows alone or below the source.
-    defineCodeBlockPreviewPlugin(),
+    preview,
   )
 }

--- a/packages/react/src/extensions/code-block-view.ts
+++ b/packages/react/src/extensions/code-block-view.ts
@@ -4,19 +4,15 @@ import { defineReactNodeView, type ReactNodeViewComponent } from '@prosekit/reac
 
 import { CodeBlockView } from '../components/code-block-view.tsx'
 
-export function defineCodeBlockView(
-  component: ReactNodeViewComponent | false = CodeBlockView,
-): Extension {
-  // Decorates the code block under the caret; `CodeBlockView` reads it to
-  // decide whether the preview shows alone or below the source.
-  const preview = defineCodeBlockPreviewPlugin()
-  if (!component) return preview
+export function defineCodeBlockView(component: ReactNodeViewComponent = CodeBlockView): Extension {
   return union(
     defineReactNodeView({
       name: 'codeBlock',
       contentAs: 'code',
       component,
     }),
-    preview,
+    // Decorates the code block under the caret; `CodeBlockView` reads it to
+    // decide whether the preview shows alone or below the source.
+    defineCodeBlockPreviewPlugin(),
   )
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -28,4 +28,4 @@ export type {
 
 export type { SelectionJSON } from '@prosekit/core'
 export type { LinkPreview, LinkPreviewResolver } from '@meowdown/core'
-export { useEditor, useExtension, useKeymap } from '@prosekit/react'
+export { useEditor, useExtension, useKeymap, type ReactNodeViewComponent } from '@prosekit/react'


### PR DESCRIPTION
Adds a `CodeBlockView` prop so a host can pass its own `ReactNodeViewComponent` to render code blocks instead of the built-in one.