### PR TITLE
feat: keep leading and trailing empty paragraphs

### DIFF
--- a/packages/core/src/converters/check-roundtrip.test.ts
+++ b/packages/core/src/converters/check-roundtrip.test.ts
@@ -7,6 +7,10 @@ const EXACT_CASES: string[] = [
   // a plain paragraph
   'hello world',
 
+  // blank lines at the document's edges are empty paragraphs
+  '\n\nhello world\n\n\n',
+  '\n<?\n\n',
+
   // raw HTML is literal text
   '<div class="x">hi</div>',
 
@@ -195,7 +199,6 @@ const NORMALIZING_CASES: string[] = [
   // an unterminated processing instruction runs to the end of the document,
   // the blank lines after it included; an unterminated comment the same
   '<?\n\t',
-  '\n<?\n\n',
   ' <!--',
 
   // an info string that opens with the fence character keeps off the fence

--- a/packages/core/src/converters/md-to-pm.test.ts
+++ b/packages/core/src/converters/md-to-pm.test.ts
@@ -50,11 +50,60 @@ describe('markdownToDoc', () => {
     })
   })
 
-  it('skips leading and trailing blank lines', () => {
+  it('materializes empty paragraphs from leading and trailing blank lines', () => {
     expect(markdownToDoc('\n\na\n\n\n').toJSON()).toEqual({
       type: 'doc',
       attrs: { frontmatter: null },
-      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'a' }] }],
+      content: [
+        { type: 'paragraph' },
+        { type: 'paragraph' },
+        { type: 'paragraph', content: [{ type: 'text', text: 'a' }] },
+        { type: 'paragraph' },
+        { type: 'paragraph' },
+      ],
+    })
+  })
+
+  it('reads a document of blank lines as empty paragraphs', () => {
+    const empty = { type: 'doc', attrs: { frontmatter: null }, content: [{ type: 'paragraph' }] }
+    expect(markdownToDoc('').toJSON()).toEqual(empty)
+    expect(markdownToDoc('\n').toJSON()).toEqual(empty)
+    expect(markdownToDoc('\n\n').toJSON()).toEqual({
+      type: 'doc',
+      attrs: { frontmatter: null },
+      content: [{ type: 'paragraph' }, { type: 'paragraph' }],
+    })
+  })
+
+  it('reads the blank line after frontmatter as a separator', () => {
+    const paragraph = { type: 'paragraph', content: [{ type: 'text', text: 'a' }] }
+    expect(markdownToDoc('---\nt: x\n---\n\na', { frontmatter: true }).toJSON()).toEqual({
+      type: 'doc',
+      attrs: { frontmatter: 't: x' },
+      content: [paragraph],
+    })
+    expect(markdownToDoc('---\nt: x\n---\n\n\n\na', { frontmatter: true }).toJSON()).toEqual({
+      type: 'doc',
+      attrs: { frontmatter: 't: x' },
+      content: [{ type: 'paragraph' }, { type: 'paragraph' }, paragraph],
+    })
+  })
+
+  it('materializes empty paragraphs from blank quote lines at the edges', () => {
+    expect(markdownToDoc('>\n>\n> a\n>').toJSON()).toEqual({
+      type: 'doc',
+      attrs: { frontmatter: null },
+      content: [
+        {
+          type: 'blockquote',
+          content: [
+            { type: 'paragraph' },
+            { type: 'paragraph' },
+            { type: 'paragraph', content: [{ type: 'text', text: 'a' }] },
+            { type: 'paragraph' },
+          ],
+        },
+      ],
     })
   })
 

--- a/packages/core/src/converters/md-to-pm.ts
+++ b/packages/core/src/converters/md-to-pm.ts
@@ -75,7 +75,7 @@ export function markdownToDoc(
 
   const tree = gfmBlockOnlyParser.parse(rest)
   const cursor = tree.cursor()
-  const blocks = collectBlocks(nodes, cursor, rest, 0)
+  const blocks = collectBlocks(nodes, cursor, rest, 0, rest !== markdown)
 
   return nodes.doc(frontmatterBody === undefined ? {} : { frontmatter: frontmatterBody }, blocks)
 }
@@ -100,18 +100,30 @@ function matchFrontmatter(
 }
 
 /**
- * Walk the current node's children, converting each block-level child
- * and flattening any node converter that returns multiple siblings
- * (lists are the main case).
+ * Walk the document's children, converting each block-level child and
+ * flattening any node converter that returns multiple siblings (lists are the
+ * main case). Blank lines before the first block and after the last one are
+ * content too, one empty paragraph each; when a frontmatter block was peeled
+ * off ahead of `text`, the first leading blank line is that block's separator.
  */
 function collectBlocks(
   nodes: TypedNodeBuilders,
   cursor: TreeCursor,
   text: string,
   column: number,
+  afterFrontmatter: boolean,
 ): ProseMirrorNode[] {
   const out: ProseMirrorNode[] = []
-  if (!cursor.firstChild()) return out
+  if (!cursor.firstChild()) {
+    // A document holds at least one block: the empty document is one empty paragraph.
+    appendEmptyParagraphs(out, nodes, Math.max(1, countNewlines(text, 0, text.length)))
+    return out
+  }
+  appendEmptyParagraphs(
+    out,
+    nodes,
+    countNewlines(text, 0, cursor.from) - (afterFrontmatter ? 1 : 0),
+  )
   let previousTo: number | undefined
   do {
     if (previousTo != null) appendGapParagraphs(out, nodes, text, previousTo, cursor.from)
@@ -119,6 +131,9 @@ function collectBlocks(
     appendBlocks(out, nodes, convertBlock(nodes, cursor, text, column))
   } while (cursor.nextSibling())
   cursor.parent()
+  // The last line's own terminator is not a blank line.
+  const end = text.endsWith('\n') ? text.length - 1 : text.length
+  appendEmptyParagraphs(out, nodes, countNewlines(text, previousTo, end))
   return out
 }
 
@@ -166,11 +181,23 @@ function appendGapParagraphs(
   gapFrom: number,
   gapTo: number,
 ): void {
-  let newlineCount = 0
-  for (let i = gapFrom; i < gapTo; i++) {
-    if (text.charCodeAt(i) === CHAR_LINE_FEED) newlineCount++
+  appendEmptyParagraphs(out, nodes, countNewlines(text, gapFrom, gapTo) - 2)
+}
+
+function appendEmptyParagraphs(
+  out: ProseMirrorNode[],
+  nodes: TypedNodeBuilders,
+  count: number,
+): void {
+  for (let i = 0; i < count; i++) out.push(nodes.paragraph())
+}
+
+function countNewlines(text: string, from: number, to: number): number {
+  let count = 0
+  for (let i = from; i < to; i++) {
+    if (text.charCodeAt(i) === CHAR_LINE_FEED) count++
   }
-  for (let i = 2; i < newlineCount; i++) out.push(nodes.paragraph())
+  return count
 }
 
 function convertBlock(
@@ -527,6 +554,11 @@ function convertHTMLComment(
 /**
  * A blockquote's children start at column 0: every column an enclosing container
  * wrote sits in front of the `> ` marker on the line, and comes off with it.
+ *
+ * Blank quote lines before the first block and after the last one are empty
+ * paragraphs, like the document's own edges. The quote's range ends on its last
+ * line rather than after it, so every newline in the trailing slice is a blank
+ * line, and a quote made of markers only has one more line than newlines.
  */
 function convertBlockquote(
   nodes: TypedNodeBuilders,
@@ -534,16 +566,27 @@ function convertBlockquote(
   text: string,
 ): ProseMirrorNode {
   const content: ProseMirrorNode[] = []
+  const from = cursor.from
+  const to = cursor.to
+  let previousTo: number | undefined
   if (cursor.firstChild()) {
-    let previousTo: number | undefined
     do {
       if (cursor.type.id === LEZER_NODE_IDS.QuoteMark) continue
-      if (previousTo != null) appendGapParagraphs(content, nodes, text, previousTo, cursor.from)
+      if (previousTo == null) {
+        appendEmptyParagraphs(content, nodes, countNewlines(text, from, cursor.from))
+      } else {
+        appendGapParagraphs(content, nodes, text, previousTo, cursor.from)
+      }
       previousTo = cursor.to
       appendBlocks(content, nodes, convertBlock(nodes, cursor, text, 0))
     } while (cursor.nextSibling())
     cursor.parent()
   }
+  appendEmptyParagraphs(
+    content,
+    nodes,
+    previousTo == null ? countNewlines(text, from, to) + 1 : countNewlines(text, previousTo, to),
+  )
   return nodes.blockquote(content)
 }
 

--- a/packages/core/src/converters/pm-to-md.test.ts
+++ b/packages/core/src/converters/pm-to-md.test.ts
@@ -22,14 +22,50 @@ describe('docToMarkdown', () => {
     expect(docToMarkdown(doc)).toBe('a\n\n\nb\n')
   })
 
-  it('drops a leading empty paragraph', () => {
+  it('keeps a leading empty paragraph', () => {
     const doc = n.doc(n.paragraph(), n.paragraph('a'))
-    expect(docToMarkdown(doc)).toBe('a\n')
+    expect(docToMarkdown(doc)).toBe('\na\n')
   })
 
-  it('drops a trailing empty paragraph', () => {
+  it('keeps a trailing empty paragraph', () => {
     const doc = n.doc(n.paragraph('a'), n.paragraph())
-    expect(docToMarkdown(doc)).toBe('a\n')
+    expect(docToMarkdown(doc)).toBe('a\n\n')
+  })
+
+  it('keeps a document of empty paragraphs', () => {
+    const doc = n.doc(n.paragraph(), n.paragraph(), n.paragraph())
+    expect(docToMarkdown(doc)).toBe('\n\n\n')
+  })
+
+  it('writes a lone empty paragraph as the empty document', () => {
+    expect(docToMarkdown(n.doc(n.paragraph()))).toBe('\n')
+    const doc = n.doc({ frontmatter: 'title: x' }, n.paragraph())
+    expect(docToMarkdown(doc, { frontmatter: true })).toBe('---\ntitle: x\n---\n')
+  })
+
+  it('keeps empty paragraphs after frontmatter', () => {
+    const doc = n.doc({ frontmatter: 'title: x' }, n.paragraph(), n.paragraph(), n.paragraph('a'))
+    expect(docToMarkdown(doc, { frontmatter: true })).toBe('---\ntitle: x\n---\n\n\n\na\n')
+  })
+
+  it('keeps a leading empty paragraph in a blockquote', () => {
+    const doc = n.doc(n.blockquote(n.paragraph(), n.paragraph('a')))
+    expect(docToMarkdown(doc)).toBe('>\n> a\n')
+  })
+
+  it('keeps a trailing empty paragraph in a blockquote', () => {
+    const doc = n.doc(n.blockquote(n.paragraph('a'), n.paragraph()))
+    expect(docToMarkdown(doc)).toBe('> a\n>\n')
+  })
+
+  it('separates a blockquote opening with an empty paragraph from the block above', () => {
+    const doc = n.doc(n.paragraph('x'), n.blockquote(n.paragraph(), n.paragraph('a')))
+    expect(docToMarkdown(doc)).toBe('x\n\n>\n> a\n')
+  })
+
+  it('writes a trailing empty paragraph of a list item after the list', () => {
+    const doc = n.doc(n.list({ kind: 'bullet' }, n.paragraph('x'), n.paragraph()))
+    expect(docToMarkdown(doc)).toBe('- x\n\n')
   })
 
   it('keeps a level-1 heading', () => {

--- a/packages/core/src/converters/pm-to-md.ts
+++ b/packages/core/src/converters/pm-to-md.ts
@@ -59,7 +59,12 @@ export function docToMarkdown(node: ProseMirrorNode, options: DocToMarkdownOptio
   if (options.frontmatter) {
     emitFrontmatter(node.attrs.frontmatter as Frontmatter, out)
   }
-  emit(node, out)
+  // A document holds at least one block, so a lone empty paragraph is the
+  // empty document, not a blank line.
+  const child = node.childCount === 1 ? node.child(0) : undefined
+  if (!(child && isNodeOfType(child, 'paragraph') && child.childCount === 0)) {
+    emit(node, out)
+  }
   return out.finish()
 }
 
@@ -145,6 +150,11 @@ class MdOut {
    * "> " prefix).
    */
   private deferredBlankPrefix: string | null = null
+  /**
+   * Length of `parts` when the last line carrying content was closed. Whatever
+   * follows is the blank lines empty blocks wrote, which `finish` keeps.
+   */
+  private contentEnd = 0
 
   /**
    * Write `text`, opening each embedded line with the current line prefix.
@@ -191,20 +201,30 @@ class MdOut {
   }
 
   /**
-   * End a block that owns no line of its own (an empty paragraph): flush the
-   * blank line owed by the previous block now and owe the next block a fresh
-   * one, so each empty block yields one extra blank line. A marker-bearing
-   * block (an empty list item's `- `) still owns its first line and falls
-   * through to `closeBlock`. At the very start of the output there is no
-   * blank line to flush or owe - leading empty blocks vanish, mirroring the
-   * parser, which materializes empty paragraphs only between sibling blocks.
+   * End a block that owns no line of its own (an empty paragraph): it is one
+   * blank line. After another block, the blank line that block owes is this
+   * one, and the next block is owed a fresh one, so each empty block adds a
+   * blank line to the separator. With nothing owed (the start of the output)
+   * the line is written directly and nothing is owed after it: a leading empty
+   * block is a blank line, not a separator. A marker-bearing block (an empty
+   * list item's `- `, an empty quote line's `>`) writes its marker as the line.
    */
   closeEmptyBlock(): void {
-    if (!this.atLineStart || this.pendingFirst !== null) {
+    if (!this.atLineStart) {
       this.closeBlock()
       return
     }
-    if (this.parts.length === 0) return
+    if (this.pendingFirst !== null) {
+      this.emitDeferredBlankLine()
+      const marker = this.pendingFirst
+      this.parts.push(marker.endsWith('] ') ? marker : marker.trimEnd(), '\n')
+      this.pendingFirst = null
+      return
+    }
+    if (this.deferredBlankPrefix === null) {
+      this.parts.push(this.linePrefix.trimEnd(), '\n')
+      return
+    }
     this.emitDeferredBlankLine()
     this.deferredBlankPrefix = this.linePrefix
   }
@@ -225,7 +245,10 @@ class MdOut {
       this.pendingFirst = null
       this.atLineStart = false
     }
-    if (!this.atLineStart) this.parts.push('\n')
+    if (!this.atLineStart) {
+      this.parts.push('\n')
+      this.contentEnd = this.parts.length
+    }
     this.atLineStart = true
     this.deferredBlankPrefix = this.linePrefix
   }
@@ -293,17 +316,19 @@ class MdOut {
   }
 
   finish(): string {
-    // Drop the blank lines the last block left behind and end with exactly one
-    // newline. A blank line is layout; trailing spaces on a line that carries
-    // content are part of that text and stay, so the text survives a round trip.
-    const text = this.parts.join('')
+    // The last line carrying content ends with exactly one newline: the blank
+    // line it owes and the line breaks its text ended with are dropped, while
+    // trailing spaces on the line are part of that text and stay. The blank
+    // lines that empty blocks wrote after it are content and stay too.
+    const text = this.parts.slice(0, this.contentEnd).join('')
     let cut = text.length
     for (let i = text.length - 1; i >= 0; i--) {
       const code = text.charCodeAt(i)
       if (code === CHAR_LINE_FEED) cut = i
       else if (code !== CHAR_SPACE && code !== CHAR_TAB) break
     }
-    return text.slice(0, cut) + '\n'
+    const head = cut === 0 ? '' : text.slice(0, cut) + '\n'
+    return head + this.parts.slice(this.contentEnd).join('') || '\n'
   }
 
   private emitDeferredBlankLine(): void {

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -319,6 +319,18 @@ describe('blockquotes', () => {
     expect(roundtrip('>')).toBe('>\n')
   })
 
+  it('keeps a run of empty quote markers', () => {
+    expect(roundtrip('>\n>\n>')).toBe('>\n>\n>\n')
+  })
+
+  it('keeps leading blank quote lines', () => {
+    expect(roundtrip('>\n>\n> a')).toBe('>\n>\n> a\n')
+  })
+
+  it('keeps trailing blank quote lines', () => {
+    expect(roundtrip('> a\n>\n>')).toBe('> a\n>\n>\n')
+  })
+
   it('keeps a heading in a quote', () => {
     expect(roundtrip('> # heading')).toBe('> # heading\n')
   })
@@ -882,6 +894,49 @@ describe('escapes and whitespace', () => {
     expect(reparsed.toJSON()).toEqual(doc.toJSON())
   })
 
+  it('keeps leading blank lines', () => {
+    expect(roundtrip('\n\nhello')).toBe('\n\nhello\n')
+  })
+
+  it('keeps trailing blank lines', () => {
+    expect(roundtrip('hello\n\n\n')).toBe('hello\n\n\n')
+  })
+
+  it('keeps a document of blank lines', () => {
+    expect(roundtrip('\n\n\n')).toBe('\n\n\n')
+  })
+
+  it('keeps typed empty paragraphs at both edges', () => {
+    const doc = n.doc(
+      n.paragraph(),
+      n.paragraph(),
+      n.paragraph('Foo'),
+      n.paragraph(),
+      n.paragraph(),
+    )
+    const reparsed = markdownToDoc(docToMarkdown(doc))
+    expect(reparsed.toJSON()).toEqual(doc.toJSON())
+  })
+
+  it('keeps typed empty paragraphs at the edges of a blockquote', () => {
+    const doc = n.doc(n.blockquote(n.paragraph(), n.paragraph('Foo'), n.paragraph()))
+    const reparsed = markdownToDoc(docToMarkdown(doc))
+    expect(reparsed.toJSON()).toEqual(doc.toJSON())
+  })
+
+  // A blank line after an item's last line belongs to no item, so the empty
+  // paragraph comes back after the list.
+  it('moves a trailing empty paragraph out of a list item', () => {
+    const doc = n.doc(n.list({ kind: 'bullet' }, n.paragraph('x'), n.paragraph()))
+    const markdown = docToMarkdown(doc)
+    expect(markdown).toBe('- x\n\n')
+    const reparsed = markdownToDoc(markdown)
+    expect(reparsed.childCount).toBe(2)
+    expect(reparsed.child(0).type.name).toBe('list')
+    expect(reparsed.child(1).toJSON()).toEqual({ type: 'paragraph' })
+    expect(docToMarkdown(reparsed)).toBe(markdown)
+  })
+
   it('keeps YAML frontmatter', () => {
     expect(roundtrip('---\ntitle: x\n---', { frontmatter: true })).toBe('---\ntitle: x\n---\n')
   })
@@ -889,6 +944,17 @@ describe('escapes and whitespace', () => {
   it('keeps YAML frontmatter before content', () => {
     const md = ['---', 'title: x', '---', '', '# heading'].join('\n')
     expect(roundtrip(md, { frontmatter: true })).toBe(md + '\n')
+  })
+
+  it('keeps a blank-line run after YAML frontmatter', () => {
+    const md = ['---', 'title: x', '---', '', '', '', '# heading'].join('\n')
+    expect(roundtrip(md, { frontmatter: true })).toBe(md + '\n')
+  })
+
+  it('keeps blank lines after body-less YAML frontmatter', () => {
+    expect(roundtrip('---\ntitle: x\n---\n\n\n', { frontmatter: true })).toBe(
+      '---\ntitle: x\n---\n\n\n',
+    )
   })
 
   it('normalizes a missing blank line after frontmatter', () => {
@@ -971,8 +1037,13 @@ describe('idempotency', () => {
     expect(roundtrip(once)).toBe(once)
   })
 
-  it('keeps a normalized leading blank line stable', () => {
-    const once = roundtrip('\n\nhello')
+  it('keeps a document of blank lines stable', () => {
+    const once = roundtrip('\n\n')
+    expect(roundtrip(once)).toBe(once)
+  })
+
+  it('keeps a lone blank line stable', () => {
+    const once = roundtrip('\n')
     expect(roundtrip(once)).toBe(once)
   })
 

--- a/packages/core/src/extensions/horizontal-rule.test.ts
+++ b/packages/core/src/extensions/horizontal-rule.test.ts
@@ -50,7 +50,7 @@ describe('horizontal rule input rule in lists', () => {
     await userEvent.keyboard('- ')
     await userEvent.keyboard('---')
     expect(fixture.doc.toJSON()).toEqual(doc2.toJSON())
-    expect(docToMarkdown(fixture.doc)).toBe('---\n')
+    expect(docToMarkdown(fixture.doc)).toBe('---\n\n')
   })
 
   it('replaces an otherwise-empty ordered item typed with `1. `', async () => {
@@ -65,7 +65,7 @@ describe('horizontal rule input rule in lists', () => {
     await userEvent.keyboard('1. ')
     await userEvent.keyboard('---')
     expect(fixture.doc.toJSON()).toEqual(doc2.toJSON())
-    expect(docToMarkdown(fixture.doc)).toBe('---\n')
+    expect(docToMarkdown(fixture.doc)).toBe('---\n\n')
   })
 
   it('replaces an otherwise-empty task item', async () => {
@@ -79,7 +79,7 @@ describe('horizontal rule input rule in lists', () => {
 
     await userEvent.keyboard('---')
     expect(fixture.doc.toJSON()).toEqual(doc2.toJSON())
-    expect(docToMarkdown(fixture.doc)).toBe('---\n')
+    expect(docToMarkdown(fixture.doc)).toBe('---\n\n')
   })
 
   it('replaces only the item under the caret, splitting the list', async () => {
@@ -117,7 +117,7 @@ describe('horizontal rule input rule in lists', () => {
 
     await userEvent.keyboard('---')
     expect(fixture.doc.toJSON()).toEqual(doc2.toJSON())
-    expect(docToMarkdown(fixture.doc)).toBe('- first\n\n  ---\n')
+    expect(docToMarkdown(fixture.doc)).toBe('- first\n\n  ---\n\n')
   })
 
   it('keeps the outer item when a nested empty item gets the `---`', async () => {
@@ -139,7 +139,7 @@ describe('horizontal rule input rule in lists', () => {
 
     await userEvent.keyboard('---')
     expect(fixture.doc.toJSON()).toEqual(doc2.toJSON())
-    expect(docToMarkdown(fixture.doc)).toBe('- foo\n\n  ---\n')
+    expect(docToMarkdown(fixture.doc)).toBe('- foo\n\n  ---\n\n')
   })
 
   it('keeps an item whose paragraph still has text after the caret', async () => {

--- a/packages/core/src/extensions/wililink-fuzz.test.ts
+++ b/packages/core/src/extensions/wililink-fuzz.test.ts
@@ -2797,7 +2797,10 @@ describe('caret fuzz over a wikilink inside a paragraph in focus mode', () => {
     expect(await run('focus', INLINE_MARKDOWN, '{Enter}')).toMatchInlineSnapshot(`
       """
       ===== key: {Enter} pos: 1 ========
-      ----- markdown before/after ------
+      ----- markdown before ------------
+      a [[foo]] b
+      ----- markdown after -------------
+
       a [[foo]] b
       ----- selection before -----------
       ┃a [[foo]] b
@@ -2947,8 +2950,11 @@ describe('caret fuzz over a wikilink inside a paragraph in focus mode', () => {
       ----------------------------------
 
       ===== key: {Enter} pos: 12 =======
-      ----- markdown before/after ------
+      ----- markdown before ------------
       a [[foo]] b
+      ----- markdown after -------------
+      a [[foo]] b
+
       ----- selection before -----------
       a [[foo]] b┃
       ----- selection after ------------
@@ -3303,7 +3309,10 @@ describe('caret fuzz over two adjacent wikilinks in focus mode', () => {
     expect(await run('focus', ADJACENT_MARKDOWN, '{Enter}')).toMatchInlineSnapshot(`
       """
       ===== key: {Enter} pos: 1 ========
-      ----- markdown before/after ------
+      ----- markdown before ------------
+      [[foo]][[bar]]
+      ----- markdown after -------------
+
       [[foo]][[bar]]
       ----- selection before -----------
       ┃[[foo]][[bar]]
@@ -3411,8 +3420,11 @@ describe('caret fuzz over two adjacent wikilinks in focus mode', () => {
       ----------------------------------
 
       ===== key: {Enter} pos: 9 ========
-      ----- markdown before/after ------
+      ----- markdown before ------------
       [[foo]][[bar]]
+      ----- markdown after -------------
+      [[foo]][[bar]]
+
       ----- selection before -----------
       [[foo]][[bar]]┃
       ----- selection after ------------
@@ -3421,8 +3433,11 @@ describe('caret fuzz over two adjacent wikilinks in focus mode', () => {
       ----------------------------------
 
       ===== key: {Enter} pos: 10 =======
-      ----- markdown before/after ------
+      ----- markdown before ------------
       [[foo]][[bar]]
+      ----- markdown after -------------
+      [[foo]][[bar]]
+
       ----- selection before -----------
       [[foo]][[bar]]┃
       ----- selection after ------------
@@ -3431,8 +3446,11 @@ describe('caret fuzz over two adjacent wikilinks in focus mode', () => {
       ----------------------------------
 
       ===== key: {Enter} pos: 11 =======
-      ----- markdown before/after ------
+      ----- markdown before ------------
       [[foo]][[bar]]
+      ----- markdown after -------------
+      [[foo]][[bar]]
+
       ----- selection before -----------
       [[foo]][[bar]]┃
       ----- selection after ------------
@@ -3441,8 +3459,11 @@ describe('caret fuzz over two adjacent wikilinks in focus mode', () => {
       ----------------------------------
 
       ===== key: {Enter} pos: 12 =======
-      ----- markdown before/after ------
+      ----- markdown before ------------
       [[foo]][[bar]]
+      ----- markdown after -------------
+      [[foo]][[bar]]
+
       ----- selection before -----------
       [[foo]][[bar]]┃
       ----- selection after ------------
@@ -3451,8 +3472,11 @@ describe('caret fuzz over two adjacent wikilinks in focus mode', () => {
       ----------------------------------
 
       ===== key: {Enter} pos: 13 =======
-      ----- markdown before/after ------
+      ----- markdown before ------------
       [[foo]][[bar]]
+      ----- markdown after -------------
+      [[foo]][[bar]]
+
       ----- selection before -----------
       [[foo]][[bar]]┃
       ----- selection after ------------
@@ -3461,8 +3485,11 @@ describe('caret fuzz over two adjacent wikilinks in focus mode', () => {
       ----------------------------------
 
       ===== key: {Enter} pos: 14 =======
-      ----- markdown before/after ------
+      ----- markdown before ------------
       [[foo]][[bar]]
+      ----- markdown after -------------
+      [[foo]][[bar]]
+
       ----- selection before -----------
       [[foo]][[bar]]┃
       ----- selection after ------------
@@ -3471,8 +3498,11 @@ describe('caret fuzz over two adjacent wikilinks in focus mode', () => {
       ----------------------------------
 
       ===== key: {Enter} pos: 15 =======
-      ----- markdown before/after ------
+      ----- markdown before ------------
       [[foo]][[bar]]
+      ----- markdown after -------------
+      [[foo]][[bar]]
+
       ----- selection before -----------
       [[foo]][[bar]]┃
       ----- selection after ------------

--- a/packages/react/src/components/prosekit-editor.tsx
+++ b/packages/react/src/components/prosekit-editor.tsx
@@ -429,10 +429,11 @@ export function ProseKitEditor({
         const doc = markdownToDoc(markdown, { nodes: editor.nodes, frontmatter })
         const currentMarkdown = docToMarkdown(transaction.doc, { frontmatter })
         const nextMarkdown = docToMarkdown(doc, { frontmatter })
-        // Edge-only blank blocks intentionally normalize away in Markdown. An
-        // equivalent host echo must not replace the document and erase that
-        // transient editor structure; refreshMarkdownRendering forces the
-        // replacement when a caller explicitly needs one.
+        // A host echo of equivalent Markdown must not replace the document: the
+        // editor may hold structure Markdown cannot spell (a trailing empty
+        // paragraph inside a list item), and the caret would move.
+        // refreshMarkdownRendering forces the replacement when a caller
+        // explicitly needs one.
         if (forceMarkdown || currentMarkdown !== nextMarkdown) {
           transaction.replaceWith(0, transaction.doc.content.size, doc.content)
         } else if (!selection) {

--- a/packages/react/src/components/slash-menu.test.tsx
+++ b/packages/react/src/components/slash-menu.test.tsx
@@ -106,7 +106,7 @@ describe('SlashMenu', () => {
     await userEvent.keyboard('{Enter}')
 
     await expect.element(page.locate('.ProseMirror table')).not.toBeInTheDocument()
-    expect(ref.current?.getMarkdown()).toBe('Name // Table\n')
+    expect(ref.current?.getMarkdown()).toBe('Name // Table\n\n')
   })
 
   it('does not select a matching host template from double-slash text', async () => {
@@ -124,7 +124,7 @@ describe('SlashMenu', () => {
     await userEvent.keyboard('{Enter}')
 
     expect(onSelect).not.toHaveBeenCalled()
-    expect(ref.current?.getMarkdown()).toBe('Name // Meeting note\n')
+    expect(ref.current?.getMarkdown()).toBe('Name // Meeting note\n\n')
   })
 
   it('applies the selected block type and removes the query text', async () => {


### PR DESCRIPTION
Blank lines before the first block and after the last one (at the document level and inside a blockquote) now round-trip as empty paragraphs, one per blank line, instead of being dropped on reopen. The serializer writes them back as the same blank lines, so a file with a gap typed at the top or bottom of a note keeps it across save and reload.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>