### PR TITLE
feat: keep empty paragraphs inside a list item

### DIFF
--- a/packages/core/src/converters/md-to-pm.test.ts
+++ b/packages/core/src/converters/md-to-pm.test.ts
@@ -89,6 +89,17 @@ describe('markdownToDoc', () => {
     })
   })
 
+  it('materializes empty paragraphs from a blank-line run inside a list item', () => {
+    const doc = markdownToDoc('- a\n\n\n\n  b')
+    expect(doc.childCount).toBe(1)
+    expect(doc.child(0).toJSON().content).toEqual([
+      { type: 'paragraph', content: [{ type: 'text', text: 'a' }] },
+      { type: 'paragraph' },
+      { type: 'paragraph' },
+      { type: 'paragraph', content: [{ type: 'text', text: 'b' }] },
+    ])
+  })
+
   it('materializes empty paragraphs from blank quote lines at the edges', () => {
     expect(markdownToDoc('>\n>\n> a\n>').toJSON()).toEqual({
       type: 'doc',

--- a/packages/core/src/converters/md-to-pm.test.ts
+++ b/packages/core/src/converters/md-to-pm.test.ts
@@ -92,12 +92,15 @@ describe('markdownToDoc', () => {
   it('materializes empty paragraphs from a blank-line run inside a list item', () => {
     const doc = markdownToDoc('- a\n\n\n\n  b')
     expect(doc.childCount).toBe(1)
-    expect(doc.child(0).toJSON().content).toEqual([
-      { type: 'paragraph', content: [{ type: 'text', text: 'a' }] },
-      { type: 'paragraph' },
-      { type: 'paragraph' },
-      { type: 'paragraph', content: [{ type: 'text', text: 'b' }] },
-    ])
+    expect(doc.child(0).toJSON()).toMatchObject({
+      type: 'list',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'a' }] },
+        { type: 'paragraph' },
+        { type: 'paragraph' },
+        { type: 'paragraph', content: [{ type: 'text', text: 'b' }] },
+      ],
+    })
   })
 
   it('materializes empty paragraphs from blank quote lines at the edges', () => {

--- a/packages/core/src/converters/md-to-pm.ts
+++ b/packages/core/src/converters/md-to-pm.ts
@@ -699,7 +699,10 @@ function convertListItem(
   // on top of whatever the enclosing containers already add. Both the marker and
   // the gap are known once the first block after the mark is reached.
   let contentColumn = column + markWidth + markerGap
-  let sawContent = false
+  // The end of the previous block, once the item has one. Blank lines between
+  // an item's blocks are empty paragraphs, as between any siblings; a blank
+  // quote line's `QuoteMark` sits in the gap and is counted through it.
+  let previousTo: number | undefined
 
   if (cursor.firstChild()) {
     do {
@@ -715,8 +718,7 @@ function convertListItem(
         markEndColumn = measureContentColumn(text, cursor.to)
         continue
       }
-      if (!sawContent) {
-        sawContent = true
+      if (previousTo == null) {
         // Only content that opens on the marker's own line measures a gap; an
         // item whose content starts on the next line takes the canonical single
         // space, the column its own continuation lines are indented to.
@@ -724,7 +726,10 @@ function convertListItem(
         const gap = onMarkLine ? measureContentColumn(text, cursor.from) - markEndColumn : 1
         markerGap = gap >= 2 && gap <= 4 ? gap : 1
         contentColumn = column + markWidth + markerGap
+      } else {
+        appendGapParagraphs(content, nodes, text, previousTo, cursor.from)
       }
+      previousTo = cursor.to
       if (kind === 'bullet' && cursor.type.id === LEZER_NODE_IDS.Task) {
         const task = convertTaskItem(nodes, cursor, text, contentColumn)
         taskChecked = task.checked

--- a/packages/core/src/converters/md-to-pm.ts
+++ b/packages/core/src/converters/md-to-pm.ts
@@ -674,6 +674,26 @@ function convertTaskItem(
   return { checked, taskMarker, paragraph }
 }
 
+/**
+ * The gap between a list marker ending at `markTo` and the item's first content
+ * at `contentFrom`. Only content that opens on the marker's own line measures a
+ * gap; an item whose content starts on the next line takes the canonical single
+ * space, the column its own continuation lines are indented to. A gap of 5+ is
+ * indented code (a different node, so the content's column would be the code
+ * block's), and 1 is the canonical default; only a 2-4 space gap is a faithful,
+ * content-preserving variation.
+ */
+function measureMarkerGap(
+  text: string,
+  contentFrom: number,
+  markTo: number | undefined,
+  markEndColumn: number,
+): number {
+  const onMarkLine = markTo != null && text.lastIndexOf('\n', contentFrom - 1) < markTo
+  const gap = onMarkLine ? measureContentColumn(text, contentFrom) - markEndColumn : 1
+  return gap >= 2 && gap <= 4 ? gap : 1
+}
+
 function convertListItem(
   nodes: TypedNodeBuilders,
   cursor: TreeCursor,
@@ -690,10 +710,6 @@ function convertListItem(
   let markWidth = 1
   let markTo: number | undefined
   let markEndColumn = 0
-  // The gap between the marker and the content. A gap of 5+ is indented code (a
-  // different node, so the first child's column would be the code block's), and 1 is
-  // the canonical default; only a 2-4 space gap is a faithful, content-preserving
-  // variation.
   let markerGap = 1
   // The item's blocks are indented past the marker on every line but the first,
   // on top of whatever the enclosing containers already add. Both the marker and
@@ -719,12 +735,7 @@ function convertListItem(
         continue
       }
       if (previousTo == null) {
-        // Only content that opens on the marker's own line measures a gap; an
-        // item whose content starts on the next line takes the canonical single
-        // space, the column its own continuation lines are indented to.
-        const onMarkLine = markTo != null && text.lastIndexOf('\n', cursor.from - 1) < markTo
-        const gap = onMarkLine ? measureContentColumn(text, cursor.from) - markEndColumn : 1
-        markerGap = gap >= 2 && gap <= 4 ? gap : 1
+        markerGap = measureMarkerGap(text, cursor.from, markTo, markEndColumn)
         contentColumn = column + markWidth + markerGap
       } else {
         appendGapParagraphs(content, nodes, text, previousTo, cursor.from)

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -924,6 +924,26 @@ describe('escapes and whitespace', () => {
     expect(reparsed.toJSON()).toEqual(doc.toJSON())
   })
 
+  it('keeps a blank-line run between the blocks of a list item', () => {
+    expect(roundtrip('- a\n\n\n\n  b')).toBe('- a\n\n\n\n  b\n')
+  })
+
+  it('keeps a blank-line run before a nested list', () => {
+    expect(roundtrip('- a\n\n\n\n  - b')).toBe('- a\n\n\n\n  - b\n')
+  })
+
+  it('keeps a blank-line run between the blocks of a quoted list item', () => {
+    expect(roundtrip('> - a\n>\n>\n>   b')).toBe('> - a\n>\n>\n>   b\n')
+  })
+
+  it('keeps typed empty paragraphs inside a list item', () => {
+    const doc = n.doc(
+      n.list({ kind: 'bullet', marker: '-' }, n.paragraph('x'), n.paragraph(), n.paragraph('y')),
+    )
+    const reparsed = markdownToDoc(docToMarkdown(doc))
+    expect(reparsed.toJSON()).toEqual(doc.toJSON())
+  })
+
   // A blank line after an item's last line belongs to no item, so the empty
   // paragraph comes back after the list.
   it('moves a trailing empty paragraph out of a list item', () => {


### PR DESCRIPTION
Blank lines between the blocks of one list item now round-trip as empty paragraphs, the same way they already do between top-level siblings. The serializer already wrote them; only the parser folded them away.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>