### PR TITLE
feat: read a blank-line run between list items as empty paragraphs

### DIFF
--- a/packages/core/src/converters/md-to-pm.test.ts
+++ b/packages/core/src/converters/md-to-pm.test.ts
@@ -103,6 +103,21 @@ describe('markdownToDoc', () => {
     })
   })
 
+  it('splits a list at a blank-line run between items', () => {
+    const doc = markdownToDoc('- a\n\n\n- b')
+    expect(doc.childCount).toBe(3)
+    expect(doc.child(0).type.name).toBe('list')
+    expect(doc.child(1).toJSON()).toEqual({ type: 'paragraph' })
+    expect(doc.child(2).type.name).toBe('list')
+  })
+
+  it('keeps a loose list together', () => {
+    const doc = markdownToDoc('- a\n\n- b')
+    expect(doc.childCount).toBe(2)
+    expect(doc.child(0).type.name).toBe('list')
+    expect(doc.child(1).type.name).toBe('list')
+  })
+
   it('materializes empty paragraphs from blank quote lines at the edges', () => {
     expect(markdownToDoc('>\n>\n> a\n>').toJSON()).toEqual({
       type: 'doc',

--- a/packages/core/src/converters/md-to-pm.ts
+++ b/packages/core/src/converters/md-to-pm.ts
@@ -597,16 +597,26 @@ function convertList(
   column: number,
   kind: 'bullet' | 'ordered',
 ): ProseMirrorNode[] {
-  const items: ProseMirrorNode[] = []
+  const out: ProseMirrorNode[] = []
   if (cursor.firstChild()) {
+    // One blank line between two items only makes the list loose; each further
+    // one is an empty paragraph between the items, which the flat list model
+    // holds as a sibling of the two `list` nodes. The gap is measured from the
+    // item's last block, not the item's end: in a blockquote the item's range
+    // swallows the `>` of the blank lines after it.
+    let previousContentEnd: number | undefined
     do {
-      if (cursor.type.id === LEZER_NODE_IDS.ListItem) {
-        items.push(convertListItem(nodes, cursor, text, column, kind))
+      if (cursor.type.id !== LEZER_NODE_IDS.ListItem) continue
+      if (previousContentEnd != null) {
+        appendGapParagraphs(out, nodes, text, previousContentEnd, cursor.from)
       }
+      const [item, contentEnd] = convertListItem(nodes, cursor, text, column, kind)
+      out.push(item)
+      previousContentEnd = contentEnd
     } while (cursor.nextSibling())
     cursor.parent()
   }
-  return items
+  return out
 }
 
 /**
@@ -700,7 +710,7 @@ function convertListItem(
   text: string,
   column: number,
   kind: 'bullet' | 'ordered',
-): ProseMirrorNode {
+): [item: ProseMirrorNode, contentEnd: number] {
   const content: ProseMirrorNode[] = []
 
   let taskChecked: boolean | undefined
@@ -768,7 +778,7 @@ function convertListItem(
     taskMarker,
     markerGap,
   }
-  return nodes.list(attrs, content)
+  return [nodes.list(attrs, content), previousTo ?? cursor.to]
 }
 
 function convertCodeBlock(

--- a/packages/core/src/converters/roundtrip.test.ts
+++ b/packages/core/src/converters/roundtrip.test.ts
@@ -936,6 +936,29 @@ describe('escapes and whitespace', () => {
     expect(roundtrip('> - a\n>\n>\n>   b')).toBe('> - a\n>\n>\n>   b\n')
   })
 
+  it('keeps a blank-line run between list items', () => {
+    expect(roundtrip('- a\n\n\n- b')).toBe('- a\n\n\n- b\n')
+    expect(roundtrip('- a\n\n\n\n- b')).toBe('- a\n\n\n\n- b\n')
+  })
+
+  it('keeps a blank-line run between ordered items', () => {
+    expect(roundtrip('1. a\n\n\n2. b')).toBe('1. a\n\n\n2. b\n')
+  })
+
+  it('keeps a blank-line run between quoted list items', () => {
+    expect(roundtrip('> - a\n>\n>\n> - b')).toBe('> - a\n>\n>\n> - b\n')
+  })
+
+  it('keeps a typed empty paragraph between two lists', () => {
+    const doc = n.doc(
+      n.list({ kind: 'bullet', marker: '-' }, n.paragraph('x')),
+      n.paragraph(),
+      n.list({ kind: 'bullet', marker: '-' }, n.paragraph('y')),
+    )
+    const reparsed = markdownToDoc(docToMarkdown(doc))
+    expect(reparsed.toJSON()).toEqual(doc.toJSON())
+  })
+
   it('keeps typed empty paragraphs inside a list item', () => {
     const doc = n.doc(
       n.list({ kind: 'bullet', marker: '-' }, n.paragraph('x'), n.paragraph(), n.paragraph('y')),


### PR DESCRIPTION
Two or more blank lines between two list items now read as empty paragraphs between two lists, so the gap a user types between bullets survives a reload byte for byte. A single blank line keeps the CommonMark loose-list meaning and is unchanged.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Markdown list conversion to preserve multiple blank lines between list items.
  - Preserved empty paragraphs and spacing when converting lists between Markdown and documents.
  - Improved round-trip handling for ordered lists, quoted list items, and separate lists divided by blank lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->