### PR TITLE
feat(core): persist post-embed snapshots in the magic comment

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,7 @@
     "@meowdown/markdown": "workspace:^",
     "@ocavue/utils": "^1.8.0",
     "@post-embed/elements": "^0.1.0",
+    "@post-embed/schema": "^0.1.0",
     "@post-embed/types": "^0.1.0",
     "@prosekit/core": "^0.13.2",
     "@prosekit/extensions": "^0.18.2",
@@ -49,7 +50,8 @@
     "remark-gfm": "^4.0.1",
     "remark-stringify": "^11.0.0",
     "unicode-by-name": "^0.2.0",
-    "unified": "^11.0.5"
+    "unified": "^11.0.5",
+    "valibot": "^1.4.2"
   },
   "devDependencies": {
     "@meowdown/vitest": "workspace:*",

--- a/packages/core/src/extensions/atom-mark-navigation.test.ts
+++ b/packages/core/src/extensions/atom-mark-navigation.test.ts
@@ -11,8 +11,6 @@ import {
   traceShiftKeySelection,
   type Fixture,
 } from '../testing/index.ts'
-import { createTweet } from '../testing/tweet-fixture.ts'
-import { createYouTubeVideo } from '../testing/youtube-fixture.ts'
 
 import { defineImage } from './image.ts'
 import type { MarkMode } from './mark-mode.ts'
@@ -35,8 +33,10 @@ function setup(mode: MarkMode, paragraphs: string[]): Fixture {
   editor.use(
     defineImage({
       resolveImageUrl: () => getSVGImageURL(24, 24),
-      resolveXPost: () => createTweet(),
-      resolveYouTubeVideo: () => createYouTubeVideo(),
+      // No snapshot: a resolved one is written back into the source, which
+      // would put its JSON into every traced selection below.
+      resolveXPost: () => undefined,
+      resolveYouTubeVideo: () => undefined,
     }),
   )
   fixture.set(n.doc(...paragraphs.map((text) => n.paragraph(text))))

--- a/packages/core/src/extensions/embed-paste.test.ts
+++ b/packages/core/src/extensions/embed-paste.test.ts
@@ -151,11 +151,14 @@ describe('undo restores the raw link', () => {
     editor.commands.undo()
     expect(editor.state.doc.textContent).toBe('')
 
-    // Redo mirrors it: link, then embed.
+    // Redo mirrors it: link, then embed. The second redo restores what the
+    // first undo removed: the embed together with the snapshot that had been
+    // written behind it.
     editor.commands.redo()
     expect(editor.state.doc.textContent).toBe(YT)
     editor.commands.redo()
-    expect(editor.state.doc.textContent).toBe(EMBED)
+    expect(editor.state.doc.textContent.startsWith(EMBED)).toBe(true)
+    expect(editor.state.doc.textContent).toContain('"snapshot"')
     await expect.element(youtubeEmbed).toBeInTheDocument()
   })
 

--- a/packages/core/src/extensions/image.test.ts
+++ b/packages/core/src/extensions/image.test.ts
@@ -3,6 +3,7 @@ import { NodeSelection } from '@prosekit/pm/state'
 import { describe, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 
+import { docToMarkdown } from '../converters/pm-to-md.ts'
 import { findText } from '../testing/find-text.ts'
 import {
   getSelectionSnapshot,
@@ -329,6 +330,20 @@ describe('image resize', () => {
     using fixture = setupResize('![cat](u)<!-- {"width":200} -->')
     void fixture
     await expect.element(resizable).toHaveAttribute('data-width', '200')
+  })
+
+  // A stacked run reads its first comment and a rewrite folds the run into
+  // one; before, the run failed to parse and the rewrite kept only the patch.
+  it('keeps the fields of the first comment in a stacked run when resized', async () => {
+    const snapshot = '{"snapshot":{"kind":"x-post","data":{"b":1}}}'
+    using fixture = setupResize(`![cat](u)<!-- ${snapshot} --><!-- {"width":100} -->`)
+    const { editor } = fixture
+    await expect.element(resizable).toBeInTheDocument()
+    endResize(200)
+    await expect.element(resizable).toHaveAttribute('data-width', '200')
+    expect(docToMarkdown(editor.state.doc).trim()).toBe(
+      `![cat](u)<!-- {"width":200,"height":100,${snapshot.slice(1)} -->`,
+    )
   })
 
   // A persisted height is applied directly, not recomputed from width: the

--- a/packages/core/src/extensions/image.ts
+++ b/packages/core/src/extensions/image.ts
@@ -1,5 +1,6 @@
-import { registerXPost } from '@post-embed/elements/x'
+import { registerXPost, type Resolver } from '@post-embed/elements/x'
 import { registerYouTubeVideo } from '@post-embed/elements/youtube'
+import type { Tweet, YouTubeVideo } from '@post-embed/types'
 import { defineMarkView, type PlainExtension } from '@prosekit/core'
 import type { Mark } from '@prosekit/pm/model'
 import type { EditorView, MarkView, ViewMutationRecord } from '@prosekit/pm/view'
@@ -24,7 +25,9 @@ import {
   defaultResolveXPost,
   defaultResolveYouTubeVideo,
   matchPostEmbed,
+  parsePostEmbedSnapshot,
   type PostEmbedKind,
+  type PostEmbedSnapshot,
   type XPostResolver,
   type YouTubeVideoResolver,
 } from './post-embed.ts'
@@ -176,6 +179,38 @@ function commitEmbedWidth(view: EditorView, content: HTMLElement, rawWidth: numb
   rewriteMagicComment(view, range, { width: Math.round(rawWidth), height: undefined }, true)
 }
 
+/**
+ * Persist a resolved snapshot into the trailing magic comment. The whole
+ * `![alt](src)<!-- ... -->` range is rewritten, not just the comment: the
+ * transaction stays out of history, and undoing the edit that inserted the
+ * image must delete the snapshot with it. prosemirror-history maps the
+ * inverse deletion through this step, and a position at the end of a
+ * replaced range maps to the end of the replacement, so the mapped deletion
+ * covers the comment. An insertion at the range end would survive that undo
+ * as an orphan comment rendered as plain text.
+ */
+function commitSnapshot(
+  view: EditorView,
+  content: HTMLElement,
+  src: string,
+  snapshot: PostEmbedSnapshot,
+): void {
+  const pos = view.posAtDOM(content, 0)
+  const range = getMarkRangeAt(view.state, pos, 'mdImage')
+  if (!range) return
+  const attrs = range.mark.attrs as MdImageAttrs
+  if (attrs.src !== src) return
+
+  const current = view.state.doc.textBetween(range.from, range.to)
+  const base = stripMagicComment(current)
+  const comment = formatMagicComment({ ...parseMagicComment(current.slice(base.length)), snapshot })
+  if (base + comment === current) return
+
+  view.dispatch(
+    view.state.tr.insertText(base + comment, range.from, range.to).setMeta('addToHistory', false),
+  )
+}
+
 class ImageMarkView implements MarkView {
   readonly #dom: HTMLElement
   readonly #contentDOM: HTMLElement
@@ -186,6 +221,7 @@ class ImageMarkView implements MarkView {
   #attrs: MdImageAttrs
   #resizableRoot: HTMLElement | undefined
   #image: HTMLImageElement | undefined
+  #destroyed = false
 
   constructor(mark: Mark, view: EditorView, options: ImageOptions) {
     this.#attrs = mark.attrs as MdImageAttrs
@@ -224,8 +260,9 @@ class ImageMarkView implements MarkView {
   update(mark: Mark): boolean {
     const next = mark.attrs as MdImageAttrs
     const previous = this.#attrs
-    // False rebuilds the view from the constructor; a new src can change the preview shape.
-    if (next.src !== previous.src) return false
+    // False rebuilds the view from the constructor: a new src can change the
+    // preview shape, and a new snapshot switches the card to its data path.
+    if (next.src !== previous.src || next.snapshot !== previous.snapshot) return false
     this.#attrs = next
     if (this.#image && next.alt !== previous.alt) {
       this.#image.alt = next.alt
@@ -242,6 +279,10 @@ class ImageMarkView implements MarkView {
 
   ignoreMutation(mutation: ViewMutationRecord): boolean {
     return !this.#contentDOM.contains(mutation.target)
+  }
+
+  destroy(): void {
+    this.#destroyed = true
   }
 
   /**
@@ -267,23 +308,53 @@ class ImageMarkView implements MarkView {
   }
 
   /**
-   * A post-embed card loads its own snapshot through the resolver, and renders
-   * its own pending and unavailable states.
+   * A post-embed card renders a saved snapshot as is. Without one (or with
+   * one that does not validate or names another kind) it loads through the
+   * resolver, rendering its own pending and unavailable states, and the first
+   * answer is written back into the source so the next open renders in the
+   * first frame with no request.
    */
   #buildPostEmbed(kind: PostEmbedKind, src: string): HTMLElement {
+    const saved =
+      this.#attrs.snapshot == null ? undefined : parsePostEmbedSnapshot(this.#attrs.snapshot)
     if (kind === 'x-post') {
       registerXPost()
       const element = document.createElement('post-embed-x-post')
-      element.resolver = this.#resolveXPost
+      element.data = saved?.kind === 'x-post' ? saved.data : null
+      element.resolver = this.#persisting(kind, this.#resolveXPost)
       element.url = src
       return element
     }
     registerYouTubeVideo()
     const element = document.createElement('post-embed-youtube-video')
     element.playback = 'inline'
-    element.resolver = this.#resolveYouTubeVideo
+    element.data = saved?.kind === 'youtube-video' ? saved.data : null
+    element.resolver = this.#persisting(kind, this.#resolveYouTubeVideo)
     element.url = src
     return this.#buildResizableVideo(element)
+  }
+
+  /**
+   * Wrap a resolver so its first valid answer is persisted under `kind`.
+   * post-embed only calls it while `data` is null, and logs a rejection
+   * itself.
+   */
+  #persisting<T extends Tweet | YouTubeVideo>(
+    kind: PostEmbedKind,
+    resolver: Resolver<T>,
+  ): Resolver<T> {
+    return (url) => {
+      const result = resolver(url)
+      void Promise.resolve(result).then(
+        (value) => {
+          if (this.#destroyed || value == null) return
+          const snapshot = parsePostEmbedSnapshot({ kind, data: value })
+          if (snapshot) commitSnapshot(this.#view, this.#contentDOM, url, snapshot)
+        },
+        () => {},
+      )
+      return result
+    }
   }
 
   /**

--- a/packages/core/src/extensions/inline-marks.ts
+++ b/packages/core/src/extensions/inline-marks.ts
@@ -30,6 +30,10 @@ export interface MdImageAttrs {
    */
   height: number | null
   /**
+   * The saved post-embed snapshot from the trailing comment, or `null`.
+   */
+  snapshot: object | null
+  /**
    * `wikiEmbed` when the source is `![[target]]`; otherwise `null`.
    */
   syntax: 'wikiEmbed' | null
@@ -49,6 +53,7 @@ function defineMdImage() {
       title: { default: '' },
       width: { default: null },
       height: { default: null },
+      snapshot: { default: null },
       syntax: { default: null },
       wikiTarget: { default: null },
     },

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.test.ts
@@ -9,7 +9,9 @@ import {
   type FileLinkResolver,
   type InlineMarkOptions,
 } from './inline-text-to-mark-chunks.ts'
+import { formatMagicComment } from './magic-comment.ts'
 import type { MarkChunk } from './mark-chunk.ts'
+import { isMarkOfType } from './mark-names.ts'
 import {
   normalizeReferenceLabel,
   type ReferenceDefinition,
@@ -670,6 +672,17 @@ describe('image', () => {
       [7, 20]
       "
     `)
+  })
+
+  it('folds a trailing snapshot comment into the image attrs', () => {
+    const snapshot = { kind: 'x-post', data: { text: 'a -- b' } }
+    const text = `![](https://x.com/i/status/20)${formatMagicComment({ snapshot })}`
+    const chunks = inlineTextToMarkChunks(getMarkBuilders(), text)
+    const image = chunks
+      .flatMap(([, , marks]) => marks)
+      .find((mark) => isMarkOfType(mark, 'mdImage'))
+    expect(image?.attrs.snapshot).toEqual(snapshot)
+    expect(chunks.at(-1)?.[1]).toBe(text.length)
   })
 
   it('folds a trailing width comment on an image inside a link label', () => {

--- a/packages/core/src/extensions/inline-text-to-mark-chunks.ts
+++ b/packages/core/src/extensions/inline-text-to-mark-chunks.ts
@@ -741,6 +741,7 @@ function walkImage(
   const title: string = resolution.title
   const width = trailing?.magic.width ?? null
   const height = trailing?.magic.height ?? null
+  const snapshot = trailing?.magic.snapshot ?? null
   const to = trailing?.to ?? node.to
 
   emit(out, node.from, to, [
@@ -752,6 +753,7 @@ function walkImage(
       title,
       width,
       height,
+      snapshot,
       syntax: null,
       wikiTarget: null,
     }),
@@ -850,6 +852,7 @@ function walkWikiEmbed(
         title: '',
         width: embed.width,
         height: embed.height,
+        snapshot: null,
         syntax: 'wikiEmbed',
         wikiTarget: embed.target,
       }),

--- a/packages/core/src/extensions/magic-comment.test.ts
+++ b/packages/core/src/extensions/magic-comment.test.ts
@@ -33,6 +33,21 @@ describe('parseMagicComment', () => {
     expect(parseMagicComment('<!-- {bad json} -->')).toBeUndefined()
     expect(parseMagicComment('not a comment')).toBeUndefined()
   })
+
+  it('reads a nested snapshot object and rejects other snapshot values', () => {
+    expect(parseMagicComment('<!-- {"snapshot":{"kind":"x-post","data":{"b":1}}} -->')).toEqual({
+      snapshot: { kind: 'x-post', data: { b: 1 } },
+    })
+    expect(parseMagicComment('<!-- {"snapshot":1} -->')).toBeUndefined()
+    expect(parseMagicComment('<!-- {"snapshot":null} -->')).toBeUndefined()
+    expect(parseMagicComment('<!-- {"snapshot":[]} -->')).toBeUndefined()
+  })
+
+  it('reads the first comment of a stacked run', () => {
+    expect(parseMagicComment('<!-- {"width":100} --><!-- {"width":320} -->')).toEqual({
+      width: 100,
+    })
+  })
 })
 
 describe('formatMagicComment / stripMagicComment', () => {
@@ -42,6 +57,13 @@ describe('formatMagicComment / stripMagicComment', () => {
     expect(parseMagicComment(comment)).toEqual({ width: 320, height: 240 })
   })
 
+  it('escapes double dashes so the comment survives the inline comment rule', () => {
+    const snapshot = { kind: 'x-post', data: { text: 'a -- b ---> c' } }
+    const comment = formatMagicComment({ snapshot })
+    expect(comment).not.toContain('--')
+    expect(parseMagicComment(comment)).toEqual({ snapshot })
+  })
+
   it('strips only a trailing comment', () => {
     expect(stripMagicComment('![a](u)<!-- {"width":320} -->')).toBe('![a](u)')
     expect(stripMagicComment('![a](u)')).toBe('![a](u)')
@@ -49,6 +71,9 @@ describe('formatMagicComment / stripMagicComment', () => {
 
   it('strips a whole stacked run of trailing comments', () => {
     expect(stripMagicComment('![a](u)<!-- {"width":320} --><!-- {"height":240} -->')).toBe(
+      '![a](u)',
+    )
+    expect(stripMagicComment('![a](u)<!-- {"snapshot":{"x":{}}} --><!-- {"width":1} -->')).toBe(
       '![a](u)',
     )
   })

--- a/packages/core/src/extensions/magic-comment.test.ts
+++ b/packages/core/src/extensions/magic-comment.test.ts
@@ -60,7 +60,7 @@ describe('formatMagicComment / stripMagicComment', () => {
   it('escapes double dashes so the comment survives the inline comment rule', () => {
     const snapshot = { kind: 'x-post', data: { text: 'a -- b ---> c' } }
     const comment = formatMagicComment({ snapshot })
-    expect(comment).not.toContain('--')
+    expect(comment.slice('<!--'.length, -'-->'.length)).not.toContain('--')
     expect(parseMagicComment(comment)).toEqual({ snapshot })
   })
 

--- a/packages/core/src/extensions/magic-comment.ts
+++ b/packages/core/src/extensions/magic-comment.ts
@@ -17,14 +17,22 @@ export interface MagicComment {
    * autolinking.
    */
   noLink?: boolean
+  /**
+   * The saved post-embed snapshot behind an image `src`: the JSON object as
+   * written, validated where the card kind is known.
+   */
+  snapshot?: object
 }
 
-// A whole inline comment carrying a JSON object: `<!-- {...} -->`.
-const MAGIC_COMMENT_RE = /^<!--\s*(\{[^}]*\})\s*-->$/
-// Same, anchored to the end of a string, for stripping the whole trailing
-// run: a rewrite of an image whose comment had not folded could stack a
-// second comment behind the first.
-const TRAILING_MAGIC_COMMENT_RE = /(?:<!--\s*\{[^}]*\}\s*-->)+$/
+// The inline comment carrying a JSON object at the start of the text:
+// `<!-- {...} -->`. The object may nest (a snapshot), so the body runs to the
+// first closing marker (a body never contains `-->`, see formatMagicComment).
+// Not anchored at the end: a rewrite of an image whose comment had not folded
+// could stack a second comment behind the first, and the first one wins,
+// exactly as the inline-mark walker reads a stacked run.
+const MAGIC_COMMENT_RE = /^<!--\s*(\{[\s\S]*?\})\s*-->/
+// A whole trailing run of such comments, for stripping them all at once.
+const TRAILING_MAGIC_COMMENT_RE = /(?:<!--\s*\{[\s\S]*?\}\s*-->)+$/
 
 /**
  * Read the metadata out of a `<!-- {...} -->` comment, or `undefined` when the
@@ -45,11 +53,12 @@ export function parseMagicComment(comment: string): MagicComment | undefined {
   const width = toPositiveNumber(data.width)
   const height = toPositiveNumber(data.height)
   const noLink = data.noLink === true ? true : undefined
+  const snapshot = isObject(data.snapshot) ? data.snapshot : undefined
 
   // Not a magic comment unless it carries at least one recognized field.
-  if (!width && !height && !noLink) return
+  if (!width && !height && !noLink && !snapshot) return
 
-  return { width, height, noLink }
+  return { width, height, noLink, snapshot }
 }
 
 function toPositiveNumber(value: unknown): number | undefined {
@@ -59,10 +68,15 @@ function toPositiveNumber(value: unknown): number | undefined {
 }
 
 /**
- * The canonical comment meowdown writes for the metadata.
+ * The canonical comment meowdown writes for the metadata. `--` inside a JSON
+ * string becomes `--`: the inline comment rule of `@lezer/markdown`
+ * (CommonMark 0.30) ends a comment at any `--`, so a snapshot text holding a
+ * double dash would otherwise cut the comment short. Outside strings JSON
+ * only writes `-` as a number sign, never doubled, so the escape keeps the
+ * JSON valid and `JSON.parse` restores the text.
  */
 export function formatMagicComment(magic: MagicComment): string {
-  return `<!-- ${JSON.stringify(magic)} -->`
+  return `<!-- ${JSON.stringify(magic).replaceAll('--', String.raw`-\u002d`)} -->`
 }
 
 /**

--- a/packages/core/src/extensions/magic-comment.ts
+++ b/packages/core/src/extensions/magic-comment.ts
@@ -53,7 +53,8 @@ export function parseMagicComment(comment: string): MagicComment | undefined {
   const width = toPositiveNumber(data.width)
   const height = toPositiveNumber(data.height)
   const noLink = data.noLink === true ? true : undefined
-  const snapshot = isObject(data.snapshot) ? data.snapshot : undefined
+  const snapshot =
+    isObject(data.snapshot) && !Array.isArray(data.snapshot) ? data.snapshot : undefined
 
   // Not a magic comment unless it carries at least one recognized field.
   if (!width && !height && !noLink && !snapshot) return

--- a/packages/core/src/extensions/post-embed-view.test.ts
+++ b/packages/core/src/extensions/post-embed-view.test.ts
@@ -10,7 +10,7 @@ import { createYouTubeVideo } from '../testing/youtube-fixture.ts'
 
 import { defineEmbedPaste } from './embed-paste.ts'
 import { defineImage, type ImageOptions } from './image.ts'
-import { formatMagicComment } from './magic-comment.ts'
+import { formatMagicComment, parseMagicComment } from './magic-comment.ts'
 
 const pmRoot = page.locate('.ProseMirror')
 const xPostEmbed = pmRoot.getByTestId('x-post-embed')
@@ -108,15 +108,27 @@ describe('snapshot persistence', () => {
   const tweet = createTweet('a -- b')
   const saved = `${TWEET}${formatMagicComment({ snapshot: { kind: 'x-post', data: tweet } })}`
 
+  // The comment written behind `prefix`, and the snapshot it carries. The
+  // schema writes the fields in its own order, so tests compare the parsed
+  // object, not the string.
+  function written(fixture: Fixture, prefix: string) {
+    const markdown = docToMarkdown(fixture.editor.state.doc).trim()
+    const comment = markdown.startsWith(prefix) ? markdown.slice(prefix.length) : ''
+    return { markdown, comment, snapshot: parseMagicComment(comment)?.snapshot }
+  }
+
   it('writes the resolved snapshot back, escaped, outside history', async () => {
     using fixture = setup(TWEET, { resolveXPost: () => Promise.resolve(tweet) })
     const { editor } = fixture
     await expect.element(xPostCard.getByText('a -- b')).toBeInTheDocument()
-    await expect.poll(() => docToMarkdown(editor.state.doc).trim()).toBe(saved)
-    expect(saved).not.toContain('--')
+    await expect
+      .poll(() => written(fixture, TWEET).snapshot)
+      .toEqual({ kind: 'x-post', data: tweet })
+    const { markdown, comment } = written(fixture, TWEET)
+    expect(comment.slice('<!--'.length, -'-->'.length)).not.toContain('--')
 
     editor.commands.undo()
-    expect(docToMarkdown(editor.state.doc).trim()).toBe(saved)
+    expect(docToMarkdown(editor.state.doc).trim()).toBe(markdown)
   })
 
   it('renders a saved snapshot without calling the resolver', async () => {
@@ -132,11 +144,10 @@ describe('snapshot persistence', () => {
     using fixture = setup(`${TWEET}<!-- {"snapshot":{"kind":"x-post","data":{"bogus":1}}} -->`, {
       resolveXPost: () => createTweet(),
     })
-    const { editor } = fixture
     await expect.element(xPostCard.getByText('just setting up my twttr')).toBeInTheDocument()
     await expect
-      .poll(() => docToMarkdown(editor.state.doc).trim())
-      .toBe(`${TWEET}${formatMagicComment({ snapshot: { kind: 'x-post', data: createTweet() } })}`)
+      .poll(() => written(fixture, TWEET).snapshot)
+      .toEqual({ kind: 'x-post', data: createTweet() })
   })
 
   it('replaces a snapshot whose kind does not match the URL', async () => {
@@ -145,14 +156,11 @@ describe('snapshot persistence', () => {
       `${VIDEO}${formatMagicComment({ snapshot: { kind: 'x-post', data: tweet } })}`,
       { resolveYouTubeVideo },
     )
-    const { editor } = fixture
     await expect.element(videoCard.getByText('Big Buck Bunny')).toBeInTheDocument()
     expect(resolveYouTubeVideo).toHaveBeenCalledOnce()
     await expect
-      .poll(() => docToMarkdown(editor.state.doc).trim())
-      .toBe(
-        `${VIDEO}${formatMagicComment({ snapshot: { kind: 'youtube-video', data: createYouTubeVideo() } })}`,
-      )
+      .poll(() => written(fixture, VIDEO).snapshot)
+      .toEqual({ kind: 'youtube-video', data: createYouTubeVideo() })
   })
 
   it('writes nothing when the resolver has no snapshot', async () => {
@@ -201,8 +209,9 @@ describe('YouTube video resize', () => {
     expect(getComputedStyle(videoCard.element()).width).toBe('320px')
   })
 
+  // No snapshot from the resolver, so the width is the only thing written.
   it('writes a width comment when resized', async () => {
-    using fixture = setup(VIDEO, { resolveYouTubeVideo })
+    using fixture = setup(VIDEO, { resolveYouTubeVideo: () => undefined })
     const { editor } = fixture
     await expect.element(videoResizable).toBeInTheDocument()
     endResize(200)
@@ -223,7 +232,9 @@ describe('YouTube video resize', () => {
   })
 
   it('drops a stale height when resized again', async () => {
-    using fixture = setup(`${VIDEO}<!-- {"width":100,"height":75} -->`, { resolveYouTubeVideo })
+    using fixture = setup(`${VIDEO}<!-- {"width":100,"height":75} -->`, {
+      resolveYouTubeVideo: () => undefined,
+    })
     const { editor } = fixture
     await expect.element(videoResizable).toHaveAttribute('data-width', '100')
     endResize(320)

--- a/packages/core/src/extensions/post-embed-view.test.ts
+++ b/packages/core/src/extensions/post-embed-view.test.ts
@@ -1,4 +1,5 @@
 import type { Tweet } from '@post-embed/types'
+import { pasteText } from '@prosekit/core/test'
 import { describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
 
@@ -7,7 +8,9 @@ import { setupFixture, type Fixture } from '../testing/index.ts'
 import { createTweet } from '../testing/tweet-fixture.ts'
 import { createYouTubeVideo } from '../testing/youtube-fixture.ts'
 
+import { defineEmbedPaste } from './embed-paste.ts'
 import { defineImage, type ImageOptions } from './image.ts'
+import { formatMagicComment } from './magic-comment.ts'
 
 const pmRoot = page.locate('.ProseMirror')
 const xPostEmbed = pmRoot.getByTestId('x-post-embed')
@@ -98,6 +101,87 @@ describe('YouTube video embed', () => {
   })
 })
 
+// The first resolved snapshot is written into the image's magic comment as
+// `{"snapshot":{"kind":...,"data":{...}}}`; a saved snapshot renders in the
+// first frame and never calls the resolver.
+describe('snapshot persistence', () => {
+  const tweet = createTweet('a -- b')
+  const saved = `${TWEET}${formatMagicComment({ snapshot: { kind: 'x-post', data: tweet } })}`
+
+  it('writes the resolved snapshot back, escaped, outside history', async () => {
+    using fixture = setup(TWEET, { resolveXPost: () => Promise.resolve(tweet) })
+    const { editor } = fixture
+    await expect.element(xPostCard.getByText('a -- b')).toBeInTheDocument()
+    await expect.poll(() => docToMarkdown(editor.state.doc).trim()).toBe(saved)
+    expect(saved).not.toContain('--')
+
+    editor.commands.undo()
+    expect(docToMarkdown(editor.state.doc).trim()).toBe(saved)
+  })
+
+  it('renders a saved snapshot without calling the resolver', async () => {
+    const resolveXPost = vi.fn(() => createTweet())
+    using fixture = setup(saved, { resolveXPost })
+    void fixture
+    await expect.element(xPostCard.getByText('a -- b')).toBeInTheDocument()
+    expect(resolveXPost).not.toHaveBeenCalled()
+    expect(xPostCard.locate('[data-fallback]').query()).toBeNull()
+  })
+
+  it('replaces a snapshot that does not validate', async () => {
+    using fixture = setup(`${TWEET}<!-- {"snapshot":{"kind":"x-post","data":{"bogus":1}}} -->`, {
+      resolveXPost: () => createTweet(),
+    })
+    const { editor } = fixture
+    await expect.element(xPostCard.getByText('just setting up my twttr')).toBeInTheDocument()
+    await expect
+      .poll(() => docToMarkdown(editor.state.doc).trim())
+      .toBe(`${TWEET}${formatMagicComment({ snapshot: { kind: 'x-post', data: createTweet() } })}`)
+  })
+
+  it('replaces a snapshot whose kind does not match the URL', async () => {
+    const resolveYouTubeVideo = vi.fn(() => createYouTubeVideo())
+    using fixture = setup(
+      `${VIDEO}${formatMagicComment({ snapshot: { kind: 'x-post', data: tweet } })}`,
+      { resolveYouTubeVideo },
+    )
+    const { editor } = fixture
+    await expect.element(videoCard.getByText('Big Buck Bunny')).toBeInTheDocument()
+    expect(resolveYouTubeVideo).toHaveBeenCalledOnce()
+    await expect
+      .poll(() => docToMarkdown(editor.state.doc).trim())
+      .toBe(
+        `${VIDEO}${formatMagicComment({ snapshot: { kind: 'youtube-video', data: createYouTubeVideo() } })}`,
+      )
+  })
+
+  it('writes nothing when the resolver has no snapshot', async () => {
+    using fixture = setup(TWEET, { resolveXPost: () => undefined })
+    const { editor } = fixture
+    await expect.element(xPostCard.locate('[data-fallback]')).toBeInTheDocument()
+    expect(docToMarkdown(editor.state.doc).trim()).toBe(TWEET)
+  })
+
+  // The write-back replaces the whole image range, so the undo of the paste
+  // that inserted the image maps over it and removes the snapshot too. An
+  // insertion at the range end would leave the comment behind as plain text.
+  it('undoing the paste that inserted the image removes the snapshot with it', async () => {
+    using fixture = setupFixture()
+    const { editor, n, view } = fixture
+    editor.use(defineImage({ resolveXPost: () => tweet }))
+    editor.use(defineEmbedPaste())
+    fixture.set(n.doc(n.paragraph('<a>')))
+    const url = 'https://x.com/jack/status/20'
+    pasteText(view, url)
+    await expect.poll(() => docToMarkdown(editor.state.doc)).toContain('"snapshot"')
+
+    editor.commands.undo()
+    expect(editor.state.doc.textContent).toBe(url)
+    editor.commands.undo()
+    expect(editor.state.doc.textContent).toBe('')
+  })
+})
+
 // Releasing a resize rewrites only the trailing `<!-- {"width":N} -->`; the
 // card keeps its content height, so no height is persisted.
 describe('YouTube video resize', () => {
@@ -124,6 +208,18 @@ describe('YouTube video resize', () => {
     endResize(200)
     await expect.element(videoResizable).toHaveAttribute('data-width', '200')
     expect(docToMarkdown(editor.state.doc).trim()).toBe(`${VIDEO}<!-- {"width":200} -->`)
+  })
+
+  it('keeps the saved snapshot when resized', async () => {
+    const snapshot = { kind: 'youtube-video', data: createYouTubeVideo() }
+    using fixture = setup(`${VIDEO}${formatMagicComment({ snapshot })}`, { resolveYouTubeVideo })
+    const { editor } = fixture
+    await expect.element(videoResizable).toBeInTheDocument()
+    endResize(200)
+    await expect.element(videoResizable).toHaveAttribute('data-width', '200')
+    expect(docToMarkdown(editor.state.doc).trim()).toBe(
+      `${VIDEO}${formatMagicComment({ width: 200, snapshot })}`,
+    )
   })
 
   it('drops a stale height when resized again', async () => {

--- a/packages/core/src/extensions/post-embed.test.ts
+++ b/packages/core/src/extensions/post-embed.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { createTweet } from '../testing/tweet-fixture.ts'
+import { createYouTubeVideo } from '../testing/youtube-fixture.ts'
 
 import {
   defaultResolveXPost,
   defaultResolveYouTubeVideo,
   matchPostEmbed,
+  parsePostEmbedSnapshot,
   parseXPostId,
 } from './post-embed.ts'
 
@@ -41,6 +43,33 @@ describe('matchPostEmbed', () => {
     expect(matchPostEmbed('https://example.com/cat.png')).toBeUndefined()
     expect(matchPostEmbed('https://www.youtube.com/@Blender')).toBeUndefined()
     expect(matchPostEmbed('https://www.youtube.com/watch?v=short')).toBeUndefined()
+  })
+})
+
+describe('parsePostEmbedSnapshot', () => {
+  it('validates the data against the schema the kind names', () => {
+    const tweet = createTweet()
+    expect(parsePostEmbedSnapshot({ kind: 'x-post', data: tweet })).toEqual({
+      kind: 'x-post',
+      data: tweet,
+    })
+    const video = createYouTubeVideo()
+    expect(parsePostEmbedSnapshot({ kind: 'youtube-video', data: video })).toEqual({
+      kind: 'youtube-video',
+      data: video,
+    })
+  })
+
+  it('drops unknown fields', () => {
+    const parsed = parsePostEmbedSnapshot({ kind: 'x-post', data: { ...createTweet(), extra: 1 } })
+    expect(parsed?.data).not.toHaveProperty('extra')
+  })
+
+  it('rejects data of another kind, an unknown kind, and a missing kind', () => {
+    expect(parsePostEmbedSnapshot({ kind: 'x-post', data: createYouTubeVideo() })).toBeUndefined()
+    expect(parsePostEmbedSnapshot({ kind: 'other', data: createTweet() })).toBeUndefined()
+    expect(parsePostEmbedSnapshot({ data: createTweet() })).toBeUndefined()
+    expect(parsePostEmbedSnapshot({})).toBeUndefined()
   })
 })
 

--- a/packages/core/src/extensions/post-embed.ts
+++ b/packages/core/src/extensions/post-embed.ts
@@ -1,6 +1,8 @@
 import type { Resolver } from '@post-embed/elements/x'
+import { TweetSchema, YouTubeVideoSchema } from '@post-embed/schema'
 import type { Tweet, YouTubeVideo } from '@post-embed/types'
 import { createLRU } from 'lru.min'
+import * as v from 'valibot'
 
 export type XPostResolver = Resolver<Tweet>
 export type YouTubeVideoResolver = Resolver<YouTubeVideo>
@@ -106,3 +108,25 @@ export const defaultResolveYouTubeVideo: YouTubeVideoResolver = cached(async (ur
   if (!response.ok) return
   return { url, ...((await response.json()) as Omit<YouTubeVideo, 'url'>) }
 })
+
+/**
+ * The `snapshot` field of an image's magic comment: the card kind and the
+ * data post-embed renders. The kind is stored explicitly, so a saved snapshot
+ * is validated once, against the schema it names.
+ */
+const PostEmbedSnapshotSchema = v.variant('kind', [
+  v.object({ kind: v.literal('x-post'), data: TweetSchema }),
+  v.object({ kind: v.literal('youtube-video'), data: YouTubeVideoSchema }),
+])
+
+export type PostEmbedSnapshot = v.InferOutput<typeof PostEmbedSnapshotSchema>
+
+/**
+ * The snapshot a card renders from a saved JSON object, or `undefined` when
+ * the object does not validate. Unknown fields are dropped, so a persisted
+ * snapshot is exactly what the card needs.
+ */
+export function parsePostEmbedSnapshot(value: unknown): PostEmbedSnapshot | undefined {
+  const result = v.safeParse(PostEmbedSnapshotSchema, value)
+  return result.success ? result.output : undefined
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -114,8 +114,10 @@ export {
   defaultResolveXPost,
   defaultResolveYouTubeVideo,
   matchPostEmbed,
+  parsePostEmbedSnapshot,
   parseXPostId,
   type PostEmbedKind,
+  type PostEmbedSnapshot,
   type XPostResolver,
   type YouTubeVideoResolver,
 } from './extensions/post-embed.ts'

--- a/packages/react/src/components/markdown-view.test.tsx
+++ b/packages/react/src/components/markdown-view.test.tsx
@@ -268,6 +268,25 @@ describe('MarkdownView', () => {
     expect(card.locate('[data-pending]').query()).toBeNull()
   })
 
+  it('renders a saved snapshot in the first frame without calling the resolver', async () => {
+    const resolveXPost = vi.fn(() => createTweet())
+    const comment = `<!-- ${JSON.stringify({ snapshot: { kind: 'x-post', data: createTweet('saved') } })} -->`
+    await renderView(`![](https://x.com/jack/status/20)${comment}`, { resolveXPost })
+    const card = view.getByTestId('x-post-embed').locate('[data-post-embed="x-post"]')
+    await expect.element(card).toMatchTextContent('saved')
+    expect(resolveXPost).not.toHaveBeenCalled()
+    expect(card.locate('[data-fallback]').query()).toBeNull()
+  })
+
+  it('resolves when the saved snapshot does not validate', async () => {
+    await renderView(
+      '![](https://x.com/jack/status/20)<!-- {"snapshot":{"kind":"x-post","data":{"bogus":1}}} -->',
+      { resolveXPost: () => createTweet() },
+    )
+    const card = view.getByTestId('x-post-embed').locate('[data-post-embed="x-post"]')
+    await expect.element(card).toMatchTextContent('just setting up my twttr')
+  })
+
   it('renders the unavailable card without a snapshot', async () => {
     await renderView('![](https://x.com/jack/status/20)', { resolveXPost: () => undefined })
     await expect

--- a/packages/react/src/components/markdown-view.tsx
+++ b/packages/react/src/components/markdown-view.tsx
@@ -13,6 +13,7 @@ import {
   isReferenceDefinitionNode,
   markdownToDoc,
   matchPostEmbed,
+  parsePostEmbedSnapshot,
   type CodeBlockAttrs,
   type CodeToken,
   type FileClickHandler,
@@ -296,14 +297,17 @@ function PostEmbed(props: {
   kind: PostEmbedKind
   src: string
   width: number | null
+  snapshot: object | null
   resolveXPost: XPostResolver
   resolveYouTubeVideo: YouTubeVideoResolver
 }): ReactElement {
-  const { kind, src, width, resolveXPost, resolveYouTubeVideo } = props
+  const { kind, src, width, snapshot, resolveXPost, resolveYouTubeVideo } = props
   // Registration is idempotent and must precede the element so React sets
-  // `url` and `resolver` as properties of the upgraded element.
+  // `data`, `url`, and `resolver` as properties of the upgraded element.
   registerXPost()
   registerYouTubeVideo()
+  // A saved snapshot renders as is; the card only resolves while `data` is null.
+  const saved = snapshot == null ? undefined : parsePostEmbedSnapshot(snapshot)
   return (
     <span
       className="md-image-view-preview md-atom-view-preview"
@@ -311,8 +315,13 @@ function PostEmbed(props: {
       data-testid={`${kind}-embed`}
     >
       {kind === 'x-post'
-        ? createElement('post-embed-x-post', { url: src, resolver: resolveXPost })
+        ? createElement('post-embed-x-post', {
+            data: saved?.kind === 'x-post' ? saved.data : null,
+            url: src,
+            resolver: resolveXPost,
+          })
         : createElement('post-embed-youtube-video', {
+            data: saved?.kind === 'youtube-video' ? saved.data : null,
             url: src,
             resolver: resolveYouTubeVideo,
             playback: 'inline',
@@ -328,6 +337,7 @@ function ImagePreview(props: {
   src: string
   alt: string
   width: number | null
+  snapshot: object | null
   resolveImageUrl?: (src: string) => string | undefined
   resolveXPost?: XPostResolver
   resolveYouTubeVideo?: YouTubeVideoResolver
@@ -338,6 +348,7 @@ function ImagePreview(props: {
     src,
     alt,
     width,
+    snapshot,
     resolveImageUrl,
     resolveXPost,
     resolveYouTubeVideo,
@@ -353,6 +364,7 @@ function ImagePreview(props: {
         kind={kind}
         src={src}
         width={width}
+        snapshot={snapshot}
         resolveXPost={resolveXPost ?? defaultResolveXPost}
         resolveYouTubeVideo={resolveYouTubeVideo ?? defaultResolveYouTubeVideo}
       />
@@ -391,16 +403,18 @@ function ImageView(props: {
   src: string
   alt: string
   width: number | null
+  snapshot: object | null
   context: RenderContext
   children: ReactNode
 }): ReactElement {
-  const { src, alt, width, context, children } = props
+  const { src, alt, width, snapshot, context, children } = props
   return (
     <span className="md-image-view md-atom-view">
       <ImagePreview
         src={src}
         alt={alt}
         width={width}
+        snapshot={snapshot}
         resolveImageUrl={context.resolveImageUrl}
         resolveXPost={context.resolveXPost}
         resolveYouTubeVideo={context.resolveYouTubeVideo}
@@ -612,7 +626,13 @@ function wrapMark(mark: Mark, children: ReactNode, context: RenderContext): Reac
     case 'mdImage': {
       const attrs = mark.attrs as MdImageAttrs
       return (
-        <ImageView src={attrs.src} alt={attrs.alt} width={attrs.width} context={context}>
+        <ImageView
+          src={attrs.src}
+          alt={attrs.alt}
+          width={attrs.width}
+          snapshot={attrs.snapshot}
+          context={context}
+        >
           {children}
         </ImageView>
       )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@post-embed/elements':
         specifier: ^0.1.0
         version: 0.1.0(typescript@6.0.3)
+      '@post-embed/schema':
+        specifier: ^0.1.0
+        version: 0.1.0(typescript@6.0.3)
       '@post-embed/types':
         specifier: ^0.1.0
         version: 0.1.0
@@ -138,6 +141,9 @@ importers:
       unified:
         specifier: ^11.0.5
         version: 11.0.5
+      valibot:
+        specifier: ^1.4.2
+        version: 1.4.2(typescript@6.0.3)
     devDependencies:
       '@meowdown/vitest':
         specifier: workspace:*


### PR DESCRIPTION
After a resolver answers, the X post or YouTube snapshot is written into the image's `<!-- {"snapshot":{"kind":...,"data":{...}}} -->` comment, so the next open renders the card in the first frame without a request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Saved previews for supported social posts and videos are now preserved in Markdown and displayed immediately.
  - Markdown rendering can use saved embed data without contacting the live resolver when the data is valid.
  - Invalid or outdated saved data automatically falls back to refreshed content.

- **Bug Fixes**
  - Resizing images now preserves saved preview information and handles stacked image metadata comments correctly.
  - Embed metadata is safely validated before being displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->